### PR TITLE
Do not use Nexus plugin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,16 +8,6 @@ on:
         default: true
         type: boolean
 
-      skip-deploy:
-        description: "Skip deployment step"
-        default: false
-        type: boolean
-
-      skip-pages:
-        description: "Skip page publishing step"
-        default: false
-        type: boolean
-
       skip-initial-verification:
         description: "Skip tests, dependency check, formatting, licenses"
         default: false
@@ -104,18 +94,14 @@ jobs:
             "-DskipTests"
             "-Dlicense.skip=true"
             "-Dcheckstyle.skip=true"
+            "-Preleases"
+            '-P!acceptance-tests'
           )
-
-          build_goals=()
-          if [[ '${{ inputs.skip-deploy }}' == 'true' ]]; then
-            build_goals+=("clean" "package" "javadoc:jar" "javadoc:javadoc")
-            build_goals+=("${build_args[@]}")
-          else
-            build_goals+=("release:prepare" "release:perform" "javadoc:javadoc")
-          fi
           
           run <<-SCRIPT          
             ./mvnw -B -e \
+                -Preleases \
+                '-P!acceptance-tests' \
                 --no-transfer-progress \
                 -Darguments='${build_args[@]}' \
                 -DdryRun='${{ inputs.dry-run }}' \
@@ -125,7 +111,7 @@ jobs:
                 -DsignTag=false \
                 -Dstyle.color=always \
                 -Dtag='v${release_version}' \
-                ${build_goals[@]}
+                release:prepare release:perform
           SCRIPT
           
           success "Release has been performed successfully"
@@ -135,12 +121,3 @@ jobs:
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
-      - name: Upload JavaDocs as a build artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: java-compiler-testing/target/apidocs
-
-      - name: Deploy JavaDocs build artifact to GitHub Pages
-        if: ${{ ! inputs.dry-run }} && ${{ ! inputs.skip-pages }}
-        id: deployment
-        uses: actions/deploy-pages@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,7 +80,6 @@ jobs:
           run <<-SCRIPT          
             ./mvnw -B -e \
                 -Preleases \
-                '-P!acceptance-tests' \
                 --no-transfer-progress \
                 -Darguments='${build_args[@]}' \
                 -DdryRun='${{ inputs.dry-run }}' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -94,7 +94,9 @@ jobs:
           SCRIPT
           
           success "Release has been performed successfully"
-          info "Please log onto the Nexus staging site and mark the release as closed to publish it"
+          info "Please login on https://s01.oss.sonatype.org/#stagingRepositories site and mark the"
+          info "release as closed. Once checks pass, click the 'release' option to promote it to"
+          info "Maven Central."
 
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,6 @@ on:
         default: true
         type: boolean
 
-      skip-dependency-scan:
-        description: "Skip dependency scan"
-        default: false
-        type: boolean
-
       skip-deploy:
         description: "Skip deployment step"
         default: false
@@ -23,8 +18,8 @@ on:
         default: false
         type: boolean
 
-      skip-tests:
-        description: "Skip tests"
+      skip-initial-verification:
+        description: "Skip tests, dependency check, formatting, licenses"
         default: false
         type: boolean
 
@@ -61,6 +56,21 @@ jobs:
           gpg-passphrase: GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
 
+      - name: Ensure all tests pass
+        if: ${{ ! inputs.skip-initial-verification }}
+        shell: bash
+        run: >-
+          ./mvnw 
+          -B 
+          -e
+          -T4
+          -U
+          -P dependency-check
+          --no-transfer-progress
+          -Dstyle.color=always
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          clean verify
+
       - name: Configure Git
         shell: bash
         run: |-
@@ -89,14 +99,13 @@ jobs:
           info "Preparing and performing the release"
           ensure-set OSSRH_USERNAME OSSRH_TOKEN GPG_PASSPHRASE
           
-          build_args=()
-          if [[ '${{ inputs.skip-dependency-check }}' == 'false' ]]; then
-            build_args+=("-P" "dependency-check")
-          fi
-          if [[ '${{ inputs.skip-tests }}' == 'true' ]]; then
-            build_args+=("-Dmaven.test.skip" "-DskipTests")
-          fi
-          
+          build_args=(
+            "-Dmaven.test.skip" 
+            "-DskipTests"
+            "-Dlicense.skip=true"
+            "-Dcheckstyle.skip=true"
+          )
+
           build_goals=()
           if [[ '${{ inputs.skip-deploy }}' == 'true' ]]; then
             build_goals+=("clean" "package" "javadoc:jar")
@@ -120,6 +129,7 @@ jobs:
           SCRIPT
           
           success "Release has been performed successfully"
+
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -108,10 +108,10 @@ jobs:
 
           build_goals=()
           if [[ '${{ inputs.skip-deploy }}' == 'true' ]]; then
-            build_goals+=("clean" "package" "javadoc:jar")
+            build_goals+=("clean" "package" "javadoc:jar" "javadoc:javadoc")
             build_goals+=("${build_args[@]}")
           else
-            build_goals+=("release:prepare" "release:perform")
+            build_goals+=("release:prepare" "release:perform" "javadoc:javadoc")
           fi
           
           run <<-SCRIPT          

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,11 +8,6 @@ on:
         default: true
         type: boolean
 
-      skip-initial-verification:
-        description: "Skip tests, dependency check, formatting, licenses"
-        default: false
-        type: boolean
-
       version:
         description: "Version (leave blank to release non-SNAPSHOT patch)"
         default: ""
@@ -45,21 +40,6 @@ jobs:
           server-password: OSSRH_TOKEN
           gpg-passphrase: GPG_PASSPHRASE
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-
-      - name: Ensure all tests pass
-        if: ${{ ! inputs.skip-initial-verification }}
-        shell: bash
-        run: >-
-          ./mvnw 
-          -B 
-          -e
-          -T4
-          -U
-          -P dependency-check
-          --no-transfer-progress
-          -Dstyle.color=always
-          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          clean verify
 
       - name: Configure Git
         shell: bash
@@ -95,7 +75,6 @@ jobs:
             "-Dlicense.skip=true"
             "-Dcheckstyle.skip=true"
             "-Preleases"
-            '-P!acceptance-tests'
           )
           
           run <<-SCRIPT          
@@ -115,6 +94,7 @@ jobs:
           SCRIPT
           
           success "Release has been performed successfully"
+          info "Please log onto the Nexus staging site and mark the release as closed to publish it"
 
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-avaje-inject</artifactId>
   <name>JCT acceptance tests for Avaje Inject</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <avaje-inject.version>8.11</avaje-inject.version>

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-avaje-jsonb</artifactId>
   <name>JCT acceptance tests for Avaje JSONB</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <avaje-jsonb.version>1.1</avaje-jsonb.version>

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-checkerframework</artifactId>
   <name>JCT acceptance tests for CheckerFramework</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <argLine>

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-dagger</artifactId>
   <name>JCT acceptance tests for Google Dagger</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <dagger.version>2.44.2</dagger.version>

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-error-prone</artifactId>
   <name>JCT acceptance tests for Google ErrorProne</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <argLine>

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-google-auto-factory</artifactId>
   <name>JCT acceptance tests for Google AutoFactory</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <auto-factory.version>1.0.1</auto-factory.version>

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-google-auto-service</artifactId>
   <name>JCT acceptance tests for Google AutoService</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <auto-service.version>1.0.1</auto-service.version>

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-google-auto-value</artifactId>
   <name>JCT acceptance tests for Google AutoValue</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <auto-value.version>1.10.1</auto-value.version>

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-immutables</artifactId>
   <name>JCT acceptance tests for Immutables</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <immutables.version>2.9.3</immutables.version>

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-lombok</artifactId>
   <name>JCT acceptance tests for Lombok</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <lombok.version>1.18.24</lombok.version>

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
+++ b/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
+++ b/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
+++ b/acceptance-tests/acceptance-tests-manifold-systems/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-manifold-systems</artifactId>
   <name>JCT acceptance tests for Manifold Systems</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <manifold.version>2022.1.34</manifold.version>

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-mapstruct</artifactId>
   <name>JCT acceptance tests for MapStruct</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <mapstruct.version>1.5.3.Final</mapstruct.version>

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-micronaut</artifactId>
   <name>JCT acceptance tests for Micronaut</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <micronaut.version>3.8.0</micronaut.version>

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-serviceloader-jpms</artifactId>
   <name>JCT acceptance tests for a service loader API (JPMS)</name>
+  <description>Acceptance test components.</description>
 
   <dependencies>
     <dependency>

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-serviceloader</artifactId>
   <name>JCT acceptance tests for a service loader API</name>
+  <description>Acceptance test components.</description>
 
   <dependencies>
     <dependency>

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -28,6 +28,7 @@
 
   <artifactId>acceptance-tests-spring</artifactId>
   <name>JCT acceptance tests for Spring Framework 6</name>
+  <description>Acceptance test components.</description>
 
   <properties>
     <spring-boot.version>3.0.1</spring-boot.version>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -59,7 +59,6 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.release.skip>true</maven.release.skip>
     <skip-dependency-scan>true</skip-dependency-scan>
-    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
   </properties>
 
   <dependencyManagement>

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -30,6 +30,7 @@
   <packaging>pom</packaging>
 
   <name>JCT acceptance test parent project</name>
+  <description>Acceptance test components.</description>
 
   <modules>
     <module>acceptance-tests-avaje-inject</module>
@@ -58,6 +59,7 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <maven.release.skip>true</maven.release.skip>
     <skip-dependency-scan>true</skip-dependency-scan>
+    <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
   </properties>
 
   <dependencyManagement>

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.0.1-M3-SNAPSHOT</version>
+    <version>0.0.1-M4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.0.1-M4</version>
+    <version>0.0.1-M5-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
 
   <modules>
     <module>java-compiler-testing</module>
+    <module>acceptance-tests</module>
   </modules>
 
   <inceptionYear>2022</inceptionYear>
@@ -605,24 +606,6 @@
             </execution>
           </executions>
         </plugin>
-
-        <plugin>
-          <!-- Swaps out the maven deploy steps with Nexus-specific logic that can automate staging
-               checks for us. -->
-          <groupId>org.sonatype.plugins</groupId>
-          <artifactId>nexus-staging-maven-plugin</artifactId>
-          <version>${nexus-staging-maven-plugin.version}</version>
-          <extensions>true</extensions>
-          <configuration>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-            <autoDropAfterRelease>true</autoDropAfterRelease>
-            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
-            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
-            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-            <serverId>ossrh</serverId>
-            <updateReleaseInfo>true</updateReleaseInfo>
-          </configuration>
-        </plugin>
       </plugins>
     </pluginManagement>
 
@@ -723,21 +706,6 @@
     </profile>
 
     <profile>
-      <id>acceptance-tests</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-
-      <modules>
-        <!-- 
-          Activate these here so that they do not appear when Nexus is being
-          invoked
-        -->
-        <module>acceptance-tests</module>
-      </modules>
-    </profile>
-
-    <profile>
       <id>releases</id>
 
       <build>
@@ -787,12 +755,6 @@
                 </configuration>
               </execution>
             </executions>
-          </plugin>
-
-          <!-- Swap out the deploy plugin with the Nexus support to skip staging entirely. -->
-          <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>0.0.1-M3-SNAPSHOT</version>
+  <version>0.0.1-M4</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>
@@ -89,7 +89,7 @@
     <url>scm:git:${project.url}</url>
     <connection>scm:git:${project.url}</connection>
     <developerConnection>scm:git:${project.url}</developerConnection>
-    <tag>vHEAD</tag>
+    <tag>v0.0.1-M4</tag>
   </scm>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,6 @@
 
   <modules>
     <module>java-compiler-testing</module>
-    <module>acceptance-tests</module>
   </modules>
 
   <inceptionYear>2022</inceptionYear>
@@ -89,7 +88,7 @@
     <url>scm:git:${project.url}</url>
     <connection>scm:git:${project.url}</connection>
     <developerConnection>scm:git:${project.url}</developerConnection>
-    <tag>v0.0.1-M1</tag>
+    <tag>vHEAD</tag>
   </scm>
 
   <properties>
@@ -621,20 +620,8 @@
             <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
             <serverId>ossrh</serverId>
-            <skipLocalStaging>true</skipLocalStaging>
-            <skipStaging>true</skipStaging>
             <updateReleaseInfo>true</updateReleaseInfo>
           </configuration>
-
-          <executions>
-            <execution>
-              <id>default-deploy</id>
-              <phase>deploy</phase>
-              <goals>
-                <goal>deploy</goal>
-              </goals>
-            </execution>
-          </executions>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -736,10 +723,25 @@
     </profile>
 
     <profile>
+      <id>acceptance-tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+
+      <modules>
+        <!-- 
+          Activate these here so that they do not appear when Nexus is being
+          invoked
+        -->
+        <module>acceptance-tests</module>
+      </modules>
+    </profile>
+
+    <profile>
       <id>releases</id>
+
       <build>
         <plugins>
-
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,7 @@
             <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
             <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
             <serverId>ossrh</serverId>
+            <skipLocalStaging>true</skipLocalStaging>
             <skipStaging>true</skipStaging>
             <updateReleaseInfo>true</updateReleaseInfo>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>0.0.1-M4</version>
+  <version>0.0.1-M5-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>
@@ -89,7 +89,7 @@
     <url>scm:git:${project.url}</url>
     <connection>scm:git:${project.url}</connection>
     <developerConnection>scm:git:${project.url}</developerConnection>
-    <tag>v0.0.1-M4</tag>
+    <tag>vHEAD</tag>
   </scm>
 
   <properties>


### PR DESCRIPTION
Do not use the Nexus plugin for releases, as there is no nice way of satisfying all of these constraints due to how the plugin works:

- Update ALL version numbers correctly
- Do not attempt to deploy acceptance tests
- Do not fail because acceptance tests do not contain artifacts in the main sources
- Automatically close the release on Nexus to deploy it. 