### PR TITLE
Fix bug around registering a module in an empty output location.

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
@@ -146,7 +146,21 @@ public final class OutputContainerGroupImpl
     // For output locations, we only need the first root. We then just put a subdirectory
     // in there, as it reduces the complexity of this tenfold and means we don't have to
     // worry about creating more in-memory locations on the fly.
+    //
+    // The reason we have to do this relates to the fact that we will be provided an output
+    // directory to write to regardless of whether we want to write out modules or normal
+    // packages.
     var release = getRelease();
+    var packages = getPackages();
+
+    if (packages.isEmpty()) {
+      // This *shouldn't* be reachable in most cases.
+      throw new IllegalStateException(
+          "Cannot add module " + moduleLocation + " to outputs. No output path has been "
+              + "provided for this location! Please register a package path to output generated "
+              + "modules to first before running the compiler."
+      );
+    }
 
     // Use an anonymous class here to avoid the constraints that the PackageContainerGroupImpl
     // imposes on us.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -39,18 +39,26 @@ import org.apiguardian.api.API.Status;
 public interface JctFileManager extends JavaFileManager {
 
   /**
-   * Add a path to a given location.
+   * Add a package-oriented path to a given location.
+   *
+   * <p>To add a module, first obtain the module location using
+   * {@link #getLocationForModule(Location, String)}, and pass that result to this call.
    *
    * @param location the location to use.
    * @param path     the path to add.
+   * @see #getLocationForModule(Location, String)
    */
   void addPath(Location location, PathRoot path);
 
   /**
-   * Add a collection of paths to a given location.
+   * Add a collection of package-oriented paths to a given location.
+   *
+   * <p>To add a module, first obtain the module location using
+   * {@link #getLocationForModule(Location, String)}, and pass that result to this call.
    *
    * @param location the location to use.
    * @param paths    the paths to add.
+   * @see #getLocationForModule(Location, String)
    */
   void addPaths(Location location, Collection<? extends PathRoot> paths);
 
@@ -70,7 +78,15 @@ public interface JctFileManager extends JavaFileManager {
    *
    * <p>If the location already exists, then do not do anything.
    *
+   * <p>If the location is an output location, then this operation does not make any sense, since
+   * an empty location cannot have files output to it. In this case, you will likely get an
+   * exception.
+   *
+   * <p>Likewise, this operation does not make sense for module locations within a module-oriented
+   * location group, so this operation will fail with an error for those inputs as well.
+   *
    * @param location the location to apply an empty container for.
+   * @throws IllegalArgumentException if the location is an output location or a module location.
    */
   void createEmptyLocation(Location location);
 


### PR DESCRIPTION
A bug was discovered that results in a NoSuchElementException being raised if a user attempts to register a module in an output location that was created without an initial package on a file system to place files in.

To fix this bug, a few core functionalities have changed slightly:

- JctFileManager can now throw IllegalArgumentException from createEmptyLocation(). This will be thrown if the location is an output location or a module location.
- OutputContainerGroupImpl will now raise an IllegalStateException if it detects that the container group has been misconfigured as outlined above. This error will explain how to mitigate the issue.
- ContainerGroupRepositoryImpl will now register the path root that resides behind one or more modules being registered to it. This is also covered by the case that will check if no modules were discovered in anything being registered, since this will treat the path as an empty single package root anyway.
- ContainerGroupRepositoryImpl will now refuse to create empty locations for output locations, as this would not make sense under the above constraints.