### PR TITLE
Add helpful error message if module errors encountered with junit support

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
@@ -30,6 +30,7 @@ import org.apiguardian.api.API.Status;
  * @since 0.0.1
  */
 @API(since = "0.0.1", status = Status.INTERNAL)
+@SuppressWarnings("CommentedOutCode")
 public final class PackageContainerGroupUrlClassLoader extends URLClassLoader {
 
   /**
@@ -52,4 +53,41 @@ public final class PackageContainerGroupUrlClassLoader extends URLClassLoader {
         .map(PathRoot::getUrl)
         .toArray(URL[]::new);
   }
+
+  // TODO(ascopes): find a way to retain module information for modules that exist within this
+  //   path. Currently we are discarding that information due to the nature of how URLClassLoader
+  //   works internally.
+  //
+  // This would need something a bit more complicated to potentially mimic how the internal boot
+  // classloaders currently work in the JVM.
+  //
+  // Module resolution for classloaders is a bit different to regular loading of classes.
+  // As an example, this is how a classloader should be loading modules.
+  //
+  // var bootLayer = ModuleLayer.boot();
+  //
+  // var compiledCodeModuleConfig = Configuration.resolveAndBind(
+  //     ModuleFinder.of(compilation.getFileManager()
+  //         .getOutputContainerGroup(StandardLocation.CLASS_OUTPUT)
+  //         .getPackages()
+  //         .stream()
+  //         .map(Container::getPathRoot)
+  //         .map(PathRoot::getPath)
+  //         .toArray(Path[]::new)),
+  //     List.of(bootLayer.configuration()),
+  //     ModuleFinder.of(),
+  //     List.of("org.example")
+  // );
+  //
+  // var compiledCodeController = ModuleLayer.defineModulesWithOneLoader(
+  //     compiledCodeModuleConfig,
+  //     List.of(bootLayer),
+  //     getClass().getClassLoader()
+  // );
+  //
+  // @SuppressWarnings("unchecked")
+  // var someConfigurerCls = (Class<? extends JctCompilerConfigurer<?>>) compiledCodeController
+  //     .layer()
+  //     .findLoader("org.example")
+  //     .loadClass("org.example.SomeConfigurer");
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -123,7 +123,7 @@ public final class PathWrappingContainerImpl implements Container {
 
   @Override
   public ModuleFinder getModuleFinder() {
-    return null;
+    return ModuleFinder.of(getPathRoot().getPath());
   }
 
   @Override

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -81,7 +81,16 @@ public @interface JavacCompilerTest {
    * Get an array of compiler configurers to apply in-order before starting the test.
    *
    * <p>Each configurer must have a public no-args constructor, and their package must be
-   * open to this module if JPMS modules are in-use.
+   * open to this module if JPMS modules are in-use, for example:
+   * <p>
+   * <pre><code>
+   * module mytests {
+   *   requires io.github.ascopes.jct;
+   *   requires org.junit.jupiter.api;
+   *
+   *   opens org.example.mytests to io.github.ascopes.jct;
+   * }
+   * </code></pre>
    *
    * @return an array of classes to run to configure the compiler. These run in the given order.
    */


### PR DESCRIPTION
If an error occurs using compiler configurers via the junit 
annotations because the module does not open itself to the 
JCT module for reflection, then show an error message showing
the snippet of code to add to module-info.java to fix this,
rather than propagating an internal reflection exception.