### PR TITLE
Versioning strategies in Junit support.

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -79,4 +79,15 @@ public @interface JavacCompilerTest {
    */
   boolean modules() default false;
 
+  /**
+   * The version strategy to use.
+   *
+   * <p>This determines whether the version number being iterated across specifies the
+   * release, source, target, or source and target versions.
+   *
+   * <p>The default is to specify the release.
+   *
+   * @return the version strategy to use.
+   */
+  VersionStrategy versionStrategy() default VersionStrategy.RELEASE;
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
@@ -41,8 +41,8 @@ public final class JavacCompilersProvider extends AbstractCompilersProvider
   }
 
   @Override
-  protected JctCompiler<?, ?> compilerForVersion(int release) {
-    return new JavacJctCompilerImpl("javac release " + release).release(release);
+  protected JctCompiler<?, ?> initializeNewCompiler() {
+    return new JavacJctCompilerImpl();
   }
 
   @Override
@@ -62,7 +62,8 @@ public final class JavacCompilersProvider extends AbstractCompilersProvider
         javacCompilers.minVersion(),
         javacCompilers.maxVersion(),
         javacCompilers.modules(),
-        javacCompilers.configurers()
+        javacCompilers.configurers(),
+        javacCompilers.versionStrategy()
     );
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/VersionStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/VersionStrategy.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.junit;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import java.util.function.BiConsumer;
+import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Strategy for setting a version on a JUnit compiler annotation.
+ *
+ * @author Ashley Scopes
+ * @since 0.0.1 (0.0.1-M7)
+ */
+@API(since = "0.0.1", status = Status.STABLE)
+@Immutable
+@ThreadSafe
+public enum VersionStrategy {
+
+  /**
+   * Set the {@link JctCompiler#release release}.
+   */
+  RELEASE(
+      JctCompiler::release,
+      (compiler, version) -> compiler
+          .name(compiler.getName() + " (release = Java " + version + ")")
+  ),
+
+  /**
+   * Set the {@link JctCompiler#source} source}.
+   */
+  SOURCE(
+      JctCompiler::source,
+      (compiler, version) -> compiler
+          .name(compiler.getName() + " (source = Java " + version + ")")
+  ),
+
+  /**
+   * Set the {@link JctCompiler#target} target}.
+   */
+  TARGET(
+      JctCompiler::target,
+      (compiler, version) -> compiler
+          .name(compiler.getName() + " (target = Java " + version + ")")
+  ),
+
+  /**
+   * Set the {@link JctCompiler#source source} and {@link JctCompiler#target target}.
+   */
+  SOURCE_AND_TARGET(
+      (compiler, version) -> compiler
+          .source(version)
+          .target(version),
+      (compiler, version) -> compiler
+          .name(compiler.getName() + " (source and target = Java " + version + ")")
+  );
+
+  private final BiConsumer<JctCompiler<?, ?>, Integer> versionSetter;
+  private final BiConsumer<JctCompiler<?, ?>, Integer> descriptionFormatter;
+
+  VersionStrategy(
+      BiConsumer<JctCompiler<?, ?>, Integer> versionSetter,
+      BiConsumer<JctCompiler<?, ?>, Integer> descriptionFormatter
+  ) {
+    this.versionSetter = versionSetter;
+    this.descriptionFormatter = descriptionFormatter;
+  }
+
+  /**
+   * Set the given version on the compiler, according to the strategy in use.
+   *
+   * @param compiler the compiler to configure.
+   * @param version  the version to set.
+   */
+  public void configureCompiler(JctCompiler<?, ?> compiler, int version) {
+    versionSetter.accept(compiler, version);
+    descriptionFormatter.accept(compiler, version);
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/JavacCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/JavacCompilersProviderTest.java
@@ -28,6 +28,7 @@ import io.github.ascopes.jct.compilers.JctCompilerConfigurer;
 import io.github.ascopes.jct.compilers.javac.JavacJctCompilerImpl;
 import io.github.ascopes.jct.junit.JavacCompilerTest;
 import io.github.ascopes.jct.junit.JavacCompilersProvider;
+import io.github.ascopes.jct.junit.VersionStrategy;
 import java.lang.reflect.AnnotatedElement;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
@@ -69,7 +70,7 @@ class JavacCompilersProviderTest {
           var compiler = compilers.get(i);
           softly.assertThat(compiler.getName())
               .as("compilers[%d].getName()", i)
-              .isEqualTo("javac release %d", 10 + i);
+              .isEqualTo("JDK Compiler (release = Java %d)", 10 + i);
           softly.assertThat(compiler.getRelease())
               .as("compilers[%d].getRelease()", i)
               .isEqualTo("%d", 10 + i);
@@ -106,7 +107,7 @@ class JavacCompilersProviderTest {
           var compiler = compilers.get(i);
           softly.assertThat(compiler.getName())
               .as("compilers[%d].getName()", i)
-              .isEqualTo("javac release %d", 8 + i);
+              .isEqualTo("JDK Compiler (release = Java %d)", 8 + i);
           softly.assertThat(compiler.getRelease())
               .as("compilers[%d].getRelease()", i)
               .isEqualTo("%d", 8 + i);
@@ -143,7 +144,7 @@ class JavacCompilersProviderTest {
           var compiler = compilers.get(i);
           softly.assertThat(compiler.getName())
               .as("compilers[%d].getName()", i)
-              .isEqualTo("javac release %d", 10 + i);
+              .isEqualTo("JDK Compiler (release = Java %d)", 10 + i);
           softly.assertThat(compiler.getRelease())
               .as("compilers[%d].getRelease()", i)
               .isEqualTo("%d", 10 + i);
@@ -164,6 +165,7 @@ class JavacCompilersProviderTest {
     when(annotation.maxVersion()).thenReturn(max);
     when(annotation.modules()).thenReturn(modules);
     when(annotation.configurers()).thenReturn(configurers);
+    when(annotation.versionStrategy()).thenReturn(VersionStrategy.RELEASE);
     when(annotation.annotationType()).thenAnswer(ctx -> JavacCompilerTest.class);
     return annotation;
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/VersionStrategyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/VersionStrategyTest.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.junit;
+
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someText;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.junit.VersionStrategy;
+import io.github.ascopes.jct.tests.helpers.Fixtures;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mock.Strictness;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link VersionStrategy} tests.
+ * 
+ * @author Ashley Scopes
+ */
+@DisplayName("VersionStrategy tests")
+@ExtendWith(MockitoExtension.class)
+class VersionStrategyTest {
+  String baseName;
+
+  @Mock(answer = Answers.RETURNS_SELF, strictness = Strictness.LENIENT)
+  JctCompiler<?, ?> compiler;
+
+  @BeforeEach
+  void setUp() {
+    baseName = someText();
+    when(compiler.getName()).thenReturn(baseName);
+  }
+  
+  @DisplayName("RELEASE sets the release")
+  @ValueSource(ints = {10, 15, 20})
+  @ParameterizedTest(name = "for version {0}")
+  void releaseSetsTheRelease(int version) {
+    // When
+    VersionStrategy.RELEASE.configureCompiler(compiler, version);
+    
+    // Then
+    verify(compiler).release(version);
+    verify(compiler).getName();
+    verify(compiler).name(baseName + " (release = Java " + version + ")");
+    verifyNoMoreInteractions(compiler);
+  }
+
+  @DisplayName("SOURCE sets the source")
+  @ValueSource(ints = {10, 15, 20})
+  @ParameterizedTest(name = "for version {0}")
+  void sourceSetsTheSource(int version) {
+    // When
+    VersionStrategy.SOURCE.configureCompiler(compiler, version);
+
+    // Then
+    verify(compiler).source(version);
+    verify(compiler).getName();
+    verify(compiler).name(baseName + " (source = Java " + version + ")");
+    verifyNoMoreInteractions(compiler);
+  }
+
+  @DisplayName("TARGET sets the target")
+  @ValueSource(ints = {10, 15, 20})
+  @ParameterizedTest(name = "for version {0}")
+  void targetSetsTheTarget(int version) {
+    // When
+    VersionStrategy.TARGET.configureCompiler(compiler, version);
+
+    // Then
+    verify(compiler).target(version);
+    verify(compiler).getName();
+    verify(compiler).name(baseName + " (target = Java " + version + ")");
+    verifyNoMoreInteractions(compiler);
+  }
+
+  @DisplayName("SOURCE_AND_TARGET sets the target")
+  @ValueSource(ints = {10, 15, 20})
+  @ParameterizedTest(name = "for version {0}")
+  void sourceAndTargetSetsTheSourceAndTarget(int version) {
+    // When
+    VersionStrategy.SOURCE_AND_TARGET.configureCompiler(compiler, version);
+
+    // Then
+    verify(compiler).source(version);
+    verify(compiler).target(version);
+    verify(compiler).getName();
+    verify(compiler).name(baseName + " (source and target = Java " + version + ")");
+    verifyNoMoreInteractions(compiler);
+  }
+}


### PR DESCRIPTION
Implement ability to change default versioning strategy in JUnit support.

If the user wishes to iterate across sources/targets instead of releases for the JUnit annotations, there is now an attribute that can be overridden to support that.

This is a breaking change in the JUnit API, but since this is not yet a fully stable release,
I am leaving the versioning as-is for this change. This only affects custom compiler
implementations with custom JUnit parameters anyway. For 99.99% of use cases, this will not
affect anything.