### PR TITLE
Add ability to customise the names of compiler objects

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -58,12 +58,12 @@ import org.apiguardian.api.API.Status;
 public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
     implements JctCompiler<A, JctCompilationImpl> {
 
-  private final String name;
   private final JavaCompiler jsr199Compiler;
   private final JctFlagBuilder flagBuilder;
   private final List<Processor> annotationProcessors;
   private final List<String> annotationProcessorOptions;
   private final List<String> compilerOptions;
+  private String name;
   private boolean showWarnings;
   private boolean showDeprecationWarnings;
   private boolean failOnWarnings;
@@ -87,7 +87,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   /**
    * Initialize this compiler.
    *
-   * @param name           the friendly name of the compiler.
+   * @param name           the friendly name of the compiler to default to.
    * @param jsr199Compiler the JSR-199 compiler implementation to use.
    * @param flagBuilder    the flag builder to use.
    */
@@ -141,6 +141,17 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
     return myself();
   }
 
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public A name(String name) {
+    this.name = requireNonNull(name, "name");
+    return myself();
+  }
+
   /**
    * Get the flag builder to use.
    *
@@ -157,15 +168,6 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
    */
   public JavaCompiler getJsr199Compiler() {
     return jsr199Compiler;
-  }
-
-  /**
-   * Get the friendly name of the compiler implementation.
-   *
-   * @return the friendly name.
-   */
-  public String getName() {
-    return name;
   }
 
   @Override

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -203,6 +203,21 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
   <E extends Exception> C configure(JctCompilerConfigurer<E> configurer) throws E;
 
   /**
+   * Get the friendly printable name of this compiler object.
+   *
+   * @return the name of the compiler.
+   */
+  String getName();
+
+  /**
+   * Set the friendly name of this compiler.
+   *
+   * @param name the name to set.
+   * @return this compiler object for further call chaining.
+   */
+  C name(String name);
+
+  /**
    * Get an <strong>immutable snapshot view</strong> of the current annotation processor options
    * that are set.
    *

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
@@ -452,6 +452,48 @@ class AbstractJctCompilerTest {
     }
   }
 
+  @DisplayName(".getName() returns the name")
+  @Test
+  void getNameReturnsName() {
+    // Then
+    assertThat(compiler.getName()).isEqualTo(name);
+  }
+
+  @DisplayName("AbstractJctCompiler#name tests")
+  @Nested
+  class NameTest {
+    @DisplayName(".name(...) sets the name")
+    @ValueSource(strings = {"foo", "bar baz", "bork"})
+    @ParameterizedTest(name = "for name = {0}")
+    void nameSetsTheName(String name) {
+      // When
+      compiler.name(name);
+
+      // Then
+      assertThatCompilerField("name").isEqualTo(name);
+    }
+
+    @DisplayName(".name(...) returns the compiler")
+    @Test
+    void nameReturnsTheCompiler() {
+      // When
+      var result = compiler.name("foo");
+
+      // Then
+      assertThat(result).isSameAs(compiler);
+    }
+
+    @DisplayName(".name(null) throws a NullPointerException")
+    @SuppressWarnings("DataFlowIssue")
+    @Test
+    void passingNullToNameThrowsNullPointerException() {
+      // Then
+      assertThatThrownBy(() -> compiler.name(null))
+          .isInstanceOf(NullPointerException.class)
+          .hasMessage("name");
+    }
+  }
+
   @DisplayName(".getFlagBuilder() returns the flag builder")
   @Test
   void getFlagBuilderReturnsFlagBuilder() {
@@ -464,13 +506,6 @@ class AbstractJctCompilerTest {
   void getJsr199CompilerReturnsTheCompiler() {
     // Then
     assertThat(compiler.getJsr199Compiler()).isSameAs(jsr199Compiler);
-  }
-
-  @DisplayName(".getName() returns the name")
-  @Test
-  void getNameReturnsName() {
-    // Then
-    assertThat(compiler.getName()).isSameAs(name);
   }
 
   @DisplayName(".isVerbose() returns the expected values")


### PR DESCRIPTION
Prerequisite of another prerequisite!

All compiler objects will now have a name in their public API.