### PR TITLE
Closes #122 - split up unit and integration test runners and coverage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,17 +156,10 @@ jobs:
       - name: Publish to codecov
         continue-on-error: true
         if: always()
-        shell: bash
-        run: |-
-          curl --fail https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring \
-              --keyring trustedkeys.gpg --import
-          curl --fail -Os https://uploader.codecov.io/latest/linux/codecov
-          curl --fail -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
-          curl --fail -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
-          gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
-          shasum -a 256 -c codecov.SHA256SUM
-          chmod -v +x codecov
-          ./codecov 
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          verbose: true
 
       - name: Publish unit test results
         uses: EnricoMi/publish-unit-test-result-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,8 @@ jobs:
         shell: bash
         run: >-
           ./mvnw 
-          -B 
+          -B
+          -e
           -T4
           -U
           -pl java-compiler-testing
@@ -98,6 +99,7 @@ jobs:
         run: >-
           ./mvnw 
           -B 
+          -e
           -T4
           -U
           --no-transfer-progress
@@ -115,15 +117,17 @@ jobs:
           ${{ matrix.java-version }}
           ${{ matrix.os-name }}
 
-      - name: Archive Surefire and Jacoco reports
+      - name: Archive test and coverage reports
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: reports-java-${{ matrix.java-version }}-${{ matrix.os-name }}
           if-no-files-found: error
           path: |-
+            **/target/failsafe-reports/
             **/target/surefire-reports/
-            **/target/site/jacoco/jacoco*.xml
+            **/target/site/jacoco/unit/jacoco*.xml
+            **/target/site/jacoco/int/jacoco*.xml
           retention-days: 5
 
   publish-test-reports:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL analysis
 on:
   pull_request:
     branches:
-      - '**'
+      - 'main'
     types:
       - opened
       - synchronize

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -35,6 +35,7 @@ jobs:
         run: >-
           ./mvnw 
           -B
+          -e
           -T4
           -U
           --no-transfer-progress

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
         run: >-
           ./mvnw
           -B
+          -e
           -T4
           -Dmaven.deploy.skip=${{ ! inputs.deploy-artifacts-to-gh-packages }}
           -Dmaven.source.includePom=true

--- a/.github/workflows/mutation-global.yml
+++ b/.github/workflows/mutation-global.yml
@@ -31,8 +31,9 @@ jobs:
         run: >-
           ./mvnw 
           -B
+          -e
           -U
-          -am
+          --also-make
           -pl java-compiler-testing
           --no-transfer-progress
           -P mutation

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -66,11 +66,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -74,11 +74,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -78,11 +78,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -66,11 +66,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -74,11 +74,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -59,11 +59,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -59,11 +59,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -66,11 +66,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -59,11 +59,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -59,11 +59,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
+++ b/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
@@ -77,12 +77,20 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>false</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>${project.artifactId}::ignore-tests-after-jdk11</id>
+      <activation>
+         <jdk>(11,)</jdk>
+      </activation>
+      <properties>
+        <maven.test.skip>true</maven.test.skip>
+      </properties>
+    </profile>
+  </profiles>
 </project>

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -66,11 +66,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -84,11 +84,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -48,11 +48,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -48,11 +48,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -97,11 +97,7 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
+        <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
     </plugins>
   </build>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -67,6 +67,25 @@
             <skipIfEmpty>true</skipIfEmpty>
           </configuration>
         </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <configuration>
+            <!-- Run all tests in failsafe. -->
+            <includes>*Test</includes>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+
+          <configuration>
+            <!-- We run using failsafe in all cases -->
+            <skip>true</skip>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,52 @@
+# General behaviour.
 codecov:
   max_report_age: 12
   require_ci_to_pass: true
+
+# PR comment format.
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: true
+  require_head: true
+
+# Global coverage options.
 coverage:
   precision: 2
-  # TODO: adjust this once coverage is better.
   range: "10...100"
   round: down
+
+# Feature flags
+flag_management:
+  default_rules:
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+      - type: patch
+        target: 90%
+
+  individual_flags:
+    # Unit testing coverage
+    - name: unit
+      paths:
+        - '**/target/site/jacoco/unit/jacoco*.xml'
+      statuses:
+        - type: project
+          target: auto
+          threshold: 65%
+        - type: patch
+          target: 90%
+
+    # Integration testing coverage
+    - name: integration
+      paths:
+        - '**/target/site/jacoco/int/jacoco*.xml'
+      statuses:
+        - type: project
+          target: auto
+          threshold: 0%
+        - type: patch
+          target: 0%

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -106,6 +106,11 @@
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
 
         <configuration>
@@ -120,10 +125,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-
-        <configuration>
-          <failIfNoTests>true</failIfNoTests>
-        </configuration>
       </plugin>
 
       <plugin>
@@ -150,13 +151,23 @@
           </plugin>
 
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-failsafe-plugin</artifactId>
+
+            <configuration>
+              <!-- Don't run normal tests alongside pitest -->
+              <skip>true</skip>
+            </configuration>
+          </plugin>
+
+
+          <plugin>
             <groupId>org.pitest</groupId>
             <artifactId>pitest-maven</artifactId>
 
             <configuration>
               <excludedGroups>
-                <!-- Do not mutation-test integration test packs. -->
-                <excludedGroup>integration</excludedGroup>
+                <excludedGroup>no-mutation</excludedGroup>
               </excludedGroups>
             </configuration>
           </plugin>

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/DoNotMutationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/DoNotMutationTest.java
@@ -23,14 +23,13 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.Tag;
 
 /**
- * Marks a test as an integration test. These get excluded from some places such as mutation
- * testing.
+ * Marks a test so that it will not be mutation tested.
  *
  * @author Ashley Scopes
  */
 @Inherited
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD, ElementType.ANNOTATION_TYPE})
-@Tag("integration")
-public @interface IntegrationTest {
+@Tag("no-mutation")
+public @interface DoNotMutationTest {
 }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicLegacyCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicLegacyCompilationIntegrationTest.java
@@ -19,7 +19,7 @@ import static io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilati
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.junit.JavacCompilerTest;
-import io.github.ascopes.jct.tests.helpers.IntegrationTest;
+import io.github.ascopes.jct.tests.helpers.DoNotMutationTest;
 import io.github.ascopes.jct.workspaces.PathStrategy;
 import io.github.ascopes.jct.workspaces.Workspaces;
 import javax.tools.StandardLocation;
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.DisplayName;
  * @author Ashley Scopes
  */
 @DisplayName("Basic legacy compilation integration tests")
-@IntegrationTest
+@DoNotMutationTest
 class BasicLegacyCompilationIntegrationTest {
 
   @DisplayName("I can compile a 'Hello, World!' program using a RAM directory")

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicModuleCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicModuleCompilationIntegrationTest.java
@@ -19,7 +19,7 @@ import static io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilati
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.junit.JavacCompilerTest;
-import io.github.ascopes.jct.tests.helpers.IntegrationTest;
+import io.github.ascopes.jct.tests.helpers.DoNotMutationTest;
 import io.github.ascopes.jct.workspaces.PathStrategy;
 import io.github.ascopes.jct.workspaces.Workspaces;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.DisplayName;
  * @author Ashley Scopes
  */
 @DisplayName("Basic module compilation integration tests")
-@IntegrationTest
+@DoNotMutationTest
 class BasicModuleCompilationIntegrationTest {
 
   @DisplayName("I can compile a 'Hello, World!' module program using a RAM disk")

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicMultiModuleCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicMultiModuleCompilationIntegrationTest.java
@@ -19,7 +19,7 @@ import static io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilati
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.junit.JavacCompilerTest;
-import io.github.ascopes.jct.tests.helpers.IntegrationTest;
+import io.github.ascopes.jct.tests.helpers.DoNotMutationTest;
 import io.github.ascopes.jct.workspaces.PathStrategy;
 import io.github.ascopes.jct.workspaces.Workspaces;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.DisplayName;
  * @author Ashley Scopes
  */
 @DisplayName("Basic multi-module compilation integration tests")
-@IntegrationTest
+@DoNotMutationTest
 class BasicMultiModuleCompilationIntegrationTest {
 
   @DisplayName("I can compile a single module using multi-module layout using a RAM disk")

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
               <disable>${hide-test-logs-in-console}</disable>
             </consoleOutputReporter>
             <statelessTestsetInfoReporter
-              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
               <disable>false</disable>
               <usePhrasedFileName>false</usePhrasedFileName>
               <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
@@ -389,7 +389,7 @@
               <disable>${hide-test-logs-in-console}</disable>
             </consoleOutputReporter>
             <statelessTestsetInfoReporter
-              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
               <disable>false</disable>
               <usePhrasedFileName>false</usePhrasedFileName>
               <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>

--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
   </scm>
 
   <properties>
-
     <!-- Dependencies -->
     <apiguardian.version>1.1.2</apiguardian.version>
     <assertj.version>3.23.1</assertj.version>
@@ -73,6 +72,7 @@
     <maven-checkstyle-plugin.version>3.2.0</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>3.0.0</maven-deploy-plugin.version>
+    <maven-failsafe-plugin.version>3.0.0-M7</maven-failsafe-plugin.version>
     <maven-install-plugin.version>3.1.0</maven-install-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <maven-javadoc-plugin.version>3.4.1</maven-javadoc-plugin.version>
@@ -230,6 +230,67 @@
         </plugin>
 
         <plugin>
+          <!-- Integration testing config -->
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-failsafe-plugin</artifactId>
+          <version>${maven-failsafe-plugin.version}</version>
+
+          <configuration>
+            <includes>
+              <include>*IntegrationTest</include>
+            </includes>
+
+            <failIfNoTests>true</failIfNoTests>
+            <runOrder>random</runOrder>
+            <useModulePath>true</useModulePath>
+
+            <!--
+              This block is needed to show @DisplayName and @ParameterizedTest
+              in reports with the provided names.
+            -->
+            <statelessTestsetReporter
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+              <disable>false</disable>
+              <version>3.0</version>
+              <usePhrasedFileName>false</usePhrasedFileName>
+              <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+              <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+              <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+            </statelessTestsetReporter>
+            <consoleOutputReporter>
+              <disable>${hide-test-logs-in-console}</disable>
+            </consoleOutputReporter>
+            <statelessTestsetInfoReporter
+              implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+              <disable>false</disable>
+              <usePhrasedFileName>false</usePhrasedFileName>
+              <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+              <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+            </statelessTestsetInfoReporter>
+          </configuration>
+
+          <dependencies>
+            <dependency>
+              <groupId>me.fabriciorby</groupId>
+              <artifactId>maven-surefire-junit5-tree-reporter</artifactId>
+              <version>${maven-surefire-junit5-tree-reporter.version}</version>
+            </dependency>
+          </dependencies>
+
+          <executions>
+            <execution>
+              <!-- Enable failsafe to run -->
+              <id>integration-test</id>
+              <!-- This must not run during the test phase - JaCoCo messes up the reporting! -->
+              <goals>
+                <goal>integration-test</goal>
+                <goal>verify</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-install-plugin</artifactId>
           <version>${maven-install-plugin.version}</version>
@@ -303,11 +364,18 @@
           <version>${maven-surefire-plugin.version}</version>
 
           <configuration>
+            <excludes>
+              <exclude>*IntegrationTest</exclude>
+            </excludes>
+
+            <failIfNoTests>true</failIfNoTests>
+            <runOrder>random</runOrder>
+            <useModulePath>true</useModulePath>
+
             <!--
               This block is needed to show @DisplayName and @ParameterizedTest
               in reports with the provided names.
             -->
-            <runOrder>random</runOrder>
             <statelessTestsetReporter
               implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
               <disable>false</disable>
@@ -369,14 +437,45 @@
               <goals>
                 <goal>prepare-agent</goal>
               </goals>
+
+              <configuration>
+                <destFile>${project.build.directory}/jacoco-unit.bin</destFile>
+              </configuration>
             </execution>
 
             <execution>
-              <id>report-coverage</id>
+              <id>report-unit-test-coverage</id>
               <phase>test</phase>
               <goals>
                 <goal>report</goal>
               </goals>
+              <configuration>
+                <dataFile>${project.build.directory}/jacoco-unit.bin</dataFile>
+                <outputDirectory>${project.build.directory}/site/jacoco/unit</outputDirectory>
+              </configuration>
+            </execution>
+
+            <execution>
+              <id>add-coverage-agent-to-failsafe-args</id>
+              <phase>pre-integration-test</phase>
+              <goals>
+                <goal>prepare-agent-integration</goal>
+              </goals>
+              <configuration>
+                <destFile>${project.build.directory}/jacoco-int.bin</destFile>
+              </configuration>
+            </execution>
+
+            <execution>
+              <id>report-integration-test-coverage</id>
+              <phase>post-integration-test</phase>
+              <goals>
+                <goal>report-integration</goal>
+              </goals>
+              <configuration>
+                <dataFile>${project.build.directory}/jacoco-int.bin</dataFile>
+                <outputDirectory>${project.build.directory}/site/jacoco/int</outputDirectory>
+              </configuration>
             </execution>
           </executions>
         </plugin>

--- a/scripts/prepare-test-outputs-for-merge.sh
+++ b/scripts/prepare-test-outputs-for-merge.sh
@@ -117,17 +117,25 @@ function find-all-surefire-reports {
   find . -wholename '**/target/surefire-reports/TEST-*Test.xml' -print0 | xargs -0
 }
 
+function find-all-failsafe-reports {
+  info "Discovering Failsafe test reports"
+  find . -wholename '**/target/failsafe-reports/TEST-*Test.xml' -print0 | xargs -0
+}
+
 function find-all-jacoco-reports {
   info "Discovering JaCoCo coverage reports"
-  # For now, we only want the one jacoco file for the main module, if it exists.
-  local desired_jacoco_file="java-compiler-testing/target/site/jacoco/jacoco.xml"
-  if [ -f "${desired_jacoco_file}" ]; then
-    echo "${desired_jacoco_file}"
+  local desired_jacoco_unit_file="java-compiler-testing/target/site/jacoco/unit/jacoco.xml"
+  if [ -f "${desired_jacoco_unit_file}" ]; then
+    echo "${desired_jacoco_unit_file}"
+  fi
+  local desired_jacoco_int_file="java-compiler-testing/target/site/jacoco/int/jacoco.xml"
+  if [ -f "${desired_jacoco_int_file}" ]; then
+    echo "${desired_jacoco_int_file}"
   fi
 }
 
-stage "Updating Surefire reports..."
-for surefire_report in $(find-all-surefire-reports); do
+stage "Updating test reports..."
+for surefire_report in $(find-all-surefire-reports) $(find-all-failsafe-reports); do
   info "Adding Java version to test case names in ${surefire_report}..."
   new_surefire_report=${surefire_report/.xml/-java-${ci_java_version}-${ci_os}.xml}
   xsltproc --stringparam prefix "[Java-${ci_java_version}-${ci_os}]" \


### PR DESCRIPTION
- Use surefire for unit tests in main module.
- Use failsafe for integration tests in main module.
- Use separate JaCoCo report for unit tests.
- Use separate JaCoCo report for integration tests.
- Rework mutation test skippage annotation in main module.
- Instruct JaCoCo to run on verify phase as well as test phase.
- Implement codecov feature flags for integration and unit tests individually.
- Skip running test runner at all for Manifold when on `<jdk>(11,)</jdk>` similar to what Spring does for `<jdk>[,15)</jdk>`
- Rewrite parts of `prepare-test-outputs-for-merge.sh` to cope with new report locations.

Closes #122.