### PR TITLE
Add location helpers in JctFileManager

### DIFF
--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -25,8 +25,10 @@ import java.util.Set;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardLocation;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Extension around a {@link JavaFileManager} that allows adding of {@link PathRoot} objects to the
@@ -163,4 +165,155 @@ public interface JctFileManager extends JavaFileManager {
       Set<Kind> kinds,
       boolean recurse
   ) throws IOException;
+
+  ///
+  /// Default helper overrides
+  ///
+
+  /**
+   * Get the location holding the {@link StandardLocation#CLASS_OUTPUT class outputs}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default OutputContainerGroup getClassOutputGroup() {
+    return getOutputContainerGroup(StandardLocation.CLASS_OUTPUT);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#SOURCE_OUTPUT source outputs}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default OutputContainerGroup getSourceOutputGroup() {
+    return getOutputContainerGroup(StandardLocation.SOURCE_OUTPUT);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#CLASS_PATH class path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default PackageContainerGroup getClassPathGroup() {
+    return getPackageContainerGroup(StandardLocation.CLASS_PATH);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#SOURCE_PATH source path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default PackageContainerGroup getSourcePathGroup() {
+    return getPackageContainerGroup(StandardLocation.SOURCE_PATH);
+  }
+
+  /**
+   * Get the location holding the
+   * {@link StandardLocation#ANNOTATION_PROCESSOR_PATH annotation processor path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default PackageContainerGroup getAnnotationProcessorPathGroup() {
+    return getPackageContainerGroup(StandardLocation.ANNOTATION_PROCESSOR_PATH);
+  }
+
+  /**
+   * Get the location holding the
+   * {@link StandardLocation#ANNOTATION_PROCESSOR_MODULE_PATH annotation processor module path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default ModuleContainerGroup getAnnotationProcessorModulePathGroup() {
+    return getModuleContainerGroup(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#PLATFORM_CLASS_PATH platform class path}
+   * (also known as the boot class path).
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default PackageContainerGroup getPlatformClassPathGroup() {
+    return getPackageContainerGroup(StandardLocation.PLATFORM_CLASS_PATH);
+  }
+
+  /**
+   * Get the location holding the
+   * {@link StandardLocation#NATIVE_HEADER_OUTPUT native header outputs}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default OutputContainerGroup getNativeHeaderOutputGroup() {
+    return getOutputContainerGroup(StandardLocation.NATIVE_HEADER_OUTPUT);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#MODULE_SOURCE_PATH module source path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default ModuleContainerGroup getModuleSourcePathGroup() {
+    return getModuleContainerGroup(StandardLocation.MODULE_SOURCE_PATH);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#UPGRADE_MODULE_PATH upgrade module path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default ModuleContainerGroup getUpgradeModulePathGroup() {
+    return getModuleContainerGroup(StandardLocation.UPGRADE_MODULE_PATH);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#SYSTEM_MODULES system modules}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default ModuleContainerGroup getSystemModulesGroup() {
+    return getModuleContainerGroup(StandardLocation.SYSTEM_MODULES);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#MODULE_PATH module path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default ModuleContainerGroup getModulePathGroup() {
+    return getModuleContainerGroup(StandardLocation.MODULE_PATH);
+  }
+
+  /**
+   * Get the location holding the {@link StandardLocation#PATCH_MODULE_PATH patch module path}.
+   *
+   * @return the location, or {@code null} if the location is not present in the file manager.
+   * @since 0.1.0
+   */
+  @Nullable
+  default ModuleContainerGroup getPatchModulePathGroup() {
+    return getModuleContainerGroup(StandardLocation.PATCH_MODULE_PATH);
+  }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -169,7 +169,7 @@ public @interface JavacCompilerTest {
    * @return {@code true} if we need to support modules, or {@code false} if we do not.
    * @deprecated this will be removed in a future release, since Java 8 is reaching end-of-life.
    */
-  @Deprecated(forRemoval = true, since = "0.0.2")
+  @Deprecated(forRemoval = true, since = "0.1.0")
   boolean modules() default false;
 
   /**

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagerTest.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.filemanagers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import io.github.ascopes.jct.containers.ModuleContainerGroup;
+import io.github.ascopes.jct.containers.OutputContainerGroup;
+import io.github.ascopes.jct.containers.PackageContainerGroup;
+import io.github.ascopes.jct.filemanagers.JctFileManager;
+import java.util.stream.Stream;
+import javax.tools.StandardLocation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * {@link JctFileManager tests}.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JctFileManager tests")
+@ExtendWith(MockitoExtension.class)
+class JctFileManagerTest {
+
+  @Mock
+  JctFileManager fileManager;
+
+  @DisplayName(".getClassOutputGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getClassOutputGroupMakesTheExpectedCall(OutputContainerGroup expected) {
+    // Given
+    when(fileManager.getClassOutputGroup()).thenCallRealMethod();
+    when(fileManager.getOutputContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getClassOutputGroup();
+
+    // Then
+    verify(fileManager).getOutputContainerGroup(StandardLocation.CLASS_OUTPUT);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourceOutputGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getSourceOutputGroupMakesTheExpectedCall(OutputContainerGroup expected) {
+    // Given
+    when(fileManager.getSourceOutputGroup()).thenCallRealMethod();
+    when(fileManager.getOutputContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getSourceOutputGroup();
+
+    // Then
+    verify(fileManager).getOutputContainerGroup(StandardLocation.SOURCE_OUTPUT);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getClassPathGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getClassPathGroupMakesTheExpectedCall(PackageContainerGroup expected) {
+    // Given
+    when(fileManager.getClassPathGroup()).thenCallRealMethod();
+    when(fileManager.getPackageContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getClassPathGroup();
+
+    // Then
+    verify(fileManager).getPackageContainerGroup(StandardLocation.CLASS_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourcePathGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getSourcePathGroupMakesTheExpectedCall(PackageContainerGroup expected) {
+    // Given
+    when(fileManager.getSourcePathGroup()).thenCallRealMethod();
+    when(fileManager.getPackageContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getSourcePathGroup();
+
+    // Then
+    verify(fileManager).getPackageContainerGroup(StandardLocation.SOURCE_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getAnnotationProcessorPathGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getAnnotationProcessorPathGroupMakesTheExpectedCall(PackageContainerGroup expected) {
+    // Given
+    when(fileManager.getAnnotationProcessorPathGroup()).thenCallRealMethod();
+    when(fileManager.getPackageContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getAnnotationProcessorPathGroup();
+
+    // Then
+    verify(fileManager).getPackageContainerGroup(StandardLocation.ANNOTATION_PROCESSOR_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getAnnotationProcessorModulePathGroup() makes the expected call")
+  @MethodSource("moduleContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getAnnotationProcessorModulePathGroupMakesTheExpectedCall(ModuleContainerGroup expected) {
+    // Given
+    when(fileManager.getAnnotationProcessorModulePathGroup()).thenCallRealMethod();
+    when(fileManager.getModuleContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getAnnotationProcessorModulePathGroup();
+
+    // Then
+    verify(fileManager).getModuleContainerGroup(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getPlatformClassPathGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getPlatformClassPathGroupMakesTheExpectedCall(PackageContainerGroup expected) {
+    // Given
+    when(fileManager.getPlatformClassPathGroup()).thenCallRealMethod();
+    when(fileManager.getPackageContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getPlatformClassPathGroup();
+
+    // Then
+    verify(fileManager).getPackageContainerGroup(StandardLocation.PLATFORM_CLASS_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getNativeHeaderOutputGroup() makes the expected call")
+  @MethodSource("outputContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getNativeHeaderOutputGroupMakesTheExpectedCall(OutputContainerGroup expected) {
+    // Given
+    when(fileManager.getNativeHeaderOutputGroup()).thenCallRealMethod();
+    when(fileManager.getOutputContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getNativeHeaderOutputGroup();
+
+    // Then
+    verify(fileManager).getOutputContainerGroup(StandardLocation.NATIVE_HEADER_OUTPUT);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getModuleSourcePathGroup() makes the expected call")
+  @MethodSource("moduleContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getModuleSourcePathGroupMakesTheExpectedCall(ModuleContainerGroup expected) {
+    // Given
+    when(fileManager.getModuleSourcePathGroup()).thenCallRealMethod();
+    when(fileManager.getModuleContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getModuleSourcePathGroup();
+
+    // Then
+    verify(fileManager).getModuleContainerGroup(StandardLocation.MODULE_SOURCE_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getUpgradeModulePathGroup() makes the expected call")
+  @MethodSource("moduleContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getUpgradeModulePathGroupMakesTheExpectedCall(ModuleContainerGroup expected) {
+    // Given
+    when(fileManager.getUpgradeModulePathGroup()).thenCallRealMethod();
+    when(fileManager.getModuleContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getUpgradeModulePathGroup();
+
+    // Then
+    verify(fileManager).getModuleContainerGroup(StandardLocation.UPGRADE_MODULE_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSystemModulesGroup() makes the expected call")
+  @MethodSource("moduleContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getSystemModulesGroupMakesTheExpectedCall(ModuleContainerGroup expected) {
+    // Given
+    when(fileManager.getSystemModulesGroup()).thenCallRealMethod();
+    when(fileManager.getModuleContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getSystemModulesGroup();
+
+    // Then
+    verify(fileManager).getModuleContainerGroup(StandardLocation.SYSTEM_MODULES);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getModulePathGroup() makes the expected call")
+  @MethodSource("moduleContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getModulePathGroupMakesTheExpectedCall(ModuleContainerGroup expected) {
+    // Given
+    when(fileManager.getModulePathGroup()).thenCallRealMethod();
+    when(fileManager.getModuleContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getModulePathGroup();
+
+    // Then
+    verify(fileManager).getModuleContainerGroup(StandardLocation.MODULE_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getPatchModulePathGroup() makes the expected call")
+  @MethodSource("moduleContainerGroupResults")
+  @ParameterizedTest(name = "when internal getter returns {0}")
+  void getPatchModulePathGroupMakesTheExpectedCall(ModuleContainerGroup expected) {
+    // Given
+    when(fileManager.getPatchModulePathGroup()).thenCallRealMethod();
+    when(fileManager.getModuleContainerGroup(any())).thenReturn(expected);
+
+    // When
+    var actual = fileManager.getPatchModulePathGroup();
+
+    // Then
+    verify(fileManager).getModuleContainerGroup(StandardLocation.PATCH_MODULE_PATH);
+    verifyNoMoreInteractions(fileManager);
+    assertThat(actual).isSameAs(expected);
+  }
+
+
+  static Stream<ModuleContainerGroup> moduleContainerGroupResults() {
+    return Stream.of(
+        mock(ModuleContainerGroup.class, "a module container group"),
+        null
+    );
+  }
+
+  static Stream<OutputContainerGroup> outputContainerGroupResults() {
+    return Stream.of(
+        mock(OutputContainerGroup.class, "an output container group"),
+        null
+    );
+  }
+
+  static Stream<PackageContainerGroup> packageContainerGroupResults() {
+    return Stream.of(
+        mock(PackageContainerGroup.class, "a package container group"),
+        null
+    );
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>0.0.2-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>


### PR DESCRIPTION
Add methods such as .getClassOutputGroup() for all StandardLocation members.