### PR TITLE
Add ability to only run annotation processing/only run compilation

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -66,6 +66,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   private boolean showWarnings;
   private boolean showDeprecationWarnings;
   private boolean failOnWarnings;
+  private CompilationMode compilationMode;
   private Locale locale;
   private Charset logCharset;
   private boolean verbose;
@@ -104,6 +105,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
     showWarnings = JctCompiler.DEFAULT_SHOW_WARNINGS;
     showDeprecationWarnings = JctCompiler.DEFAULT_SHOW_DEPRECATION_WARNINGS;
     failOnWarnings = JctCompiler.DEFAULT_FAIL_ON_WARNINGS;
+    compilationMode = JctCompiler.DEFAULT_COMPILATION_MODE;
     locale = JctCompiler.DEFAULT_LOCALE;
     logCharset = JctCompiler.DEFAULT_LOG_CHARSET;
     previewFeatures = JctCompiler.DEFAULT_PREVIEW_FEATURES;
@@ -212,6 +214,17 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   @Override
   public A failOnWarnings(boolean enabled) {
     failOnWarnings = enabled;
+    return myself();
+  }
+
+  @Override
+  public CompilationMode getCompilationMode() {
+    return compilationMode;
+  }
+
+  @Override
+  public A compilationMode(CompilationMode compilationMode) {
+    this.compilationMode = compilationMode;
     return myself();
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
@@ -15,6 +15,8 @@
  */
 package io.github.ascopes.jct.compilers;
 
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -28,6 +30,8 @@ import org.apiguardian.api.API.Status;
  * @since 0.0.1 (0.0.1-M6)
  */
 @API(since = "0.0.1", status = Status.STABLE)
+@Immutable
+@ThreadSafe
 public enum CompilationMode {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.compilers;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * An enum representing the various types of compilation mode that a compiler can
+ * run under.
+ *
+ * <p>This corresponds to the {@code -proc} flag in the OpenJDK Javac implementation.
+ *
+ * @author Ashley Scopes
+ * @since 0.0.1 (0.0.1-M6)
+ */
+@API(since = "0.0.1", status = Status.STABLE)
+public enum CompilationMode {
+
+  /**
+   * Run compilation and run the annotation processors, if configured.
+   *
+   * <p>This is usually the default mode.
+   */
+  COMPILATION_AND_ANNOTATION_PROCESSING,
+
+  /**
+   * Run compilation, but skip any annotation processing that may run.
+   *
+   * <p>This corresponds to providing {@code -proc:none} in the OpenJDK Javac implementation.
+   */
+  COMPILATION_ONLY,
+
+  /**
+   * Skip compilation, but run any annotation processing that may be enabled.
+   *
+   * <p>This corresponds to providing {@code -proc:only} in the OpenJDK Javac implementation.
+   */
+  ANNOTATION_PROCESSING_ONLY,
+}

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -112,6 +112,12 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
   LoggingMode DEFAULT_DIAGNOSTIC_LOGGING_MODE = LoggingMode.ENABLED;
 
   /**
+   * Default setting for the compilation mode to use
+   * ({@link CompilationMode#COMPILATION_AND_ANNOTATION_PROCESSING}).
+   */
+  CompilationMode DEFAULT_COMPILATION_MODE = CompilationMode.COMPILATION_AND_ANNOTATION_PROCESSING;
+
+  /**
    * Default setting for how to apply annotation processor discovery when no processors are
    * explicitly defined ({@link AnnotationProcessorDiscovery#INCLUDE_DEPENDENCIES}).
    */
@@ -357,6 +363,27 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @return this compiler object for further call chaining.
    */
   C failOnWarnings(boolean enabled);
+
+  /**
+   * Get the compilation mode that is in use.
+   *
+   * <p>Unless otherwise changed or specified, implementations should default to
+   * {@link #DEFAULT_COMPILATION_MODE}.
+   *
+   * @return the compilation mode.
+   */
+  CompilationMode getCompilationMode();
+
+  /**
+   * Set the compilation mode to use for this compiler.
+   *
+   * <p>Unless otherwise changed or specified, implementations should default to
+   * {@link #DEFAULT_COMPILATION_MODE}.
+   *
+   * @param compilationMode the compilation mode to use.
+   * @return this compiler object for further call chaining.
+   */
+  C compilationMode(CompilationMode compilationMode);
 
   /**
    * Get the default release to use if no release or target version is specified.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
@@ -63,6 +63,14 @@ public interface JctFlagBuilder {
   JctFlagBuilder failOnWarnings(boolean enabled);
 
   /**
+   * Set the compilation mode to run under.
+   *
+   * @param compilationMode the compilation mode to run under.
+   * @return this builder.
+   */
+  JctFlagBuilder compilationMode(CompilationMode compilationMode);
+
+  /**
    * Add deprecation warning preferences.
    *
    * @param enabled whether the feature is enabled.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctFlagBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctFlagBuilderImpl.java
@@ -15,6 +15,7 @@
  */
 package io.github.ascopes.jct.compilers.javac;
 
+import io.github.ascopes.jct.compilers.CompilationMode;
 import io.github.ascopes.jct.compilers.JctFlagBuilder;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,6 +71,25 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
   @Override
   public JavacJctFlagBuilderImpl failOnWarnings(boolean enabled) {
     return addFlagIfTrue(enabled, WERROR);
+  }
+
+  @Override
+  public JctFlagBuilder compilationMode(CompilationMode compilationMode) {
+    switch (compilationMode) {
+      case COMPILATION_ONLY:
+        craftedFlags.add("-proc:none");
+        break;
+
+      case ANNOTATION_PROCESSING_ONLY:
+        craftedFlags.add("-proc:only");
+        break;
+
+      default:
+        // Do nothing. The default behaviour is to allow this.
+        break;
+    }
+
+    return this;
   }
 
   @Override

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 import io.github.ascopes.jct.compilers.AbstractJctCompiler;
+import io.github.ascopes.jct.compilers.CompilationMode;
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.compilers.JctCompilerConfigurer;
 import io.github.ascopes.jct.compilers.JctFlagBuilder;
@@ -200,6 +201,14 @@ class AbstractJctCompilerTest {
       // Then
       assertThatCompilerField("failOnWarnings")
           .isEqualTo(JctCompiler.DEFAULT_FAIL_ON_WARNINGS);
+    }
+
+    @DisplayName("constructor initialises compilationMode to default value")
+    @Test
+    void constructorInitialisesCompilationModeToDefaultValue() {
+      // Then
+      assertThatCompilerField("compilationMode")
+          .isEqualTo(JctCompiler.DEFAULT_COMPILATION_MODE);
     }
 
     @DisplayName("constructor initialises locale to default value")
@@ -620,6 +629,43 @@ class AbstractJctCompilerTest {
     void failOnWarningsReturnsTheCompiler() {
       // When
       var result = compiler.failOnWarnings(true);
+
+      // Then
+      assertThat(result).isSameAs(compiler);
+    }
+  }
+
+  @DisplayName(".isCompilationMode() returns the expected values")
+  @EnumSource(CompilationMode.class)
+  @ParameterizedTest(name = "for compilationMode = {0}")
+  void isCompilationModeReturnsExpectedValue(CompilationMode expected) {
+    // Given
+    setFieldOnCompiler("compilationMode", expected);
+
+    // Then
+    assertThat(compiler.getCompilationMode()).isEqualTo(expected);
+  }
+
+  @DisplayName("AbstractJctCompiler#compilationMode tests")
+  @Nested
+  class CompilationModeTests {
+
+    @DisplayName(".compilationMode(...) sets the expected values")
+    @EnumSource(CompilationMode.class)
+    @ParameterizedTest(name = "for compilationMode = {0}")
+    void compilationModeSetsExpectedValue(CompilationMode expected) {
+      // When
+      compiler.compilationMode(expected);
+
+      // Then
+      assertThatCompilerField("compilationMode").isEqualTo(expected);
+    }
+
+    @DisplayName(".compilationMode(...) returns the compiler")
+    @Test
+    void compilationModeReturnsTheCompiler() {
+      // When
+      var result = compiler.compilationMode(CompilationMode.COMPILATION_AND_ANNOTATION_PROCESSING);
 
       // Then
       assertThat(result).isSameAs(compiler);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctFlagBuilderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/javac/JavacJctFlagBuilderImplTest.java
@@ -20,6 +20,7 @@ import static io.github.ascopes.jct.tests.helpers.Fixtures.someRelease;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.ascopes.jct.compilers.CompilationMode;
 import io.github.ascopes.jct.compilers.javac.JavacJctFlagBuilderImpl;
 import io.github.ascopes.jct.tests.helpers.Fixtures;
 import java.util.List;
@@ -33,6 +34,8 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 /**
@@ -179,6 +182,50 @@ class JavacJctFlagBuilderImplTest {
     void returnsFlagBuilder() {
       // Then
       assertThat(flagBuilder.failOnWarnings(someBoolean()))
+          .isSameAs(flagBuilder);
+    }
+  }
+
+  @DisplayName(".compilationMode(CompilationMode) tests")
+  @Nested
+  class CompilationModeFlagTest {
+
+    @DisplayName(".compilationMode(COMPILATION_AND_ANNOTATION_PROCESSING) adds no flags")
+    @Test
+    void compilationAndAnnotationProcessingAddsNoFlags() {
+      // When
+      flagBuilder.compilationMode(CompilationMode.COMPILATION_AND_ANNOTATION_PROCESSING);
+
+      // Then
+      assertThat(flagBuilder.build()).isEmpty();
+    }
+
+    @DisplayName(".compilationMode(COMPILATION_ONLY) adds -proc:none")
+    @Test
+    void compilationOnlyAddsProcNone() {
+      // When
+      flagBuilder.compilationMode(CompilationMode.COMPILATION_ONLY);
+
+      // Then
+      assertThat(flagBuilder.build()).containsExactly("-proc:none");
+    }
+
+    @DisplayName(".compilationMode(ANNOTATION_PROCESSING_ONLY) adds -proc:only")
+    @Test
+    void annotationProcessingOnlyAddsProcOnly() {
+      // When
+      flagBuilder.compilationMode(CompilationMode.ANNOTATION_PROCESSING_ONLY);
+
+      // Then
+      assertThat(flagBuilder.build()).containsExactly("-proc:only");
+    }
+
+    @DisplayName(".compilationMode(...) returns the flag builder")
+    @EnumSource(CompilationMode.class)
+    @ParameterizedTest(name = "for compilationMode = {0}")
+    void returnsFlagBuilder(CompilationMode mode) {
+      // Then
+      assertThat(flagBuilder.compilationMode(mode))
           .isSameAs(flagBuilder);
     }
   }


### PR DESCRIPTION
Adds a new option to JctCompiler that enables the user to specify the
compiler mode to run under.

By default, nothing is changed, but the user may opt to specify the
`ANNOTATION_PROCESSING_ONLY` option which will pass `-proc:only` to
Javac, or to specify `COMPILATION_ONLY` which will pass `-proc:none`
to Javac.