### PR TITLE
Replace mockito-inline with mockito-core

### DIFF
--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -99,8 +99,9 @@
     </dependency>
 
     <dependency>
+      <!-- v5.0.0 uses the inline mock maker by default -->
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
v5.0.0 of Mockito uses the inline mock maker by default so there is no need to use mockito-inline now.

Signed-off-by: Ashley <73482956+ascopes@users.noreply.github.com>