### PR TITLE
[Fixes #194] Made changes to the main YML pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,11 @@ jobs:
             java-version: 11
           - os-name: windows-2022
             java-version: 11
-
+          - os-name: macos-12
+            java-version: 19
+          - os-name: windows-2022
+            java-version: 19
+          
     name: Build - JDK ${{ matrix.java-version }} - ${{ matrix.os-name }}
     runs-on: ${{ matrix.os-name }}
 


### PR DESCRIPTION
Made changes to [the main YML pipeline](https://github.com/ascopes/java-compiler-testing/blob/main/.github/workflows/main.yml#L151) to enable CI to run on macos-12 on java 19 and windows-2022 on java 19.