### PR TITLE
Support project loom threads properly

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListener.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListener.java
@@ -17,6 +17,7 @@ package io.github.ascopes.jct.diagnostics;
 
 import static java.util.Objects.requireNonNull;
 
+import io.github.ascopes.jct.utils.LoomPolyfill;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
@@ -130,10 +131,7 @@ public class TracingDiagnosticListener<S extends JavaFileObject> implements Diag
     var thisThread = threadGetter.get();
     var threadName = thisThread.getName();
     var stackTrace = List.of(thisThread.getStackTrace());
-
-    // Thread#getId deprecated for Thread#threadId in Java 19.
-    @SuppressWarnings("deprecation")
-    var threadId = thisThread.getId();
+    var threadId = LoomPolyfill.getThreadId(thisThread);
 
     var wrapped = new TraceDiagnostic<S>(now, threadId, threadName, stackTrace, diagnostic);
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/LoomPolyfill.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/LoomPolyfill.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.utils;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Polyfill support for Project Loom virtual threads.
+ *
+ * @author Ashley Scopes
+ * @since 0.0.1
+ */
+@API(since = "0.0.1", status = Status.INTERNAL)
+public final class LoomPolyfill extends UtilityClass {
+
+  private LoomPolyfill() {
+    // Static-only class.
+  }
+
+  /**
+   * Get the thread ID (possibly the virtual thread ID if Project Loom is enabled).
+   *
+   * <p>This ensures that the underlying system does not spoof the thread ID on JDK 19 and newer.
+   *
+   * @param thread the thread to use.
+   * @return the thread ID (possibly the virtual thread ID).
+   */
+  public static long getThreadId(Thread thread) {
+    try {
+      // If we are on JDK 19, attempt to call the .threadId() method instead of the .getId()
+      // method. The former is new to JDK 19 and fetches the virtual thread ID.
+      var method = Thread.class.getDeclaredMethod("threadId");
+      return (long) method.invoke(thread);
+    } catch (Exception ex) {
+      @SuppressWarnings("deprecation")
+      var tid = thread.getId();
+      return tid;
+    }
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
@@ -27,6 +27,7 @@ import com.google.common.jimfs.Feature;
 import com.google.common.jimfs.Jimfs;
 import com.google.common.jimfs.PathType;
 import io.github.ascopes.jct.diagnostics.TraceDiagnostic;
+import io.github.ascopes.jct.utils.LoomPolyfill;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.io.IOException;
 import java.lang.module.ModuleReference;
@@ -215,7 +216,7 @@ public final class Fixtures {
     createStubMethodsFor(mock);
     when(mock.getTimestamp()).thenReturn(Instant.now());
     when(mock.getThreadName()).thenReturn(Thread.currentThread().getName());
-    when(mock.getThreadId()).thenReturn(Thread.currentThread().getId());
+    when(mock.getThreadId()).thenReturn(LoomPolyfill.getThreadId(Thread.currentThread()));
     when(mock.getStackTrace()).thenReturn(someStackTraceList());
     return mock;
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TraceDiagnosticTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TraceDiagnosticTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.github.ascopes.jct.diagnostics.TraceDiagnostic;
+import io.github.ascopes.jct.utils.LoomPolyfill;
 import io.github.ascopes.jct.utils.StringUtils;
 import java.util.Locale;
 import java.util.Random;
@@ -237,7 +238,7 @@ class TraceDiagnosticTest {
   @Test
   void getThreadIdReturnsTheThreadId() {
     // Given
-    var expectedThreadId = Thread.currentThread().getId() + someInt(100);
+    var expectedThreadId = LoomPolyfill.getThreadId(Thread.currentThread()) + someInt(100);
     var diagnostic = new TraceDiagnostic<>(
         now(),
         expectedThreadId,

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/LoomPolyfillTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/LoomPolyfillTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.ascopes.jct.tests.helpers.Fixtures;
+import io.github.ascopes.jct.tests.helpers.UtilityClassTestTemplate;
+import io.github.ascopes.jct.utils.LoomPolyfill;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+/**
+ * {@link LoomPolyfill} tests.
+ *
+ * @author Ashley Scopes
+ */
+class LoomPolyfillTest implements UtilityClassTestTemplate {
+
+  @Override
+  public Class<?> getTypeBeingTested() {
+    return LoomPolyfill.class;
+  }
+
+  @DisplayName(".getThreadId(Thread) on JRE <= 18 calls .getId()")
+  @EnabledForJreRange(max = JRE.JAVA_18)
+  @Test
+  void getThreadIdOnJre18AndOlderUsesThreadGetId() throws Throwable {
+    // Given
+    var expectedThreadId = Fixtures.someLong(1, Short.MAX_VALUE);
+    var thread = mock(Thread.class);
+    var getIdMethod = Thread.class.getDeclaredMethod("getId");
+
+    when((long) getIdMethod.invoke(thread)).thenReturn(expectedThreadId);
+
+    // When
+    var actualThreadId = LoomPolyfill.getThreadId(thread);
+
+    // Then
+    assertThat(actualThreadId).isEqualTo(expectedThreadId);
+    getIdMethod.invoke(verify(thread));
+  }
+
+  @DisplayName(".getThreadId(Thread) on JRE >= 19 calls .threadId()")
+  @EnabledForJreRange(min = JRE.JAVA_19)
+  @Test
+  void getThreadIdOnJre19AndNewerUsesThreadId() throws Throwable {
+    // Given
+    var expectedThreadId = Fixtures.someLong(1, Short.MAX_VALUE);
+    var thread = mock(Thread.class);
+    var threadIdMethod = Thread.class.getDeclaredMethod("threadId");
+
+    when((long) threadIdMethod.invoke(thread)).thenReturn(expectedThreadId);
+
+    // When
+    var actualThreadId = LoomPolyfill.getThreadId(thread);
+
+    // Then
+    assertThat(actualThreadId).isEqualTo(expectedThreadId);
+    threadIdMethod.invoke(verify(thread));
+    verifyNoMoreInteractions(thread);
+  }
+}


### PR DESCRIPTION
This enables the use of the newer thread ID support that cannot be spoofed or overridden in the OpenJDK implementation.