### PR TITLE
Remove names from copyright notice

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 - 2023 Ashley Scopes
+# Copyright (C) 2022 - 2023, the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.mvn/license/license-header.txt
+++ b/.mvn/license/license-header.txt
@@ -1,4 +1,4 @@
-Copyright (C) ${inceptionYear} - ${currentYear} Ashley Scopes
+Copyright (C) ${inceptionYear} - ${currentYear}, the original author or authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-inject/src/test/groovy/io/github/ascopes/jct/acceptancetests/avajeinject/AvajeInjectTest.groovy
+++ b/acceptance-tests/acceptance-tests-avaje-inject/src/test/groovy/io/github/ascopes/jct/acceptancetests/avajeinject/AvajeInjectTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/module-info.java
+++ b/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/org/example/CoffeeMaker.java
+++ b/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/org/example/CoffeeMaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/org/example/Grinder.java
+++ b/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/org/example/Grinder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/org/example/Pump.java
+++ b/acceptance-tests/acceptance-tests-avaje-inject/src/test/resources/code/org/example/Pump.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/src/test/groovy/io/github/ascopes/jct/acceptancetests/avajejsonb/AvajeJsonbTest.groovy
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/src/test/groovy/io/github/ascopes/jct/acceptancetests/avajejsonb/AvajeJsonbTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/src/test/resources/code/User.java
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/src/test/resources/code/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-checkerframework/src/test/groovy/io/github/ascopes/jct/acceptancetests/checkerframework/CheckerNullTest.groovy
+++ b/acceptance-tests/acceptance-tests-checkerframework/src/test/groovy/io/github/ascopes/jct/acceptancetests/checkerframework/CheckerNullTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-checkerframework/src/test/resources/code/nullness/happy/HappyCase.java
+++ b/acceptance-tests/acceptance-tests-checkerframework/src/test/resources/code/nullness/happy/HappyCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-checkerframework/src/test/resources/code/nullness/sad/SadCase.java
+++ b/acceptance-tests/acceptance-tests-checkerframework/src/test/resources/code/nullness/sad/SadCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-dagger/src/test/groovy/io/github/ascopes/jct/acceptancetests/dagger/DaggerTest.groovy
+++ b/acceptance-tests/acceptance-tests-dagger/src/test/groovy/io/github/ascopes/jct/acceptancetests/dagger/DaggerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-dagger/src/test/resources/code/WebServer.java
+++ b/acceptance-tests/acceptance-tests-dagger/src/test/resources/code/WebServer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-dagger/src/test/resources/code/WebServerConfiguration.java
+++ b/acceptance-tests/acceptance-tests-dagger/src/test/resources/code/WebServerConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-error-prone/src/test/groovy/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.groovy
+++ b/acceptance-tests/acceptance-tests-error-prone/src/test/groovy/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-error-prone/src/test/resources/code/nullness/happy/HappyCase.java
+++ b/acceptance-tests/acceptance-tests-error-prone/src/test/resources/code/nullness/happy/HappyCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-error-prone/src/test/resources/code/nullness/sad/SadCase.java
+++ b/acceptance-tests/acceptance-tests-error-prone/src/test/resources/code/nullness/sad/SadCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-factory/src/test/groovy/io/github/ascopes/jct/acceptancetests/autofactory/AutoFactoryTest.groovy
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/src/test/groovy/io/github/ascopes/jct/acceptancetests/autofactory/AutoFactoryTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-factory/src/test/resources/code/User.java
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/src/test/resources/code/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-service/src/test/groovy/io/github/ascopes/jct/acceptancetests/autoservice/AutoServiceTest.groovy
+++ b/acceptance-tests/acceptance-tests-google-auto-service/src/test/groovy/io/github/ascopes/jct/acceptancetests/autoservice/AutoServiceTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-service/src/test/resources/code/SomeImpl.java
+++ b/acceptance-tests/acceptance-tests-google-auto-service/src/test/resources/code/SomeImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-service/src/test/resources/code/SomeInterface.java
+++ b/acceptance-tests/acceptance-tests-google-auto-service/src/test/resources/code/SomeInterface.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-value/src/test/groovy/io/github/ascopes/jct/acceptancetests/autovalue/AutoValueTest.groovy
+++ b/acceptance-tests/acceptance-tests-google-auto-value/src/test/groovy/io/github/ascopes/jct/acceptancetests/autovalue/AutoValueTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-value/src/test/resources/code/User.java
+++ b/acceptance-tests/acceptance-tests-google-auto-value/src/test/resources/code/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-google-auto-value/src/test/resources/code/UserBuilder.java
+++ b/acceptance-tests/acceptance-tests-google-auto-value/src/test/resources/code/UserBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-immutables/src/test/groovy/io/github/ascopes/jct/acceptancetests/immutables/ImmutablesIntegrationTest.groovy
+++ b/acceptance-tests/acceptance-tests-immutables/src/test/groovy/io/github/ascopes/jct/acceptancetests/immutables/ImmutablesIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-immutables/src/test/resources/code/flat/org/example/Animal.java
+++ b/acceptance-tests/acceptance-tests-immutables/src/test/resources/code/flat/org/example/Animal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-immutables/src/test/resources/code/jpms/module-info.java
+++ b/acceptance-tests/acceptance-tests-immutables/src/test/resources/code/jpms/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-immutables/src/test/resources/code/jpms/org/example/Animal.java
+++ b/acceptance-tests/acceptance-tests-immutables/src/test/resources/code/jpms/org/example/Animal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-lombok/src/test/groovy/io/github/ascopes/jct/acceptancetests/lombok/LombokIntegrationTest.groovy
+++ b/acceptance-tests/acceptance-tests-lombok/src/test/groovy/io/github/ascopes/jct/acceptancetests/lombok/LombokIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-lombok/src/test/resources/code/flat/org/example/Animal.java
+++ b/acceptance-tests/acceptance-tests-lombok/src/test/resources/code/flat/org/example/Animal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-lombok/src/test/resources/code/jpms/module-info.java
+++ b/acceptance-tests/acceptance-tests-lombok/src/test/resources/code/jpms/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-lombok/src/test/resources/code/jpms/org/example/Animal.java
+++ b/acceptance-tests/acceptance-tests-lombok/src/test/resources/code/jpms/org/example/Animal.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
+++ b/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/groovy/io/github/ascopes/jct/acceptancetests/manifold/ManifoldPluginConfigurer.groovy
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/groovy/io/github/ascopes/jct/acceptancetests/manifold/ManifoldPluginConfigurer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/groovy/io/github/ascopes/jct/acceptancetests/manifold/ManifoldPreprocessorTest.groovy
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/groovy/io/github/ascopes/jct/acceptancetests/manifold/ManifoldPreprocessorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/nullness/happy/HappyCase.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/nullness/happy/HappyCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/nullness/sad/SadCase.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/nullness/sad/SadCase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/preprocessor/error/ClassWithErrors.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/preprocessor/error/ClassWithErrors.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/preprocessor/if/HelloWorld.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/preprocessor/if/HelloWorld.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/preprocessor/warning/ClassWithWarnings.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/preprocessor/warning/ClassWithWarnings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/tuple/User.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/tuple/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/tuple/UserRecords.java
+++ b/acceptance-tests/acceptance-tests-manifold-systems/src/test/resources/code/tuple/UserRecords.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/groovy/io/github/ascopes/jct/acceptancetests/mapstruct/MapStructIntegrationTest.groovy
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/groovy/io/github/ascopes/jct/acceptancetests/mapstruct/MapStructIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/Car.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/Car.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/CarDto.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/CarDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/CarMapper.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/CarMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/CarType.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/flat/org/example/CarType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/module-info.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/Car.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/Car.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/CarDto.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/CarDto.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/CarMapper.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/CarMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/CarType.java
+++ b/acceptance-tests/acceptance-tests-mapstruct/src/test/resources/code/jpms/org/example/CarType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-micronaut/src/test/groovy/io/github/ascopes/jct/acceptancetests/micronaut/MicronautConfigurer.groovy
+++ b/acceptance-tests/acceptance-tests-micronaut/src/test/groovy/io/github/ascopes/jct/acceptancetests/micronaut/MicronautConfigurer.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-micronaut/src/test/groovy/io/github/ascopes/jct/acceptancetests/micronaut/MicronautIntegrationTest.groovy
+++ b/acceptance-tests/acceptance-tests-micronaut/src/test/groovy/io/github/ascopes/jct/acceptancetests/micronaut/MicronautIntegrationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-micronaut/src/test/resources/code/Application.java
+++ b/acceptance-tests/acceptance-tests-micronaut/src/test/resources/code/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-micronaut/src/test/resources/code/HelloController.java
+++ b/acceptance-tests/acceptance-tests-micronaut/src/test/resources/code/HelloController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/AnnotatedService.java
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/AnnotatedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/Service.java
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/ServiceProcessor.java
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/ServiceProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/module-info.java
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/test/groovy/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/testing/ServiceProcessorJpmsTest.groovy
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/test/groovy/io/github/ascopes/jct/acceptancetests/serviceloaderjpms/testing/ServiceProcessorJpmsTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/test/resources/code/InsultProvider.java
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/test/resources/code/InsultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/src/test/resources/code/MeanInsultProviderImpl.java
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/src/test/resources/code/MeanInsultProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloader/AnnotatedService.java
+++ b/acceptance-tests/acceptance-tests-serviceloader/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloader/AnnotatedService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloader/Service.java
+++ b/acceptance-tests/acceptance-tests-serviceloader/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloader/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloader/ServiceProcessor.java
+++ b/acceptance-tests/acceptance-tests-serviceloader/src/main/java/io/github/ascopes/jct/acceptancetests/serviceloader/ServiceProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/src/test/groovy/io/github/ascopes/jct/acceptancetests/serviceloader/testing/ServiceProcessorTest.groovy
+++ b/acceptance-tests/acceptance-tests-serviceloader/src/test/groovy/io/github/ascopes/jct/acceptancetests/serviceloader/testing/ServiceProcessorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/src/test/resources/code/InsultProvider.java
+++ b/acceptance-tests/acceptance-tests-serviceloader/src/test/resources/code/InsultProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-serviceloader/src/test/resources/code/MeanInsultProviderImpl.java
+++ b/acceptance-tests/acceptance-tests-serviceloader/src/test/resources/code/MeanInsultProviderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/groovy/io/github/ascopes/jct/acceptancetests/spring/SpringBootAutoconfigureProcessorTest.groovy
+++ b/acceptance-tests/acceptance-tests-spring/src/test/groovy/io/github/ascopes/jct/acceptancetests/spring/SpringBootAutoconfigureProcessorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/groovy/io/github/ascopes/jct/acceptancetests/spring/SpringBootConfigurationProcessorTest.groovy
+++ b/acceptance-tests/acceptance-tests-spring/src/test/groovy/io/github/ascopes/jct/acceptancetests/spring/SpringBootConfigurationProcessorTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/groovy/io/github/ascopes/jct/acceptancetests/spring/SpringContextIndexerTest.groovy
+++ b/acceptance-tests/acceptance-tests-spring/src/test/groovy/io/github/ascopes/jct/acceptancetests/spring/SpringContextIndexerTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/autoconfigure/Application.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/autoconfigure/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/autoconfigure/config/RouteConfig.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/autoconfigure/config/RouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/autoconfigure/handlers/HelloWorldHandler.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/autoconfigure/handlers/HelloWorldHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/Application.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/config/RouteConfig.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/config/RouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/handlers/HelloWorldHandler.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/handlers/HelloWorldHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/properties/HelloWorldProperties.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/configuration/properties/HelloWorldProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/indexer/Application.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/indexer/Application.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/indexer/config/RouteConfig.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/indexer/config/RouteConfig.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/acceptance-tests-spring/src/test/resources/code/indexer/handlers/HelloWorldHandler.java
+++ b/acceptance-tests/acceptance-tests-spring/src/test/resources/code/indexer/handlers/HelloWorldHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022 - 2023 Ashley Scopes
+# Copyright (C) 2022 - 2023, the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/java-compiler-testing/security-suppressions.xml
+++ b/java-compiler-testing/security-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractEnumAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractEnumAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractJavaFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractJavaFileObjectAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ClassLoaderAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ClassLoaderAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/DiagnosticKindAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/DiagnosticKindAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectKindAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectKindAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctAssertions.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctAssertions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/LocationAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/LocationAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/OutputContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/OutputContainerGroupAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PathFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PathFileObjectAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceElementAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceElementAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssert.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctJsr199Interop.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctJsr199Interop.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctCompilerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctFlagBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctFlagBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ContainerGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ModuleContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ModuleContainerGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/OutputContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/OutputContainerGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ModuleContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ModuleContainerGroupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TraceDiagnostic.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TraceDiagnostic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListener.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctCompilerException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctCompilerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctJunitConfigurerException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctJunitConfigurerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/AnnotationProcessorDiscovery.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/AnnotationProcessorDiscovery.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/LoggingFileManagerProxy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/LoggingFileManagerProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/LoggingMode.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/LoggingMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/ModuleLocation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/ModuleLocation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/PathFileObject.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/PathFileObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/DiagnosticListRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/DiagnosticListRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/LocationRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/LocationRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/StackTraceRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/StackTraceRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IoExceptionUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IoExceptionUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IterableUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IterableUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/Lazy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/Lazy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ModuleHandle.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ModuleHandle.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/NonNullApi.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/NonNullApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/NonNullImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/NonNullImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/SpecialLocationUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/SpecialLocationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringSlicer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringSlicer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ToStringBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ToStringBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/UtilityClass.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/UtilityClass.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/DirectoryBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/DirectoryBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/FileBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/FileBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/ManagedDirectory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/ManagedDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathRoot.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathRoot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspaces.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspaces.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/AbstractManagedDirectory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/AbstractManagedDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/DirectoryBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/DirectoryBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/TempDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/TempDirectoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/DoNotMutationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/DoNotMutationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/GenericMock.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/GenericMock.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Slf4jLoggerFake.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Slf4jLoggerFake.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/UtilityClassTestTemplate.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/UtilityClassTestTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicLegacyCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicLegacyCompilationIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicModuleCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicModuleCompilationIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicMultiModuleCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/BasicMultiModuleCompilationIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/AbstractContainerGroupAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/AbstractContainerGroupAssertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/AbstractEnumAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/AbstractEnumAssertTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/JctAssertionsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/JctAssertionsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilersTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilersTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctJsr199InteropTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctJsr199InteropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctCompilerImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctCompilerImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctFlagBuilderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctFlagBuilderImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TeeWriterTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TeeWriterTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TraceDiagnosticTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TraceDiagnosticTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TracingDiagnosticListenerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TracingDiagnosticListenerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctCompilerExceptionTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctCompilerExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctJunitConfigurerExceptionTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctJunitConfigurerExceptionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/JavacCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/JavacCompilersProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/DiagnosticListRepresentationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/DiagnosticListRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/LocationRepresentationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/LocationRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/StackTraceRepresentationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/StackTraceRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/TraceDiagnosticRepresentationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/TraceDiagnosticRepresentationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/repr/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/IoExceptionUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/IoExceptionUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/IterableUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/IterableUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/LazyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/LazyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/ModuleHandleTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/ModuleHandleTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/SpecialLocationsUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/SpecialLocationsUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/StringSlicerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/StringSlicerTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/StringUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/StringUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/ToStringBuilderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/ToStringBuilderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/ManagedDirectoryTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/ManagedDirectoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/PathStrategyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/PathStrategyTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspacesTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspacesTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/WrappingDirectoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/WrappingDirectoryImplTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/package-info.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java-compiler-testing/src/test/java/module-info.java
+++ b/java-compiler-testing/src/test/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 - 2023 Ashley Scopes
+ * Copyright (C) 2022 - 2023, the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 - 2023 Ashley Scopes
+# Copyright (C) 2022 - 2023, the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/prepare-test-outputs-for-merge.sh
+++ b/scripts/prepare-test-outputs-for-merge.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 - 2023 Ashley Scopes
+# Copyright (C) 2022 - 2023, the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/update-licenses.sh
+++ b/scripts/update-licenses.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright (C) 2022 - 2023 Ashley Scopes
+# Copyright (C) 2022 - 2023, the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/security-suppressions.xml
+++ b/security-suppressions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (C) 2022 - 2023 Ashley Scopes
+    Copyright (C) 2022 - 2023, the original author or authors.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Enables the license plugin to be used consistently without contributors needing to use my name in the original header if a file is entirely their own work.