### PR TITLE
Add additional API method helpers to access workspace locations

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -19,6 +19,7 @@ import io.github.ascopes.jct.containers.ModuleContainerGroup;
 import io.github.ascopes.jct.containers.OutputContainerGroup;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.workspaces.PathRoot;
+import io.github.ascopes.jct.workspaces.Workspace;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
@@ -33,6 +34,12 @@ import org.jspecify.annotations.Nullable;
 /**
  * Extension around a {@link JavaFileManager} that allows adding of {@link PathRoot} objects to the
  * manager.
+ *
+ * <p>This component is responsible for bridging the gap between a {@link Workspace} and
+ * a {@link javax.tools.JavaCompiler} when performing a compilation, and thus includes a number of
+ * required operations that the compiler will query the file system with. In addition, this
+ * interface also defines a number of additional functionalities that are useful for querying and
+ * verifying the outcome of compilations within tests.
  *
  * @author Ashley Scopes
  * @since 0.0.1

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
@@ -15,14 +15,21 @@
  */
 package io.github.ascopes.jct.tests.unit.workspaces;
 
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someModuleName;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.someText;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import io.github.ascopes.jct.workspaces.PathRoot;
 import io.github.ascopes.jct.workspaces.Workspace;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,12 +45,13 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 @DisplayName("Workspace tests")
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("unchecked")
 class WorkspaceTest {
 
   @Mock
   Workspace workspace;
 
-  @DisplayName("addClassOutputPackage(Path) calls addPackage(CLASS_OUTPUT, Path)")
+  @DisplayName(".addClassOutputPackage(Path) calls addPackage(CLASS_OUTPUT, Path)")
   @Test
   void addClassOutputPackageCallsAddPackage() {
     // Given
@@ -55,9 +63,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.CLASS_OUTPUT, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addClassOutputModule(String, Path) calls addModule(CLASS_OUTPUT, String, Path)")
+  @DisplayName(".addClassOutputModule(String, Path) calls addModule(CLASS_OUTPUT, String, Path)")
   @Test
   void addClassOutputModuleCallsAddModule() {
     // Given
@@ -70,9 +79,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.CLASS_OUTPUT, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addSourceOutputPackage(Path) calls addPackage(SOURCE_OUTPUT, Path)")
+  @DisplayName(".addSourceOutputPackage(Path) calls addPackage(SOURCE_OUTPUT, Path)")
   @Test
   void addSourceOutputPackageCallsAddPackage() {
     // Given
@@ -84,9 +94,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.SOURCE_OUTPUT, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addSourceOutputModule(String, Path) calls addModule(SOURCE_OUTPUT, String, Path)")
+  @DisplayName(".addSourceOutputModule(String, Path) calls addModule(SOURCE_OUTPUT, String, Path)")
   @Test
   void addSourceOutputModuleCallsAddModule() {
     // Given
@@ -99,9 +110,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.SOURCE_OUTPUT, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addClassPathPackage(Path) calls addPackage(CLASS_PATH, Path)")
+  @DisplayName(".addClassPathPackage(Path) calls addPackage(CLASS_PATH, Path)")
   @Test
   void addClassPathPackageCallsAddPackage() {
     // Given
@@ -113,9 +125,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.CLASS_PATH, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addModulePathModule(String, Path) calls addModule(MODULE_PATH, String, Path)")
+  @DisplayName(".addModulePathModule(String, Path) calls addModule(MODULE_PATH, String, Path)")
   @Test
   void addModulePathModuleCallsAddModule() {
     // Given
@@ -128,9 +141,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.MODULE_PATH, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addSourcePathPackage(Path) calls addPackage(SOURCE_PATH, Path)")
+  @DisplayName(".addSourcePathPackage(Path) calls addPackage(SOURCE_PATH, Path)")
   @Test
   void addSourcePathPackageCallsAddPackage() {
     // Given
@@ -142,10 +156,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.SOURCE_PATH, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addSourcePathModule(String, Path) calls addModule(MODULE_SOURCE_PATH, String, Path)"
+      ".addSourcePathModule(String, Path) calls addModule(MODULE_SOURCE_PATH, String, Path)"
   )
   @Test
   void addSourcePathModuleCallsAddModule() {
@@ -159,10 +174,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.MODULE_SOURCE_PATH, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addAnnotationProcessorPathPackage(Path) calls addPackage(ANNOTATION_PROCESSOR_PATH, Path)"
+      ".addAnnotationProcessorPathPackage(Path) calls addPackage(ANNOTATION_PROCESSOR_PATH, Path)"
   )
   @Test
   void addAnnotationProcessorPathPackageCallsAddPackage() {
@@ -175,11 +191,12 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.ANNOTATION_PROCESSOR_PATH, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addAnnotationProcessorPathModule(String, Path) calls "
-          + "addModule(ANNOTATION_PROCESSOR_MODULE_PATH, String, Path)"
+      ".addAnnotationProcessorPathModule(String, Path) calls "
+          + ".addModule(ANNOTATION_PROCESSOR_MODULE_PATH, String, Path)"
   )
   @Test
   void addAnnotationProcessorPathModuleCallsAddModule() {
@@ -193,9 +210,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addPlatformClassPathPackage(Path) calls addPackage(PLATFORM_CLASS_PATH, Path)")
+  @DisplayName(".addPlatformClassPathPackage(Path) calls addPackage(PLATFORM_CLASS_PATH, Path)")
   @Test
   void addPlatformClassPathPackageCallsAddPackage() {
     // Given
@@ -207,9 +225,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.PLATFORM_CLASS_PATH, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("addNativeHeaderOutputPackage(Path) calls addPackage(NATIVE_HEADER_OUTPUT, Path)")
+  @DisplayName(".addNativeHeaderOutputPackage(Path) calls addPackage(NATIVE_HEADER_OUTPUT, Path)")
   @Test
   void addNativeHeaderOutputPackageCallsAddPackage() {
     // Given
@@ -221,10 +240,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addPackage(StandardLocation.NATIVE_HEADER_OUTPUT, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addNativeHeaderOutputModule(String, Path) calls addModule(NATIVE_HEADER_OUTPUT, String, "
+      ".addNativeHeaderOutputModule(String, Path) calls addModule(NATIVE_HEADER_OUTPUT, String, "
           + "Path)"
   )
   @Test
@@ -239,10 +259,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.NATIVE_HEADER_OUTPUT, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addUpgradeModulePathModule(String, Path) calls addModule(UPGRADE_MODULE_PATH, String, Path)"
+      ".addUpgradeModulePathModule(String, Path) calls addModule(UPGRADE_MODULE_PATH, String, Path)"
   )
   @Test
   void addUpgradeModulePathModuleCallsAddModule() {
@@ -256,10 +277,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.UPGRADE_MODULE_PATH, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addSystemModulePathModule(String, Path) calls addModule(SYSTEM_MODULES, String, Path)"
+      ".addSystemModulePathModule(String, Path) calls addModule(SYSTEM_MODULES, String, Path)"
   )
   @Test
   void addSystemModulePathModuleCallsAddModule() {
@@ -273,10 +295,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.SYSTEM_MODULES, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "addPatchModulePathModule(String, Path) calls addModule(PATCH_MODULE_PATH, String, Path)"
+      ".addPatchModulePathModule(String, Path) calls addModule(PATCH_MODULE_PATH, String, Path)"
   )
   @Test
   void addPatchModulePathModuleCallsAddModule() {
@@ -290,9 +313,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).addModule(StandardLocation.PATCH_MODULE_PATH, module, path);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createClassOutputPackage() calls createPackage(CLASS_OUTPUT)")
+  @DisplayName(".createClassOutputPackage() calls createPackage(CLASS_OUTPUT)")
   @Test
   void createClassOutputPackageCallsCreatePackage() {
     // Given
@@ -303,9 +327,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.CLASS_OUTPUT);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createClassOutputModule(String) calls createModule(CLASS_OUTPUT, String)")
+  @DisplayName(".createClassOutputModule(String) calls createModule(CLASS_OUTPUT, String)")
   @Test
   void createClassOutputModuleCallsCreateModule() {
     // Given
@@ -317,9 +342,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.CLASS_OUTPUT, module);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createSourceOutputPackage() calls createPackage(SOURCE_OUTPUT,)")
+  @DisplayName(".createSourceOutputPackage() calls createPackage(SOURCE_OUTPUT,)")
   @Test
   void createSourceOutputPackageCallsCreatePackage() {
     // Given
@@ -330,9 +356,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.SOURCE_OUTPUT);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createSourceOutputModule(String, Path) calls createModule(SOURCE_OUTPUT, String)")
+  @DisplayName(".createSourceOutputModule(String, Path) calls createModule(SOURCE_OUTPUT, String)")
   @Test
   void createSourceOutputModuleCallsCreateModule() {
     // Given
@@ -344,9 +371,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.SOURCE_OUTPUT, module);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createClassPathPackage(Path) calls createPackage(CLASS_PATH)")
+  @DisplayName(".createClassPathPackage(Path) calls createPackage(CLASS_PATH)")
   @Test
   void createClassPathPackageCallsCreatePackage() {
     // Given
@@ -357,9 +385,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.CLASS_PATH);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createModulePathModule(String, Path) calls createModule(MODULE_PATH, String)")
+  @DisplayName(".createModulePathModule(String, Path) calls createModule(MODULE_PATH, String)")
   @Test
   void createModulePathModuleCallsCreateModule() {
     // Given
@@ -371,9 +400,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.MODULE_PATH, module);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createSourcePathPackage() calls createPackage(SOURCE_PATH)")
+  @DisplayName(".createSourcePathPackage() calls createPackage(SOURCE_PATH)")
   @Test
   void createSourcePathPackageCallsCreatePackage() {
     // Given
@@ -384,10 +414,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.SOURCE_PATH);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createSourcePathModule(String) calls createModule(MODULE_SOURCE_PATH, String)"
+      ".createSourcePathModule(String) calls createModule(MODULE_SOURCE_PATH, String)"
   )
   @Test
   void createSourcePathModuleCallsCreateModule() {
@@ -400,10 +431,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.MODULE_SOURCE_PATH, module);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createAnnotationProcessorPathPackage() calls createPackage(ANNOTATION_PROCESSOR_PATH)"
+      ".createAnnotationProcessorPathPackage() calls createPackage(ANNOTATION_PROCESSOR_PATH)"
   )
   @Test
   void createAnnotationProcessorPathPackageCallsCreatePackage() {
@@ -415,11 +447,12 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.ANNOTATION_PROCESSOR_PATH);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createAnnotationProcessorPathModule(String) calls "
-          + "createModule(ANNOTATION_PROCESSOR_MODULE_PATH, String)"
+      ".createAnnotationProcessorPathModule(String) calls "
+          + ".createModule(ANNOTATION_PROCESSOR_MODULE_PATH, String)"
   )
   @Test
   void createAnnotationProcessorPathModuleCallsCreateModule() {
@@ -432,9 +465,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH, module);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createPlatformClassPathPackage() calls createPackage(PLATFORM_CLASS_PATH)")
+  @DisplayName(".createPlatformClassPathPackage() calls createPackage(PLATFORM_CLASS_PATH)")
   @Test
   void createPlatformClassPathPackageCallsCreatePackage() {
     // Given
@@ -445,9 +479,10 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.PLATFORM_CLASS_PATH);
+    verifyNoMoreInteractions(workspace);
   }
 
-  @DisplayName("createNativeHeaderOutputPackage(Path) calls createPackage(NATIVE_HEADER_OUTPUT)")
+  @DisplayName(".createNativeHeaderOutputPackage(Path) calls createPackage(NATIVE_HEADER_OUTPUT)")
   @Test
   void createNativeHeaderOutputPackageCallsCreatePackage() {
     // Given
@@ -458,10 +493,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createPackage(StandardLocation.NATIVE_HEADER_OUTPUT);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createNativeHeaderOutputModule(String) calls createModule(NATIVE_HEADER_OUTPUT, String)"
+      ".createNativeHeaderOutputModule(String) calls createModule(NATIVE_HEADER_OUTPUT, String)"
   )
   @Test
   void createNativeHeaderOutputModuleCallsCreateModule() {
@@ -474,10 +510,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.NATIVE_HEADER_OUTPUT, module);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createUpgradeModulePathModule(String) calls createModule(UPGRADE_MODULE_PATH, String)"
+      ".createUpgradeModulePathModule(String) calls createModule(UPGRADE_MODULE_PATH, String)"
   )
   @Test
   void createUpgradeModulePathModuleCallsCreateModule() {
@@ -490,10 +527,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.UPGRADE_MODULE_PATH, module);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createSystemModulePathModule(String) calls createModule(SYSTEM_MODULES, String)"
+      ".createSystemModulePathModule(String) calls createModule(SYSTEM_MODULES, String)"
   )
   @Test
   void createSystemModulePathModuleCallsCreateModule() {
@@ -506,10 +544,11 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.SYSTEM_MODULES, module);
+    verifyNoMoreInteractions(workspace);
   }
 
   @DisplayName(
-      "createPatchModulePathModule(String) calls createModule(PATCH_MODULE_PATH, String)"
+      ".createPatchModulePathModule(String) calls createModule(PATCH_MODULE_PATH, String)"
   )
   @Test
   void createPatchModulePathModuleCallsCreateModule() {
@@ -522,5 +561,446 @@ class WorkspaceTest {
 
     // Then
     verify(workspace).createModule(StandardLocation.PATCH_MODULE_PATH, module);
+    verifyNoMoreInteractions(workspace);
+  }
+
+  @DisplayName(".getClassOutputPackages calls getPackages(CLASS_OUTPUT)")
+  @Test
+  void getClassOutputPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getClassOutputPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getClassOutputPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.CLASS_OUTPUT);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getClassOutputModule calls getModule(CLASS_OUTPUT, ...)")
+  @Test
+  void getClassOutputModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getClassOutputModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getClassOutputModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.CLASS_OUTPUT, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getClassOutputModules calls getModules(CLASS_OUTPUT)")
+  @Test
+  void getClassOutputModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getClassOutputModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getClassOutputModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.CLASS_OUTPUT);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourceOutputPackages calls getPackages(SOURCE_OUTPUT)")
+  @Test
+  void getSourceOutputPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getSourceOutputPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getSourceOutputPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.SOURCE_OUTPUT);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourceOutputModule calls getModule(SOURCE_OUTPUT, ...)")
+  @Test
+  void getSourceOutputModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getSourceOutputModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getSourceOutputModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.SOURCE_OUTPUT, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourceOutputModules calls getModules(SOURCE_OUTPUT)")
+  @Test
+  void getSourceOutputModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getSourceOutputModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getSourceOutputModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.SOURCE_OUTPUT);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getClassPathPackages calls getPackages(CLASS_PATH)")
+  @Test
+  void getClassPathPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getClassPathPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getClassPathPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.CLASS_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourcePathPackages calls getPackages(SOURCE_PATH)")
+  @Test
+  void getSourcePathPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getSourcePathPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getSourcePathPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.SOURCE_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getAnnotationProcessorPathPackages calls getPackages(ANNOTATION_PROCESSOR_PATH)")
+  @Test
+  void getAnnotationProcessorPathPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getAnnotationProcessorPathPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getAnnotationProcessorPathPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.ANNOTATION_PROCESSOR_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(
+      ".getAnnotationProcessorPathModule calls getModule(ANNOTATION_PROCESSOR_MODULE_PATH, ...)"
+  )
+  @Test
+  void getAnnotationProcessorPathModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getAnnotationProcessorPathModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getAnnotationProcessorPathModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(
+      ".getAnnotationProcessorPathModules calls getModules(ANNOTATION_PROCESSOR_MODULE_PATH)"
+  )
+  @Test
+  void getAnnotationProcessorPathModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getAnnotationProcessorPathModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getAnnotationProcessorPathModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.ANNOTATION_PROCESSOR_MODULE_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getPlatformClassPathPackages calls getPackages(PLATFORM_CLASS_PATH)")
+  @Test
+  void getPlatformClassPathPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getPlatformClassPathPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getPlatformClassPathPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.PLATFORM_CLASS_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getNativeHeaderOutputPackages calls getPackages(NATIVE_HEADER_OUTPUT)")
+  @Test
+  void getNativeHeaderOutputPackagesCallsGetPackages() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getPackages(any())).thenReturn(expected);
+    when(workspace.getNativeHeaderOutputPackages()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getNativeHeaderOutputPackages();
+
+    // Then
+    verify(workspace).getPackages(StandardLocation.NATIVE_HEADER_OUTPUT);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getNativeHeaderOutputModule calls getModule(NATIVE_HEADER_OUTPUT, ...)")
+  @Test
+  void getNativeHeaderOutputModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getNativeHeaderOutputModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getNativeHeaderOutputModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.NATIVE_HEADER_OUTPUT, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getNativeHeaderOutputModules calls getModules(NATIVE_HEADER_OUTPUT)")
+  @Test
+  void getNativeHeaderOutputModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getNativeHeaderOutputModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getNativeHeaderOutputModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.NATIVE_HEADER_OUTPUT);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+
+  @DisplayName(".getSourcePathModule calls getModule(MODULE_SOURCE_PATH, ...)")
+  @Test
+  void getSourcePathModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getSourcePathModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getSourcePathModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.MODULE_SOURCE_PATH, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSourcePathModules calls getModules(MODULE_SOURCE_PATH)")
+  @Test
+  void getSourcePathModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getSourcePathModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getSourcePathModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.MODULE_SOURCE_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+
+  @DisplayName(".getUpgradeModulePathModule calls getModule(UPGRADE_MODULE_PATH, ...)")
+  @Test
+  void getUpgradeModulePathModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getUpgradeModulePathModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getUpgradeModulePathModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.UPGRADE_MODULE_PATH, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getUpgradeModulePathModules calls getModules(UPGRADE_MODULE_PATH)")
+  @Test
+  void getUpgradeModulePathModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getUpgradeModulePathModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getUpgradeModulePathModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.UPGRADE_MODULE_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSystemModulePathModule calls getModule(SYSTEM_MODULES, ...)")
+  @Test
+  void getSystemModulePathModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getSystemModulePathModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getSystemModulePathModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.SYSTEM_MODULES, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getSystemModulePathModules calls getModules(SYSTEM_MODULES)")
+  @Test
+  void getSystemModulePathModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getSystemModulePathModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getSystemModulePathModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.SYSTEM_MODULES);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getModulePathModule calls getModule(MODULE_PATH, ...)")
+  @Test
+  void getModulePathModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getModulePathModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getModulePathModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.MODULE_PATH, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getModulePathModules calls getModules(MODULE_PATH)")
+  @Test
+  void getModulePathModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getModulePathModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getModulePathModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.MODULE_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getPatchModulePathModule calls getModule(PATCH_MODULE_PATH, ...)")
+  @Test
+  void getPatchModulePathModuleCallsGetModule() {
+    // Given
+    List<PathRoot> expected = mock();
+    when((List<PathRoot>) workspace.getModule(any(), any())).thenReturn(expected);
+    when(workspace.getPatchModulePathModule(any())).thenCallRealMethod();
+    var moduleName = someModuleName();
+
+    // When
+    var actual = workspace.getPatchModulePathModule(moduleName);
+
+    // Then
+    verify(workspace).getModule(StandardLocation.PATCH_MODULE_PATH, moduleName);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".getPatchModulePathModules calls getModules(PATCH_MODULE_PATH)")
+  @Test
+  void getPatchModulePathModulesCallsGetModules() {
+    // Given
+    Map<String, List<? extends PathRoot>> expected = mock();
+    when(workspace.getModules(any())).thenReturn(expected);
+    when(workspace.getPatchModulePathModules()).thenCallRealMethod();
+
+    // When
+    var actual = workspace.getPatchModulePathModules();
+
+    // Then
+    verify(workspace).getModules(StandardLocation.PATCH_MODULE_PATH);
+    verifyNoMoreInteractions(workspace);
+    assertThat(actual).isSameAs(expected);
   }
 }


### PR DESCRIPTION
Closes #337 - adds new helper methods to the workspace API for accessing paths and locations within a workspace object within tests.