### PR TITLE
Make CI compress reports during processing to speed up builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,9 +101,9 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: reports-java-${{ matrix.java-version }}-${{ matrix.os-name }}
+          name: reports-${{ matrix.java-version }}-${{ matrix.os-name }}
           if-no-files-found: error
-          path: reports-java-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz
+          path: reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz
           retention-days: 30
 
   mutation-tests:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,12 +8,19 @@ on:
       - synchronize
   push:
     branches:
-      - 'main'
+      - main
   workflow_call: {}
   workflow_dispatch: {}
 
 jobs:
   build:
+    name: Build on JDK ${{ matrix.java-version }} (${{ matrix.os-name }})
+    runs-on: ${{ matrix.os-name }}
+
+    concurrency:
+      group: build-build-${{ matrix.java-version }}-${{ matrix.os-name }}-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     strategy:
       fail-fast: false
       matrix:
@@ -40,11 +47,28 @@ jobs:
             java-version: 19
           - os-name: windows-2022
             java-version: 19
-          
-    name: Build on JDK ${{ matrix.java-version }} (${{ matrix.os-name }})
-    runs-on: ${{ matrix.os-name }}
 
     steps:
+      - name: Install dependencies
+        shell: bash
+        run: |-
+          # Ensure consistent versions of tools we use. MacOS uses an outdated version of bash, for
+          # example.
+          case "${OSTYPE}" in
+            win*|msys*)
+              choco install bash git tar xsltproc            
+              ;;
+            darwin*)
+              brew install bash git gnu-tar libxslt
+              ;;
+            linux*)
+              sudo apt-get install bash git tar xsltproc -qy
+              ;;
+            *)
+              echo "::warning:: Unknown OS type '${OSTYPE}'. Update build.yaml with a new case."
+              ;;
+          esac
+
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
@@ -89,9 +113,7 @@ jobs:
         shell: bash
         run: |-
           set +f -x
-          shopt -s globstar
-          
-          tar cvf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz \
+          tar -cvf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz \
               **/target/failsafe-reports/** \
               **/target/surefire-reports/** \
               **/target/site/jacoco/unit/jacoco*.xml \
@@ -109,6 +131,10 @@ jobs:
   mutation-tests:
     name: Run mutation tests
     runs-on: ubuntu-22.04
+
+    concurrency:
+      group: build-mutation-tests-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -150,9 +176,7 @@ jobs:
         shell: bash
         run: |-
           set +f -x
-          shopt -s globstar
-          
-          tar cvf reports-mutation-tests.tgz \ 
+          tar --ignore-failed-read -cvf reports-mutation-tests.tgz \
               **/target/surefire-reports/** \
               **/target/pit-reports/pit-reports/**
 
@@ -173,6 +197,10 @@ jobs:
       - build
       - mutation-tests
 
+    concurrency:
+      group: build-publish-test-reports-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     permissions:
       checks: write
       pull-requests: write
@@ -191,7 +219,7 @@ jobs:
 
       - name: Decompress stashed report tarballs
         shell: bash
-        run: find artifacts/ -name "reports-*.tgz" -exec tar xzv {} \;
+        run: find artifacts/ -name "reports-*.tgz" -exec tar -xzv {} \;
 
       - name: Publish test results
         continue-on-error: true
@@ -203,7 +231,7 @@ jobs:
           deduplicate_classes_by_file_name: true
           json_test_case_results: true
           json_thousands_separator: ","
-          junit_files: "artifacts/**/TEST-*.xml"
+          junit_files: "**/TEST-*.xml"
           report_individual_runs: false
           test_changes_limit: 500
           time_unit: "milliseconds"
@@ -236,6 +264,10 @@ jobs:
   formatting:
     name: Check formatting and licenses
     runs-on: ubuntu-22.04
+
+    concurrency:
+      group: build-formatting-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -271,6 +303,10 @@ jobs:
   dependency-check:
     name: Run dependency check
     runs-on: ubuntu-22.04
+
+    concurrency:
+      group: build-dependency-check-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository
@@ -318,6 +354,10 @@ jobs:
     name: Generate documentation
     runs-on: ubuntu-22.04
 
+    concurrency:
+      group: build-generate-documentation-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -357,13 +397,20 @@ jobs:
 
   publish-documentation:
     name: Publish documentation
+    runs-on: ubuntu-22.04
     if: ${{ github.ref-name == 'main' && github.event_name != 'pull_request' }}
+
+    concurrency:
+      group: build-publish-documentation-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     permissions:
       pages: write
       id-token: write
-    runs-on: ubuntu-22.04
+
     needs:
       - generate-documentation
+
     steps:
       - name: Deploy JavaDocs build artifact to GitHub Pages
         id: javadocs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
           set +f -x
           shopt -s globstar
           
-          tar czvf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz \
+          tar cvf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz \
               **/target/failsafe-reports/** \
               **/target/surefire-reports/** \
               **/target/site/jacoco/unit/jacoco*.xml \
@@ -152,7 +152,7 @@ jobs:
           set +f -x
           shopt -s globstar
           
-          tar czvf reports-mutation-tests.tgz \ 
+          tar cvf reports-mutation-tests.tgz \ 
               **/target/surefire-reports/** \
               **/target/pit-reports/pit-reports/**
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,128 +13,6 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  formatting:
-    name: Check formatting
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-
-      - name: Initialize Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 17
-          cache: 'maven'
-
-      - name: Run checks
-        shell: bash
-        run: >-
-          ./mvnw 
-          -B
-          -e
-          -T1C
-          -U
-          --no-transfer-progress
-          -DskipTests=true
-          -Dstyle.color=always
-          -Dmaven.main.skip
-          -Dmaven.jar.skip
-          -Dmaven.resources.skip
-          -Dmaven.test.skip
-          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          verify
-
-  dependency-check:
-    name: Run dependency check
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-
-      - name: Initialize Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 17
-          cache: 'maven'
-
-      - name: Run checks
-        shell: bash
-        run: >-
-          ./mvnw 
-          -B
-          -e
-          -T1C
-          -U
-          -Pdependency-check
-          --no-transfer-progress
-          -DskipTests=true
-          -Dstyle.color=always
-          -Dcheckstyle.skip=true
-          -Dlicense.skip=true
-          -Dmaven.main.skip
-          -Dmaven.jar.skip
-          -Dmaven.resources.skip
-          -Dmaven.test.skip
-          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          verify
-
-      - name: Archive Dependency Scan reports
-        uses: actions/upload-artifact@v3
-        if: always()
-        with:
-          name: dependency-scan-report
-          path: '**/target/dependency-check-report.html'
-          retention-days: 30
-
-  generate-documentation:
-    name: Generate documentation
-    runs-on: ubuntu-22.04
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 2
-
-      - name: Initialize Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          # Must use >= JDK 17 for JavaDocs to generate correctly.
-          java-version: 17
-          cache: 'maven'
-
-      - name: Generate JavaDocs
-        shell: bash
-        run: >-
-          ./mvnw 
-          -B
-          -e
-          -T1C
-          -U
-          -pl java-compiler-testing
-          --also-make
-          --no-transfer-progress
-          -Dmaven.test.skip=true
-          -Dcheckstyle.skip=true
-          -Dlicense.skip=true
-          -Dstyle.color=always
-          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
-          clean compile javadoc:jar
-
-      - name: Upload JavaDocs as a build artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: java-compiler-testing/target/apidocs
-
   build:
     strategy:
       fail-fast: false
@@ -354,6 +232,128 @@ jobs:
           # codecov processes it correctly. Need to hardwire the paths in here somehow.
           #./codecov -c -F unit -v
           #./codecov -c -F integration -v
+
+  formatting:
+    name: Check formatting and licenses
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Initialize Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'maven'
+
+      - name: Run checks
+        shell: bash
+        run: >-
+          ./mvnw 
+          -B
+          -e
+          -T1C
+          -U
+          --no-transfer-progress
+          -DskipTests=true
+          -Dstyle.color=always
+          -Dmaven.main.skip
+          -Dmaven.jar.skip
+          -Dmaven.resources.skip
+          -Dmaven.test.skip
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          verify
+
+  dependency-check:
+    name: Run dependency check
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Initialize Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: 17
+          cache: 'maven'
+
+      - name: Run checks
+        shell: bash
+        run: >-
+          ./mvnw 
+          -B
+          -e
+          -T1C
+          -U
+          -Pdependency-check
+          --no-transfer-progress
+          -DskipTests=true
+          -Dstyle.color=always
+          -Dcheckstyle.skip=true
+          -Dlicense.skip=true
+          -Dmaven.main.skip
+          -Dmaven.jar.skip
+          -Dmaven.resources.skip
+          -Dmaven.test.skip
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          verify
+
+      - name: Archive Dependency Scan reports
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: dependency-scan-report
+          path: '**/target/dependency-check-report.html'
+          retention-days: 30
+
+  generate-documentation:
+    name: Generate documentation
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+
+      - name: Initialize Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          # Must use >= JDK 17 for JavaDocs to generate correctly.
+          java-version: 17
+          cache: 'maven'
+
+      - name: Generate JavaDocs
+        shell: bash
+        run: >-
+          ./mvnw 
+          -B
+          -e
+          -T1C
+          -U
+          -pl java-compiler-testing
+          --also-make
+          --no-transfer-progress
+          -Dmaven.test.skip=true
+          -Dcheckstyle.skip=true
+          -Dlicense.skip=true
+          -Dstyle.color=always
+          -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+          clean compile javadoc:jar
+
+      - name: Upload JavaDocs as a build artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: java-compiler-testing/target/apidocs
 
   publish-documentation:
     name: Publish documentation

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   formatting:
-    name: Formatting
+    name: Check formatting
     runs-on: ubuntu-22.04
 
     steps:
@@ -36,7 +36,7 @@ jobs:
           ./mvnw 
           -B
           -e
-          -T4
+          -T1C
           -U
           --no-transfer-progress
           -DskipTests=true
@@ -49,7 +49,7 @@ jobs:
           verify
 
   dependency-check:
-    name: Dependency Check
+    name: Run dependency check
     runs-on: ubuntu-22.04
 
     steps:
@@ -70,7 +70,8 @@ jobs:
         run: >-
           ./mvnw 
           -B
-          -T4
+          -e
+          -T1C
           -U
           -Pdependency-check
           --no-transfer-progress
@@ -93,8 +94,8 @@ jobs:
           path: '**/target/dependency-check-report.html'
           retention-days: 30
 
-  javadocs:
-    name: JavaDocs
+  generate-documentation:
+    name: Generate documentation
     runs-on: ubuntu-22.04
 
     steps:
@@ -117,7 +118,7 @@ jobs:
           ./mvnw 
           -B
           -e
-          -T4
+          -T1C
           -U
           -pl java-compiler-testing
           --also-make
@@ -162,7 +163,7 @@ jobs:
           - os-name: windows-2022
             java-version: 19
           
-    name: Build - JDK ${{ matrix.java-version }} - ${{ matrix.os-name }}
+    name: Build on JDK ${{ matrix.java-version }} (${{ matrix.os-name }})
     runs-on: ${{ matrix.os-name }}
 
     steps:
@@ -185,7 +186,7 @@ jobs:
           ./mvnw 
           -B 
           -e
-          -T4
+          -T1C
           -U
           --no-transfer-progress
           -Dcheckstyle.skip=true
@@ -208,12 +209,15 @@ jobs:
       # file. This can take several minutes and is somewhat painful to have to wait for.
       - name: Compress test and coverage reports into tarball
         shell: bash
-        run: >-
-          tar czf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz
-          **/target/failsafe-reports/
-          **/target/surefire-reports/
-          **/target/site/jacoco/unit/jacoco*.xml
-          **/target/site/jacoco/int/jacoco*.xml
+        run: |-
+          set +f -x
+          shopt -s globstar
+          
+          tar czvf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz \
+              **/target/failsafe-reports/** \
+              **/target/surefire-reports/** \
+              **/target/site/jacoco/unit/jacoco*.xml \
+              **/target/site/jacoco/int/jacoco*.xml
 
       - name: Stash reports tarball
         uses: actions/upload-artifact@v3
@@ -225,7 +229,7 @@ jobs:
           retention-days: 30
 
   mutation-tests:
-    name: Mutation tests
+    name: Run mutation tests
     runs-on: ubuntu-22.04
 
     steps:
@@ -248,6 +252,7 @@ jobs:
           ./mvnw 
           -B
           -e
+          -T1
           -U
           --also-make
           -pl java-compiler-testing
@@ -265,10 +270,13 @@ jobs:
       # file. This can take several minutes and is somewhat painful to have to wait for.
       - name: Compress mutation test reports into tarball
         shell: bash
-        run: >-
-          tar czf reports-mutation-tests.tgz
-          **/target/surefire-reports/
-          **/target/pit-reports/pit-reports/**
+        run: |-
+          set +f -x
+          shopt -s globstar
+          
+          tar czvf reports-mutation-tests.tgz \ 
+              **/target/surefire-reports/** \
+              **/target/pit-reports/pit-reports/**
 
       - name: Stash reports tarball
         uses: actions/upload-artifact@v3
@@ -347,15 +355,15 @@ jobs:
           #./codecov -c -F unit -v
           #./codecov -c -F integration -v
 
-  publish-javadocs:
-    name: Publish latest JavaDocs to GitHub pages
+  publish-documentation:
+    name: Publish documentation
     if: ${{ github.ref-name == 'main' && github.event_name != 'pull_request' }}
     permissions:
       pages: write
       id-token: write
     runs-on: ubuntu-22.04
     needs:
-      - javadocs
+      - generate-documentation
     steps:
       - name: Deploy JavaDocs build artifact to GitHub Pages
         id: javadocs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,8 +90,7 @@ jobs:
         if: always()
         with:
           name: dependency-scan-report
-          path: |
-            **/target/dependency-check-report.html
+          path: '**/target/dependency-check-report.html'
           retention-days: 30
 
   javadocs:
@@ -198,18 +197,27 @@ jobs:
           -j "${{ matrix.java-version }}"
           -o "${{ matrix.os-name }}"
 
-      - name: Archive test and coverage reports
+      # Compress first so that the collection job later takes far less time (order of a few minutes
+      # or so). GitHub does not compress these until after the workflow finishes, meaning when
+      # we unstash them to produce the coverage reports, it will make an HTTP call for every single
+      # file. This can take several minutes and is somewhat painful to have to wait for.
+      - name: Compress test and coverage reports into tarball
+        shell: bash
+        run: >-
+          tar czf reports-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz
+          **/target/failsafe-reports/
+          **/target/surefire-reports/
+          **/target/site/jacoco/unit/jacoco*.xml
+          **/target/site/jacoco/int/jacoco*.xml
+
+      - name: Stash reports tarball
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: reports-java-${{ matrix.java-version }}-${{ matrix.os-name }}
           if-no-files-found: error
-          path: |-
-            **/target/failsafe-reports/
-            **/target/surefire-reports/
-            **/target/site/jacoco/unit/jacoco*.xml
-            **/target/site/jacoco/int/jacoco*.xml
-          retention-days: 5
+          path: reports-java-${{ matrix.java-version }}-${{ matrix.os-name }}.tgz
+          retention-days: 30
 
   mutation-tests:
     name: Mutation tests
@@ -246,16 +254,25 @@ jobs:
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
           test
 
-      - name: Archive reports
+      # Compress first so that the collection job later takes far less time (order of a few minutes
+      # or so). GitHub does not compress these until after the workflow finishes, meaning when
+      # we unstash them to produce the coverage reports, it will make an HTTP call for every single
+      # file. This can take several minutes and is somewhat painful to have to wait for.
+      - name: Compress mutation test reports into tarball
+        shell: bash
+        run: >-
+          tar czf reports-mutation-tests.tgz
+          **/target/surefire-reports/
+          **/target/pit-reports/pit-reports/**
+
+      - name: Stash reports tarball
         uses: actions/upload-artifact@v3
         if: always()
         with:
           name: reports-mutation
           if-no-files-found: error
-          path: |-
-            **/target/surefire-reports/
-            **/target/pit-reports/pit-reports/**
-          retention-days: 5
+          path: reports-mutation-tests.tgz
+          retention-days: 30
 
   publish-test-reports:
     name: Publish test reports
@@ -276,12 +293,16 @@ jobs:
           # Needed to keep actions working correctly.
           fetch-depth: 2
 
-      - name: Download artifacts
+      - name: Download stashed tarballs
         uses: actions/download-artifact@v3
         with:
-          path: 'artifacts/'
+          path: 'artifacts/reports-*.tgz'
 
-      - name: Publish unit test results
+      - name: Decompress stashed report tarballs
+        shell: bash
+        run: find artifacts/ -name "reports-*.tgz" -exec tar xzv {} \;
+
+      - name: Publish test results
         continue-on-error: true
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,11 @@ jobs:
           -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
           clean compile javadoc:jar
 
+      - name: Upload JavaDocs as a build artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: java-compiler-testing/target/apidocs
+
   build:
     strategy:
       fail-fast: false
@@ -341,3 +346,17 @@ jobs:
           # codecov processes it correctly. Need to hardwire the paths in here somehow.
           #./codecov -c -F unit -v
           #./codecov -c -F integration -v
+
+  publish-javadocs:
+    name: Publish latest JavaDocs to GitHub pages
+    if: ${{ github.ref-name == 'main' && github.event_name != 'pull_request' }}
+    permissions:
+      pages: write
+      id-token: write
+    runs-on: ubuntu-22.04
+    needs:
+      - javadocs
+    steps:
+      - name: Deploy JavaDocs build artifact to GitHub Pages
+        id: javadocs
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,13 @@ name: CodeQL analysis
 on:
   pull_request:
     branches:
-      - 'main'
+      - main
     types:
       - opened
       - synchronize
   push:
     branches:
-      - 'main'
+      - main
   workflow_call: {}
   workflow_dispatch: {}
 
@@ -16,6 +16,11 @@ jobs:
   codeql:
     name: CodeQL analysis (${{ matrix.language }})
     runs-on: ubuntu-22.04
+
+    concurrency:
+      group: codeql-codeql-${{ github.head_ref || github.run_id }}
+      cancel-in-progress: true
+
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,9 @@ jobs:
     name: Build and deploy code
     runs-on: ubuntu-22.04
 
+    # No concurrency groups, as we do not want to risk cancelling this job midway through a
+    # run and producing a tag without pushing to Maven Central at the same time.
+
     permissions:
       contents: write
       id-token: write
@@ -101,4 +104,3 @@ jobs:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_TOKEN: ${{ secrets.OSSRH_TOKEN }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
 ![Java 11+](https://img.shields.io/badge/Java-11+-yellow?logo=openjdk)
 [![Build Status](https://github.com/ascopes/java-compiler-testing/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/ascopes/java-compiler-testing/actions/workflows/build.yml)
-[![javadoc](https://javadoc.io/badge2/io.github.ascopes.jct/java-compiler-testing/javadoc.svg)](https://javadoc.io/doc/io.github.ascopes.jct/java-compiler-testing)
-[![Code Coverage](https://codecov.io/gh/ascopes/java-compiler-testing/branch/main/graph/badge.svg?token=VT74BP2742)](https://codecov.io/gh/ascopes/java-compiler-testing)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.ascopes.jct/java-compiler-testing)](https://repo1.maven.org/maven2/io/github/ascopes/jct/java-compiler-testing)
+[![Code Coverage](https://codecov.io/gh/ascopes/java-compiler-testing/branch/main/graph/badge.svg?token=VT74BP2742)](https://codecov.io/gh/ascopes/java-compiler-testing)
+[![javadoc (latest release)](https://javadoc.io/badge2/io.github.ascopes.jct/java-compiler-testing/javadoc.svg)](https://javadoc.io/doc/io.github.ascopes.jct/java-compiler-testing)
+[![javadoc (main branch)](https://img.shields.io/badge/javadoc-ref%2Fmain-brightgreen)](https://ascopes.github.io/java-compiler-testing)
 [![Issues](https://img.shields.io/github/issues-raw/ascopes/java-compiler-testing?color=orange)](https://github.com/ascopes/java-compiler-testing/issues)
 [![License](https://img.shields.io/github/license/ascopes/java-compiler-testing?color=blueviolet)](https://github.com/ascopes/java-compiler-testing/blob/main/LICENSE.txt)
 ![Activity](https://img.shields.io/github/commit-activity/y/ascopes/java-compiler-testing)
-
-<!-- [![Releases](https://img.shields.io/github/downloads/ascopes/java-compiler-testing/total)](https://github.com/ascopes/java-compiler-testing/releases) -->
-<!-- [![Maven Central](https://img.shields.io/maven-central/v/com.github.ascopes.jct/java-compiler-testing)](https://search.maven.org/artifact/com.github.ascopes.jct/java-compiler-testing) -->
 
 # java-compiler-testing
 

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -67,15 +67,6 @@ function ensure-set() {
   return "${return_code}"
 }
 
-# Ensure that each provided argument is in the path, or fail.
-function in-path() {
-  for expected; do
-    command -v "${expected}" &> /dev/null || return 1
-  done
-
-  return 0
-}
-
 # Visually run the command, showing the command being run, stdout, and stderr to the user.
 # Pass the commands to run in via a heredoc as stdin. Incorrect usage will dump an error and
 # terminate the current shell.

--- a/scripts/prepare-test-outputs-for-merge.sh
+++ b/scripts/prepare-test-outputs-for-merge.sh
@@ -49,36 +49,6 @@ if [ -z "${ci_java_version}" ] || [ -z "${ci_os}" ]; then
   exit 1
 fi
 
-info "Looking for xsltproc binary..."
-
-# If we don't have xsltproc installed, try to resolve it first.
-# If we are in CI, always attempt to install it so we ensure that it
-# is up-to-date first.
-if [[ -z ${CI+undefined} ]] && in-path xsltproc; then
-  info "xsltproc appears to be installed, and this is not a CI run"
-elif [[ "${OSTYPE}" = "darwin"* ]] && in-path brew; then
-  info "Installing xsltproc from homebrew"
-  run <<< "brew install libxslt"
-  info "Giving the brew xsltproc binary precedence over the default MacOS one..."
-  export PATH="/usr/local/opt/libxslt/bin:${PATH}"
-elif [[ "${OSTYPE}" =~ /win.*|mingw|msys|cygwin/ ]] && in-path choco; then
-  info "Installing xsltproc from choco"
-  run <<< "choco install xsltproc"
-elif [[ "${OSTYPE}" = "linux"* ]] && in-path apt-get; then
-  info "Installing xsltproc using apt-get"
-  run <<< "sudo apt-get install -qy xsltproc"
-elif [[ "${OSTYPE}" = "linux"* ]] && in-path dnf; then
-  info "Installing xsltproc using dnf"
-  run <<< "sudo dnf install -qy xsltproc"
-elif [[ "${OSTYPE}" = "linux"* ]] && in-path yum; then
-  info "Installing xsltproc using yum"
-  run <<< "sudo yum install -qy xsltproc"
-else
-  err "Cannot find xsltproc, nor can I find a suitable package manager to install it with."
-  err "Please install xsltproc manually and then try again."
-  exit 2
-fi
-
 success "Found $(command -v xsltproc)"
 run <<< "xsltproc --version"
 


### PR DESCRIPTION
GitHub does not compress the build report files until the build ends.
This means that the operation of stashing reports from each platform
and then unstashing them later for bulk processing in the publish
reports stage takes a very long time (several minutes sometimes), since
each file has to be fetched from the object store individually. This
can be several thousand files in total due to the number of tests and
the number of runners those tests get called upon.

This change compresses these files during the build into a tarball to
reduce the number of files being requested from the object store, and
reduces the size of those files via gzip compression.