### PR TITLE
Add tests to dogfood compiling JCT within JCT

### DIFF
--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2022 - 2023, the original author or authors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.ascopes.jct</groupId>
+    <artifactId>acceptance-tests</artifactId>
+    <version>0.0.2-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>acceptance-tests-dogfood</artifactId>
+  <name>JCT dogfooding acceptance tests</name>
+  <description>Acceptance test that tests JCT can compile itself.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>java-compiler-testing</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.gmavenplus</groupId>
+        <artifactId>gmavenplus-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctCompilationConfigurer.java
+++ b/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctCompilationConfigurer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.acceptancetests.dogfood;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.compilers.JctCompilerConfigurer;
+import java.util.Locale;
+
+/**
+ * Configure the compiler to mimic the Maven settings for compiling JCT
+ * that we use normally.
+ *
+ * @author Ashley Scopes
+ */
+public class JctCompilationConfigurer implements JctCompilerConfigurer<RuntimeException> {
+
+  @Override
+  public void configure(JctCompiler<?, ?> compiler) {
+    compiler
+        .failOnWarnings(false)
+        .inheritClassPath(true)
+        .inheritModulePath(true)
+        .showWarnings(false)  // ignore spam about the testing module being hidden
+        .locale(Locale.ENGLISH);
+  }
+}

--- a/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctDogfoodTest.java
+++ b/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctDogfoodTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.acceptancetests.dogfood;
+
+import static io.github.ascopes.jct.assertions.JctAssertions.assertThat;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.junit.JavacCompilerTest;
+import io.github.ascopes.jct.workspaces.Workspaces;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Tests that try to make JCT compile itself to see if it can correctly "test itself".
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JCT dogfood acceptance tests")
+class JctDogfoodTest {
+
+  static final Path PROJECT_ROOT = Path.of(System.getProperty("user.dir"))
+      .getParent()
+      .getParent()
+      .resolve("java-compiler-testing")
+      .normalize()
+      .toAbsolutePath();
+
+  static final Path SRC_MAIN_JAVA = PROJECT_ROOT
+      .resolve("src")
+      .resolve("main")
+      .resolve("java");
+
+  static final Path TARGET_CLASSES = PROJECT_ROOT
+      .resolve("target")
+      .resolve("classes");
+
+  @DisplayName("JCT can compile itself as a legacy module source")
+  @JavacCompilerTest(minVersion = 11, configurers = JctCompilationConfigurer.class)
+  void jctCanCompileItselfAsLegacyModule(JctCompiler<?, ?> compiler) throws IOException {
+    // Given
+    try (var workspace = Workspaces.newWorkspace()) {
+      workspace
+          .createSourcePathPackage()
+          .copyContentsFrom(SRC_MAIN_JAVA);
+
+      // When
+      var compilation = compiler.compile(workspace);
+
+      // Then
+      try (var walker = Files.walk(TARGET_CLASSES)) {
+        var expectedFiles = walker
+            .filter(Files::isRegularFile)
+            .filter(file -> file.getFileName().endsWith(".class"))
+            .map(TARGET_CLASSES::relativize)
+            .map(Path::toString)
+            .collect(Collectors.toSet());
+
+        assertThat(compilation)
+            .isSuccessful();
+
+        assertThat(compilation)
+            .classOutput()
+            .packages()
+            .allFilesExist(expectedFiles);
+      }
+    }
+  }
+
+  @DisplayName("JCT can compile itself as a multiple-module source")
+  @JavacCompilerTest(minVersion = 11, configurers = JctCompilationConfigurer.class)
+  void jctCanCompileItselfAsMultiModule(JctCompiler<?, ?> compiler) throws IOException {
+    // Given
+    try (var workspace = Workspaces.newWorkspace()) {
+      workspace
+          .createSourcePathModule("io.github.ascopes.jct")
+          .copyContentsFrom(SRC_MAIN_JAVA);
+
+      // When
+      var compilation = compiler.compile(workspace);
+
+      // Then
+      try (var walker = Files.walk(TARGET_CLASSES)) {
+        var expectedFiles = walker
+            .filter(Files::isRegularFile)
+            .filter(file -> file.getFileName().endsWith(".class"))
+            .map(TARGET_CLASSES::relativize)
+            .map(Path::toString)
+            .map("io.github.ascopes.jct/"::concat)
+            .collect(Collectors.toSet());
+
+        assertThat(compilation)
+            .isSuccessful();
+
+        assertThat(compilation)
+            .diagnostics()
+            .warnings()
+            .filteredOn(diag -> !diag.getCode().equals("compiler.warn.module.not.found"))
+            .withFailMessage("Expected no warnings (other than module.not.found)")
+            .isEmpty();
+
+        assertThat(compilation)
+            .classOutput()
+            .packages()
+            .allFilesExist(expectedFiles);
+      }
+    }
+  }
+}

--- a/acceptance-tests/acceptance-tests-dogfood/src/test/java/module-info.java
+++ b/acceptance-tests/acceptance-tests-dogfood/src/test/java/module-info.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+open module io.github.ascopes.jct.acceptancetests.dogfood {
+  requires io.github.ascopes.jct;
+  requires java.compiler;
+  requires transitive org.junit.jupiter.api;
+  requires transitive org.junit.jupiter.engine;
+  requires transitive org.junit.jupiter.params;
+  requires transitive org.junit.platform.commons;  // required to make IntelliJ happy.
+  requires transitive org.junit.platform.engine;   // required to make IntelliJ happy.
+}

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -37,6 +37,7 @@
     <module>acceptance-tests-avaje-jsonb</module>
     <module>acceptance-tests-checkerframework</module>
     <module>acceptance-tests-dagger</module>
+    <module>acceptance-tests-dogfood</module>
     <module>acceptance-tests-error-prone</module>
     <module>acceptance-tests-google-auto-factory</module>
     <module>acceptance-tests-google-auto-service</module>

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -50,8 +50,6 @@
     <dependency>
       <groupId>org.apiguardian</groupId>
       <artifactId>apiguardian-api</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
     </dependency>
 
     <dependency>
@@ -62,7 +60,6 @@
     <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
-      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Adds an acceptance test to "dogfood" compile JCT within itself.

This tests that the management of sources within JCT is close enough
to the regular javac file management implementation to enable compiling
a project with over 100 interlinked classes and transitive JPMS
dependencies into a RAM disk location.