### PR TITLE
Rename JctCompilers.createPlatformCompiler to newPlatformCompiler

### DIFF
--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.1.1-SNAPSHOT</version>
+    <version>0.2.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
@@ -51,7 +51,7 @@ import org.apiguardian.api.API.Status;
  *        ...
  *
  *        var compiler = JctCompilers
- *            .createPlatformCompiler()
+ *            .newPlatformCompiler()
  *            .release(17)
  *            .configure(new MyAnnotationProcessorConfigurer());
  *

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
@@ -19,6 +19,8 @@ import io.github.ascopes.jct.compilers.javac.JavacJctCompilerImpl;
 import io.github.ascopes.jct.utils.UtilityClass;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Helpers to create new compiler instances.
@@ -28,6 +30,7 @@ import org.apiguardian.api.API.Status;
  */
 @API(since = "0.0.1", status = Status.STABLE)
 public final class JctCompilers extends UtilityClass {
+  private static final Logger LOGGER = LoggerFactory.getLogger(JctCompilers.class);
 
   private JctCompilers() {
     // Disallow initialisation.
@@ -39,7 +42,22 @@ public final class JctCompilers extends UtilityClass {
    *
    * @return the compiler instance.
    */
-  public static JctCompiler<?, ?> createPlatformCompiler() {
+  @API(status = Status.STABLE, since = "0.2.0")
+  public static JctCompiler<?, ?> newPlatformCompiler() {
     return new JavacJctCompilerImpl();
+  }
+
+  /**
+   * Create a new instance of the default platform compiler that is part of the JDK ({@code javac}
+   * on OpenJDK-derived implementations).
+   *
+   * @return the compiler instance.
+   * @deprecated Renamed in 0.2.0 for consistency, use {@link #newPlatformCompiler instead}.
+   */
+  @Deprecated(forRemoval = true, since = "0.2.0")
+  public static JctCompiler<?, ?> createPlatformCompiler() {
+    LOGGER.warn("JctCompilers.createPlatformCompiler() is deprecated for removal. "
+        + "Use JctCompilers.newPlatformCompiler() instead");
+    return newPlatformCompiler();
   }
 }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilersTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilersTest.java
@@ -37,12 +37,33 @@ class JctCompilersTest implements UtilityClassTestTemplate {
     return JctCompilers.class;
   }
 
-  @DisplayName("createPlatformCompiler() creates a JavacJctCompilerImpl instance")
+  // TODO: remove me.
+  @DisplayName(".createPlatformCompiler() creates a JavacJctCompilerImpl instance")
+  @Deprecated(forRemoval = true)
   @Test
   void createPlatformCompilerReturnsTheExpectedInstance() {
     try (var javacJctCompilerImplMock = Mockito.mockConstruction(JavacJctCompilerImpl.class)) {
       // When
+      @SuppressWarnings("removal")
       var compiler = JctCompilers.createPlatformCompiler();
+
+      // Then
+      assertThat(compiler)
+          .isInstanceOf(JavacJctCompilerImpl.class);
+
+      assertThat(javacJctCompilerImplMock.constructed())
+          .singleElement()
+          // Nested assertion to swap expected/actual args.
+          .satisfies(constructed -> assertThat(compiler).isSameAs(constructed));
+    }
+  }
+
+  @DisplayName(".newPlatformCompiler() creates a JavacJctCompilerImpl instance")
+  @Test
+  void newPlatformCompilerReturnsTheExpectedInstance() {
+    try (var javacJctCompilerImplMock = Mockito.mockConstruction(JavacJctCompilerImpl.class)) {
+      // When
+      var compiler = JctCompilers.newPlatformCompiler();
 
       // Then
       assertThat(compiler)

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
@@ -399,7 +399,7 @@ class AbstractCompilersProviderTest {
           );
 
       var compilation = JctCompilers
-          .createPlatformCompiler()
+          .newPlatformCompiler()
           .release(11)
           .compile(workspace);
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -27,7 +27,7 @@ unset undefined &> /dev/null || true
 # Arg 2 = log level name (e.g. WARNING)
 # Arg 3 = Message to display (e.g. "Something ain't right here")
 function __log() {
-  printf "\033[3;37m$(date "+%H:%M:%S.%3N") \033[0;37m| \033[0;1;${1}m%s:\033[0m %s\033[0m\n" \
+  printf "\033[3;37m$(date "+%H:%M:%S.%3N") \033[0;37m| \033[0;1;${1}m%7s:\033[0m %s\033[0m\n" \
       "${2}" "${3}" >&2
 }
 
@@ -92,7 +92,9 @@ function run() {
   {
     echo "#!/usr/bin/env bash"
     echo "PS4=$'Running: \e[1;33m$ \e[0;3;33m'"
-    echo "set -euxo pipefail"
+    echo "set -o errexit"
+    echo "set -o nounset"
+    echo "set -o xtrace"
     cat -
   } >> "${file}"
 

--- a/scripts/prepare-test-outputs-for-merge.sh
+++ b/scripts/prepare-test-outputs-for-merge.sh
@@ -20,7 +20,8 @@
 ### that the test applies to, and to rename the jacoco.xml files to match the Java version in use.
 ###
 
-set -euo pipefail
+set -o errexit
+set -o nounset
 
 source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
 


### PR DESCRIPTION
Fixes a naming inconsistency in JctCompilers.createPlatformCompiler by deprecating this method in favour of a new method named JctCompilers.newPlatformCompiler.

Increments the current version to 0.2.0-SNAPSHOT