### PR TITLE
Force JavaDoc to only run on JDK17

### DIFF
--- a/.github/workflows/commit.yaml
+++ b/.github/workflows/commit.yaml
@@ -28,14 +28,6 @@ jobs:
               -Dstyle.color=always \
               -Dmaven.artifact.threads=$(($(nproc)*10))
 
-      - name: Archive JavaDoc artifacts
-        uses: actions/upload-artifact@v2
-        continue-on-error: true
-        if: success()
-        with:
-          name: javadoc-java-${{ matrix.java-version }}-${{ matrix.java-distribution }}
-          path: "**/target/apidocs/com.github.ascopes.jct"
-
       - name: Report Surefire results
         uses: dorny/test-reporter@v1
         continue-on-error: true
@@ -60,3 +52,35 @@ jobs:
         with:
           name: jacoco-reports-java-${{ matrix.java-version }}-${{ matrix.java-distribution }})
           path: "**/target/site/jacoco"
+
+  javadoc:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Initialize Java ${{ matrix.java-version }} (${{ matrix.java-distribution }})
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          # We have to use 17 for now, as assertj causes JDK 14 and older to prevent linking
+          # documentation correctly. I have opened an issue on GitHub with AssertJ to discuss
+          # this being generated correctly: https://github.com/assertj/assertj-core/issues/2573.
+          java-version: '17'
+
+      - name: Generate JavaDoc documentation
+        run: >-
+          ./mvnw -B -U -T8C clean compile javadoc:jar \
+              -Dmaven.test.skip=true \
+              -Dcheckstyle.skip=true \
+              -Dstyle.color=always \
+              -Dmaven.artifact.threads=$(($(nproc)*10))
+
+      - name: Archive JavaDoc artifacts
+        uses: actions/upload-artifact@v2
+        continue-on-error: true
+        if: success()
+        with:
+          name: javadocs
+          path: "**/target/apidocs/com.github.ascopes.jct"

--- a/pom.xml
+++ b/pom.xml
@@ -222,16 +222,6 @@
               <link>https://javadoc.io/doc/org.assertj/assertj-core/${assertj.version}</link>
             </links>
           </configuration>
-
-          <executions>
-            <execution>
-              <id>default-javadoc</id>
-              <phase>package</phase>
-              <goals>
-                <goal>jar</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Relates to: https://github.com/assertj/assertj-core/issues/2573