### PR TITLE
Remove -implicit flag from default compilation

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctCompilerImpl.java
@@ -68,7 +68,6 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler<JavacJctComp
    */
   public JavacJctCompilerImpl(String name, JavaCompiler jsr199Compiler) {
     super(name, jsr199Compiler, new JavacJctFlagBuilderImpl());
-    addCompilerOptions("-implicit:class");
   }
 
   @Override

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctCompilerImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctCompilerImplTest.java
@@ -89,11 +89,25 @@ class JavacJctCompilerImplTest {
     assertThat(compiler.getFlagBuilder()).isInstanceOf(JavacJctFlagBuilderImpl.class);
   }
 
-  @DisplayName("compilers have the -implicit:class flag set")
+  @DisplayName("Compilers have no default compiler flags set")
   @Test
-  void compilersHaveTheImplicitClassFlagSet() {
+  void compilersHaveNoDefaultCompilerFlagsSet() {
     // Then
-    assertThat(compiler.getCompilerOptions()).contains("-implicit:class");
+    assertThat(compiler.getCompilerOptions()).isEmpty();
+  }
+
+  @DisplayName("Compilers have no default annotation processor flags set")
+  @Test
+  void compilersHaveNoDefaultAnnotationProcessorFlagsSet() {
+    // Then
+    assertThat(compiler.getAnnotationProcessorOptions()).isEmpty();
+  }
+
+  @DisplayName("Compilers have no default annotation processors set")
+  @Test
+  void compilersHaveNoDefaultAnnotationProcessorsSet() {
+    // Then
+    assertThat(compiler.getAnnotationProcessors()).isEmpty();
   }
 
   @DisplayName("compilers have the expected default release string")


### PR DESCRIPTION
Removes the -implicit flag from the default compilation settings
for Javac, as it may hide potential compilation bugs.