### PR TITLE
Use factory pattern to initialise flag and JavaCompiler objects

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilderFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilderFactory.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.compilers;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Factory that creates a flag builder.
+ *
+ * @author Ashley Scopes
+ * @since 0.0.1 (0.0.1-M7)
+ */
+@API(since = "0.0.1", status = Status.STABLE)
+@FunctionalInterface
+public interface JctFlagBuilderFactory {
+
+  /**
+   * Create a new flag builder.
+   *
+   * @return the flag builder.
+   */
+  JctFlagBuilder createFlagBuilder();
+}

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/Jsr199CompilerFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/Jsr199CompilerFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.compilers;
+
+import javax.tools.JavaCompiler;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Factory that creates an instance of a JSR-199 compiler.
+ *
+ * @author Ashley Scopes
+ * @since 0.0.1 (0.0.1-M7)
+ */
+@API(since = "0.0.1", status = Status.STABLE)
+@FunctionalInterface
+public interface Jsr199CompilerFactory {
+
+  /**
+   * Create a new instance of a JSR-199 {@link JavaCompiler}.
+   *
+   * @return the JSR-199 Java compiler.
+   */
+  JavaCompiler createCompiler();
+}

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationImpl.java
@@ -52,9 +52,14 @@ public final class JctCompilationImpl implements JctCompilation {
   private final List<TraceDiagnostic<JavaFileObject>> diagnostics;
   private final JctFileManager fileManager;
 
+  @SuppressWarnings("ConstantConditions")
   private JctCompilationImpl(Builder builder) {
-    success = requireNonNull(builder.success, "success");
-    failOnWarnings = requireNonNull(builder.failOnWarnings, "failOnWarnings");
+    success = requireNonNull(
+        builder.success, "success"
+    );
+    failOnWarnings = requireNonNull(
+        builder.failOnWarnings, "failOnWarnings"
+    );
     outputLines = unmodifiableList(
         requireNonNullValues(builder.outputLines, "outputLines")
     );
@@ -64,7 +69,9 @@ public final class JctCompilationImpl implements JctCompilation {
     diagnostics = unmodifiableList(
         requireNonNullValues(builder.diagnostics, "diagnostics")
     );
-    fileManager = requireNonNull(builder.fileManager, "fileManager");
+    fileManager = requireNonNull(
+        builder.fileManager, "fileManager"
+    );
   }
 
   @Override

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/javac/JavacJctCompilerImpl.java
@@ -15,10 +15,13 @@
  */
 package io.github.ascopes.jct.compilers.javac;
 
+import static java.util.Objects.requireNonNull;
+
 import io.github.ascopes.jct.compilers.AbstractJctCompiler;
+import io.github.ascopes.jct.compilers.JctFlagBuilderFactory;
+import io.github.ascopes.jct.compilers.Jsr199CompilerFactory;
 import javax.annotation.concurrent.NotThreadSafe;
 import javax.lang.model.SourceVersion;
-import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -39,40 +42,24 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler<JavacJctComp
    * Initialize a new Java compiler.
    */
   public JavacJctCompilerImpl() {
-    this(ToolProvider.getSystemJavaCompiler());
-  }
-
-  /**
-   * Initialize a new Java compiler.
-   *
-   * @param jsr199Compiler the JSR-199 compiler backend to use.
-   */
-  public JavacJctCompilerImpl(JavaCompiler jsr199Compiler) {
-    this(NAME, jsr199Compiler);
-  }
-
-  /**
-   * Initialize a new Java compiler.
-   *
-   * @param name the name to give the compiler.
-   */
-  public JavacJctCompilerImpl(String name) {
-    this(name, ToolProvider.getSystemJavaCompiler());
-  }
-
-  /**
-   * Initialize a new Java compiler.
-   *
-   * @param name           the name to give the compiler.
-   * @param jsr199Compiler the JSR-199 compiler backend to use.
-   */
-  public JavacJctCompilerImpl(String name, JavaCompiler jsr199Compiler) {
-    super(name, jsr199Compiler, new JavacJctFlagBuilderImpl());
+    super(NAME);
   }
 
   @Override
   public String getDefaultRelease() {
     return Integer.toString(getLatestSupportedVersionInt(false));
+  }
+
+  @Override
+  public JctFlagBuilderFactory getJctFlagBuilderFactory() {
+    return JavacJctFlagBuilderImpl::new;
+  }
+
+  @Override
+  public Jsr199CompilerFactory getJsr199CompilerFactory() {
+    // RequireNonNull to ensure the return result is non-null, since the ToolProvider
+    // method is not annotated.
+    return () -> requireNonNull(ToolProvider.getSystemJavaCompiler());
   }
 
   /**


### PR DESCRIPTION
Replace #getFlagBuilder and #getJsr199Compiler with factory pattern in AbstractJctCompiler class and implementations.