### PR TITLE
Fix explicit class handling

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssert.java
@@ -59,31 +59,34 @@ public final class PackageContainerGroupAssert
    *
    * @param path  the first path to check for
    * @param paths additional paths to check for.
+   * @return this object for further call chaining.
    * @throws AssertionError       if the container group is null, or if any of the files do not
    *                              exist.
    * @throws NullPointerException if any of the paths are null.
    */
-  public void allFilesExist(String path, String... paths) {
+  public PackageContainerGroupAssert allFilesExist(String path, String... paths) {
     requireNonNull(path, "path must not be null");
     requireNonNullValues(paths, "paths");
 
-    allFilesExist(combineOneOrMore(path, paths));
+    return allFilesExist(combineOneOrMore(path, paths));
   }
 
   /**
    * Assert that all given files exist.
    *
    * @param paths paths to check for.
+   * @return this object for further call chaining.
    * @throws AssertionError       if the container group is null, or if any of the files do not
    *                              exist.
    * @throws NullPointerException if any of the paths are null.
    */
-  public void allFilesExist(Iterable<String> paths) {
+  public PackageContainerGroupAssert allFilesExist(Iterable<String> paths) {
     requireNonNullValues(paths, "paths");
 
     isNotNull();
 
     assertThat(paths).allSatisfy(this::fileExists);
+    return this;
   }
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilationFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilationFactory.java
@@ -43,7 +43,9 @@ public interface JctCompilationFactory {
    *                       should be discovered automatically.
    * @return the compilation result that contains whether the compiler succeeded or failed, amongst
    *     other information.
-   * @throws JctCompilerException if compiler raises an unhandled exception and cannot complete.
+   * @throws JctCompilerException if any prerequisites fail, such as no compilation units being
+   *    found, or if the underlying JSR-199 compiler raises an unhandled exception and cannot
+   *    complete when invoked.
    */
   JctCompilation createCompilation(
       List<String> flags,

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
@@ -16,9 +16,13 @@
 package io.github.ascopes.jct.diagnostics;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.Objects.requireNonNullElse;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -80,11 +84,29 @@ public final class TeeWriter extends Writer {
     }
   }
 
-  @Override
-  public String toString() {
+  /**
+   * Get the content of the internal buffer.
+   *
+   * @return the content.
+   * @since 0.2.1
+   */
+  @API(since = "0.2.1", status = Status.STABLE)
+  public String getContent() {
     synchronized (lock) {
       return builder.toString();
     }
+  }
+
+  /**
+   * Get the content of the internal buffer.
+   *
+   * <p>This calls {@link #getContent()} internally as of 0.2.1.
+   *
+   * @return the content.
+   */
+  @Override
+  public String toString() {
+    return getContent();
   }
 
   @Override
@@ -103,5 +125,24 @@ public final class TeeWriter extends Writer {
     if (closed) {
       throw new IllegalStateException("TeeWriter is closed");
     }
+  }
+
+  /**
+   * Create a tee writer for the given output stream.
+   *
+   * <p>Remember you may need to manually flush the tee writer for all contents to be committed to
+   * the output stream.
+   *
+   * @param outputStream the output stream.
+   * @param charset the charset.
+   * @return the Tee Writer.
+   * @since 0.2.1
+   */
+  @API(since = "0.2.1", status = Status.STABLE)
+  public static TeeWriter wrapOutputStream(OutputStream outputStream, Charset charset) {
+    requireNonNull(outputStream, "outputStream");
+    requireNonNull(charset, "charset");
+    var writer = new OutputStreamWriter(outputStream, charset);
+    return new TeeWriter(writer);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/PathFileObject.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/PathFileObject.java
@@ -151,6 +151,17 @@ public final class PathFileObject implements JavaFileObject {
   }
 
   /**
+   * Get the inferred binary name of the file object.
+   *
+   * @return the inferred binary name.
+   * @since 0.2.1
+   */
+  @API(since = "0.2.1", status = Status.STABLE)
+  public String getBinaryName() {
+    return FileUtils.pathToBinaryName(relativePath);
+  }
+
+  /**
    * Read the character content of the file into memory and decode it using the default character
    * set.
    *

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/ExtraArgumentMatchers.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/ExtraArgumentMatchers.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.helpers;
+
+import static org.mockito.ArgumentMatchers.argThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Set;
+import org.mockito.ArgumentMatcher;
+
+/**
+ * Extra Mockito argument matchers.
+ *
+ * @author Ashley Scopes
+ */
+public final class ExtraArgumentMatchers {
+
+  private ExtraArgumentMatchers() {
+    throw new UnsupportedOperationException("static-only class");
+  }
+
+  @SafeVarargs
+  public static <E, T extends Iterable<E>> T containsExactlyElements(E... expected) {
+    return containsExactlyElements(Set.of(expected));
+  }
+
+  public static <E, T extends Iterable<E>> T containsExactlyElements(Collection<E> expected) {
+    return argThat(new ArgumentMatcher<>() {
+      @Override
+      public String toString() {
+        return "containsExactlyElements(" + expected + ")";
+      }
+
+      @Override
+      public boolean matches(T actualIterable) {
+        if (actualIterable == null) {
+          return false;
+        }
+
+        var actualElements = new ArrayList<E>();
+        actualIterable.forEach(actualElements::add);
+
+        // All expected are in actual
+        for (var expectedElement : expected) {
+          if (!actualElements.contains(expectedElement)) {
+            throw new IllegalArgumentException(
+                "Expected element " + expectedElement + " was not in the actual collection"
+            );
+          }
+        }
+
+        // All actual are in expected.
+        var expectedSet = Set.copyOf(expected);
+        for (var actualElement : actualElements) {
+          if (!expectedSet.contains(actualElement)) {
+            throw new IllegalArgumentException(
+                "Actual element " + actualElement + " was not in the expected elements array"
+            );
+          }
+        }
+
+        return true;
+      }
+    });
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/CompilingSpecificClassesIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/CompilingSpecificClassesIntegrationTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.integration;
+
+import static io.github.ascopes.jct.assertions.JctAssertions.assertThat;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.junit.JavacCompilerTest;
+import io.github.ascopes.jct.workspaces.Workspaces;
+import org.junit.jupiter.api.DisplayName;
+
+/**
+ * Integration tests that test the compilation of specific classes only.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("Compiling specific classes integration tests")
+class CompilingSpecificClassesIntegrationTest {
+  @DisplayName("Only the classes that I specify get compiled")
+  @JavacCompilerTest
+  void onlyTheClassesSpecifiedGetCompiled(JctCompiler<?, ?> compiler) {
+    try (var workspace = Workspaces.newWorkspace()) {
+      workspace
+          .createSourcePathPackage()
+          .copyContentsFrom("src", "test", "resources", "integration", "specificclasses");
+
+      var compilation = compiler.compile(workspace, "Fibonacci", "HelloWorld");
+
+      assertThat(compilation)
+          .isSuccessfulWithoutWarnings()
+          .classOutput()
+          .packages()
+          .allFilesExist("Fibonacci.class", "HelloWorld.class")
+          .fileDoesNotExist("Sum.class");
+    }
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationFactoryImplTest.java
@@ -1,0 +1,695 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.compilers.impl;
+
+import static io.github.ascopes.jct.tests.helpers.ExtraArgumentMatchers.containsExactlyElements;
+import static io.github.ascopes.jct.tests.helpers.Fixtures.oneOf;
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someBinaryName;
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someFlags;
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someLinesOfText;
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someTraceDiagnostic;
+import static io.github.ascopes.jct.utils.IterableUtils.flatten;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
+
+import io.github.ascopes.jct.compilers.JctCompilation;
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.compilers.impl.JctCompilationFactoryImpl;
+import io.github.ascopes.jct.diagnostics.TeeWriter;
+import io.github.ascopes.jct.diagnostics.TracingDiagnosticListener;
+import io.github.ascopes.jct.ex.JctCompilerException;
+import io.github.ascopes.jct.filemanagers.JctFileManager;
+import io.github.ascopes.jct.filemanagers.LoggingMode;
+import io.github.ascopes.jct.filemanagers.ModuleLocation;
+import io.github.ascopes.jct.filemanagers.PathFileObject;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import javax.annotation.processing.Processor;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaCompiler.CompilationTask;
+import javax.tools.JavaFileManager.Location;
+import javax.tools.JavaFileObject;
+import javax.tools.JavaFileObject.Kind;
+import javax.tools.StandardLocation;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Answers;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction.MockInitializer;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.quality.Strictness;
+
+/**
+ * {@link JctCompilationFactoryImpl} tests.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JctCompilationFactoryImpl tests")
+@ExtendWith(MockitoExtension.class)
+class JctCompilationFactoryImplTest {
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  JctFileManager fileManager;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  JavaCompiler javaCompiler;
+
+  List<String> flags;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  JctCompiler<?, ?> jctCompiler;
+
+  @InjectMocks
+  JctCompilationFactoryImpl factory;
+
+  @BeforeEach
+  void setUp() {
+    flags = someFlags();
+  }
+
+  JctCompilation doCompile(@Nullable Collection<String> classNames) {
+    return factory.createCompilation(flags, fileManager, javaCompiler, classNames);
+  }
+
+  @DisplayName("Multi-module sources are used when they exist")
+  @Test
+  void multiModuleSourcesAreUsedWhenTheyExist() throws IOException {
+    // Given
+    var apiLocation = new ModuleLocation(StandardLocation.MODULE_SOURCE_PATH, "org.example.api");
+    var apiObjects = Set.of(
+        somePathFileObject(someBinaryName()),
+        somePathFileObject(someBinaryName())
+    );
+
+    var implLocation = new ModuleLocation(StandardLocation.MODULE_SOURCE_PATH, "org.example.impl");
+    var implObjects = Set.of(
+        somePathFileObject(someBinaryName()),
+        somePathFileObject(someBinaryName())
+    );
+
+    var allObjects = flatten(Set.of(apiObjects, implObjects));
+
+    var multiModuleLocations = (Iterable<Set<Location>>) Set.of(
+        Set.<Location>of(apiLocation, implLocation)
+    );
+
+    when(fileManager.listLocationsForModules(any()))
+        .thenReturn(multiModuleLocations);
+
+    when(fileManager.list(eq(apiLocation), any(), any(), anyBoolean()))
+        .thenReturn(apiObjects);
+
+    when(fileManager.list(eq(implLocation), any(), any(), anyBoolean()))
+        .thenReturn(implObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(fileManager).listLocationsForModules(StandardLocation.MODULE_SOURCE_PATH);
+    verify(fileManager).list(apiLocation, "", Set.of(Kind.SOURCE), true);
+    verify(fileManager).list(implLocation, "", Set.of(Kind.SOURCE), true);
+    verifyNoMoreInteractions(fileManager);
+
+    verify(javaCompiler).getTask(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        containsExactlyElements(allObjects)
+    );
+  }
+
+  @DisplayName("Legacy sources are used when multi-module sources do not exist")
+  @Test
+  void legacySourcesAreUsedWhenMultiModuleSourcesDoNotExist() throws IOException {
+    // Given
+    when(fileManager.listLocationsForModules(any()))
+        .thenReturn(Set.of());
+
+    var sourceObjects = Set.of(
+        somePathFileObject(someBinaryName()),
+        somePathFileObject(someBinaryName()),
+        somePathFileObject(someBinaryName()),
+        somePathFileObject(someBinaryName())
+    );
+
+    when(fileManager.list(eq(StandardLocation.SOURCE_PATH), any(), any(), anyBoolean()))
+        .thenReturn(sourceObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(fileManager).listLocationsForModules(StandardLocation.MODULE_SOURCE_PATH);
+    verify(fileManager).list(StandardLocation.SOURCE_PATH, "", Set.of(Kind.SOURCE), true);
+    verifyNoMoreInteractions(fileManager);
+
+    verify(javaCompiler).getTask(
+        any(),
+        any(),
+        any(),
+        any(),
+        any(),
+        containsExactlyElements(sourceObjects)
+    );
+  }
+
+  @DisplayName("All compilation units are used when null classNames collection is provided")
+  @Test
+  void allCompilationUnitsAreUsedWhenNullClassNamesCollectionIsProvided() throws IOException {
+    // Given
+    var compilationUnits = Set.of(
+        somePathFileObject("foo.bar.Baz"),
+        somePathFileObject("do.ray.Me"),
+        somePathFileObject("a.b.C")
+    );
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(compilationUnits);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(javaCompiler).getTask(
+        any(),
+        same(fileManager),
+        any(),
+        any(),
+        isNull(),
+        eq(compilationUnits)
+    );
+  }
+
+  @DisplayName("All compilation units are included in the compilation result when null "
+      + "classNames collection is provided")
+  @Test
+  void allCompilationUnitsAreIncludedInTheCompilationResultWhenNullClassNamesCollectionIsProvided()
+      throws IOException {
+    // Given
+    var compilationUnits = Set.of(
+        somePathFileObject("foo.bar.Baz"),
+        somePathFileObject("do.ray.Me"),
+        somePathFileObject("a.b.C")
+    );
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(compilationUnits);
+
+    // When
+    var result = doCompile(null);
+
+    // Then
+    assertThat(result.getCompilationUnits())
+        .isEqualTo(compilationUnits);
+  }
+
+  @DisplayName("Filtering compilation units with an empty class names collection raises an error")
+  @Test
+  void filteringCompilationUnitsWithEmptyClassNamesCollectionRaisesAnError() {
+    // Then
+    assertThatThrownBy(() -> doCompile(List.of()))
+        .isInstanceOf(JctCompilerException.class)
+        .hasMessage("The list of explicit class names to compile is empty");
+
+    verifyNoInteractions(javaCompiler);
+  }
+
+  @DisplayName("Filtered compilation units are used when class names are provided")
+  @Test
+  void filteredCompilationUnitsAreUsedWhenClassNamesAreProvided() throws IOException {
+    // Given
+    var fooBarBaz = somePathFileObject("foo.bar.Baz");
+    var doRayMe = somePathFileObject("do.ray.Me");
+
+    var compilationUnits = Set.of(fooBarBaz, doRayMe, somePathFileObject("a.b.C"));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(compilationUnits);
+
+    // When
+    doCompile(Set.of("foo.bar.Baz", "do.ray.Me"));
+
+    // Then
+    verify(javaCompiler).getTask(
+        any(),
+        same(fileManager),
+        any(),
+        any(),
+        isNull(),
+        containsExactlyElements(doRayMe, fooBarBaz)
+    );
+  }
+
+  @DisplayName("Filtered compilation units are included in the compilation result when "
+      + "class names are provided")
+  @Test
+  void filteredCompilationUnitsAreIncludedInTheCompilationResultWhenClassNamesAreProvided()
+      throws IOException {
+    // Given
+    var fooBarBaz = somePathFileObject("foo.bar.Baz");
+    var doRayMe = somePathFileObject("do.ray.Me");
+
+    var compilationUnits = Set.of(fooBarBaz, doRayMe, somePathFileObject("a.b.C"));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(compilationUnits);
+
+    // When
+    var result = doCompile(Set.of("foo.bar.Baz", "do.ray.Me"));
+
+    // Then
+    assertThat(result.getCompilationUnits())
+        .containsExactlyInAnyOrder(fooBarBaz, doRayMe);
+  }
+
+  @DisplayName("An error is raised when an explicit class name is not in the compilation units")
+  @Test
+  void anErrorIsRaisedWhenAnExplicitClassNameIsNotInTheCompilationUnits() throws IOException {
+    // Given
+    var fooBarBaz = somePathFileObject("foo.bar.Baz");
+    var doRayMe = somePathFileObject("do.ray.Me");
+
+    var compilationUnits = Set.of(fooBarBaz, doRayMe, somePathFileObject("a.b.C"));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(compilationUnits);
+
+    // Then
+    assertThatThrownBy(() -> doCompile(Set.of("foo.bar.Baz", "this.clazz.does.not.Exist")))
+        .isInstanceOf(JctCompilerException.class)
+        .hasMessage(
+            "No compilation unit matching this.clazz.does.not.Exist found in the provided sources"
+        );
+    verifyNoInteractions(javaCompiler);
+  }
+
+  @DisplayName("An error is raised if no compilation units are found")
+  @Test
+  void anErrorIsRaisedIfNoCompilationUnitsAreFound() throws IOException {
+    // Given
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(Set.of());
+
+    // Then
+    assertThatThrownBy(() -> doCompile(null))
+        .isInstanceOf(JctCompilerException.class)
+        .hasMessage("No compilation units were found in the given workspace");
+    verifyNoInteractions(javaCompiler);
+  }
+
+  @DisplayName("The compiler should write logs to System.out")
+  @Test
+  void theCompilerShouldWriteLogsToSystemOut() throws IOException {
+    // Given
+    try (var teeWriterStatic = mockStatic(TeeWriter.class)) {
+      var teeWriter = mock(TeeWriter.class);
+      teeWriterStatic.when(() -> TeeWriter.wrapOutputStream(any(), any()))
+          .thenReturn(teeWriter);
+      when(teeWriter.getContent())
+          .thenReturn(someLinesOfText());
+
+      // Do not inline this, it will break in Mockito's stubber backend.
+      var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+      when(fileManager.list(any(), any(), any(), anyBoolean()))
+          .thenReturn(fileObjects);
+
+      // When
+      doCompile(null);
+
+      // Then
+      teeWriterStatic.verify(() -> TeeWriter.wrapOutputStream(
+          System.out,
+          jctCompiler.getLogCharset()
+      ));
+      teeWriterStatic.verifyNoMoreInteractions();
+
+      // Ensure the tee writer is used for the compiler task.
+      verify(javaCompiler).getTask(same(teeWriter), any(), any(), any(), any(), any());
+    }
+  }
+
+  @DisplayName("The tee writer logs should be placed in the compilation result")
+  @Test
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  void teeWriterLogsShouldBePlacedInTheCompilationResult() throws IOException {
+    // Given
+    try (var teeWriterStatic = mockStatic(TeeWriter.class)) {
+      var teeWriter = mock(TeeWriter.class);
+      var order = inOrder(teeWriter);
+
+      teeWriterStatic.when(() -> TeeWriter.wrapOutputStream(any(), any()))
+          .thenReturn(teeWriter);
+      var lines = someLinesOfText();
+      when(teeWriter.getContent()).thenReturn(lines);
+
+      // Do not inline this, it will break in Mockito's stubber backend.
+      var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+      when(fileManager.list(any(), any(), any(), anyBoolean()))
+          .thenReturn(fileObjects);
+
+      // When
+      var result = doCompile(null);
+
+      // Then
+      assertThat(result.getOutputLines())
+          .containsExactlyElementsOf(lines.lines().collect(toList()));
+
+      // Ensure we flushed before we called toString, otherwise data might be missing.
+      order.verify(teeWriter).flush();
+      order.verify(teeWriter).getContent();
+    }
+  }
+
+  @DisplayName("A correctly configured diagnostic listener is used for compilation")
+  @CsvSource({
+      "DISABLED,   false, false",
+      "ENABLED,     true, false",
+      "STACKTRACES, true,  true"
+  })
+  @ParameterizedTest(name = "- LoggingMode.{0} should use new TracingDiagnosticListener({1}, {2})")
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  void correctlyConfiguredDiagnosticListenerIsUsedForCompilation(
+      LoggingMode loggingMode,
+      boolean expectedEnabled,
+      boolean expectedStackTraces
+  ) throws IOException {
+    // Given
+    when(jctCompiler.getDiagnosticLoggingMode())
+        .thenReturn(loggingMode);
+
+    MockInitializer<TracingDiagnosticListener> verifier = (mock, ctx) -> {
+      assertThat(ctx.arguments())
+          .hasSize(2)
+          .satisfies(
+              args -> assertThat(args).element(0).isEqualTo(expectedEnabled),
+              args -> assertThat(args).element(1).isEqualTo(expectedStackTraces)
+          );
+    };
+
+    try (var listenerCls = mockConstruction(TracingDiagnosticListener.class, verifier)) {
+      // Do not inline this, it will break in Mockito's stubber backend.
+      var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+      when(fileManager.list(any(), any(), any(), anyBoolean()))
+          .thenReturn(fileObjects);
+
+      // When
+      doCompile(null);
+
+      // Then
+      verify(javaCompiler).getTask(
+          any(),
+          any(),
+          same(listenerCls.constructed().iterator().next()),
+          any(),
+          any(),
+          any()
+      );
+    }
+  }
+
+  @DisplayName("Diagnostics get placed in the compilation result")
+  @Test
+  @SuppressWarnings("rawtypes")
+  void correctlyConfiguredDiagnosticListenerIsUsedForCompilation() throws IOException {
+    // Given
+    var diagnostics = List.of(
+        someTraceDiagnostic(),
+        someTraceDiagnostic(),
+        someTraceDiagnostic(),
+        someTraceDiagnostic()
+    );
+
+    MockInitializer<TracingDiagnosticListener> configurer =
+        (mock, ctx) -> when(mock.getDiagnostics()).thenReturn(diagnostics);
+
+    try (var ignored = mockConstruction(TracingDiagnosticListener.class, configurer)) {
+      // Do not inline this, it will break in Mockito's stubber backend.
+      var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+      when(fileManager.list(any(), any(), any(), anyBoolean()))
+          .thenReturn(fileObjects);
+
+      // When
+      var result = doCompile(null);
+
+      // Then
+      assertThat(result.getDiagnostics())
+          .isEqualTo(diagnostics);
+    }
+  }
+
+  @DisplayName("The file manager is passed to the compiler task")
+  @Test
+  void theFileManagerIsPassedToTheCompilationTask() throws IOException {
+    // Given
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(javaCompiler).getTask(any(), same(fileManager), any(), any(), any(), any());
+  }
+
+  @DisplayName("The file manager is included in the compilation result")
+  @Test
+  void theFileManagerIsIncludedInTheCompilationResult() throws IOException {
+    // Given
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    var result = doCompile(null);
+
+    // Then
+    assertThat(result.getFileManager())
+        .isSameAs(fileManager);
+  }
+
+  @DisplayName("Flags are passed to the compilation task")
+  @Test
+  void flagsArePassedToTheCompilationTask() throws IOException {
+    // Given
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(javaCompiler).getTask(any(), any(), any(), same(flags), any(), any());
+  }
+
+  @DisplayName("Annotation processors are not registered if processors list is empty")
+  @Test
+  void annotationProcessorsAreNotRegisteredIfProcessorsListIsEmpty() throws IOException {
+    // Given
+    when(jctCompiler.getAnnotationProcessors()).thenReturn(List.of());
+
+    var task = mock(CompilationTask.class);
+    when(javaCompiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenReturn(task);
+
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(task, never()).setProcessors(any());
+  }
+
+  @DisplayName("Annotation processors are registered if processors list is not empty")
+  @Test
+  void annotationProcessorsAreRegisteredIfProcessorsListIsNotEmpty() throws IOException {
+    // Given
+    var processors = List.of(
+        mock(Processor.class),
+        mock(Processor.class),
+        mock(Processor.class),
+        mock(Processor.class)
+    );
+    when(jctCompiler.getAnnotationProcessors()).thenReturn(processors);
+
+    var task = mock(CompilationTask.class);
+    when(javaCompiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenReturn(task);
+
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(task).setProcessors(processors);
+  }
+
+  @DisplayName("The locale is set on the compiler task")
+  @Test
+  void theLocaleIsSetOnTheCompilerTask() throws IOException {
+    // Given
+    var locale = someLocale();
+    when(jctCompiler.getLocale()).thenReturn(locale);
+
+    var task = mock(CompilationTask.class);
+    when(javaCompiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenReturn(task);
+
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    doCompile(null);
+
+    // Then
+    verify(task).setLocale(locale);
+  }
+
+  @DisplayName("The compilation is invoked and the outcome is placed in the compilation result")
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest(name = "when CompilationTask.call() returns {0}")
+  void theCompilationIsInvokedAndTheOutcomeIsPlacedInTheCompilationResult(boolean success)
+      throws IOException {
+    // Given
+    var task = mock(CompilationTask.class);
+    var order = inOrder(task);
+    when(javaCompiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenReturn(task);
+    when(task.call())
+        .thenReturn(success);
+
+    when(jctCompiler.getAnnotationProcessors())
+        .thenReturn(mock());
+
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    var result = doCompile(null);
+
+    // Then
+    assertThat(result.isSuccessful())
+        .isEqualTo(success);
+
+    // Verify that we call the .call() method as the last thing we call on the object.
+    order.verify(task).setProcessors(any());
+    order.verify(task).setLocale(any());
+    order.verify(task).call();
+    order.verifyNoMoreInteractions();
+  }
+
+  @DisplayName("Exceptions during compilation get wrapped and rethrown")
+  @Test
+  void exceptionsDuringCompilationGetWrappedAndRethrown() throws IOException {
+    // Given
+    var task = mock(CompilationTask.class);
+    var cause = new IOException("Something is messed up");
+
+    when(javaCompiler.getTask(any(), any(), any(), any(), any(), any()))
+        .thenReturn(task);
+    when(task.call())
+        .thenThrow(cause);
+
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // Then
+    assertThatThrownBy(() -> doCompile(null))
+        .isInstanceOf(JctCompilerException.class)
+        .hasMessage("Failed to perform compilation, an unexpected exception was raised")
+        .hasCause(cause);
+  }
+
+  @DisplayName("The compilation result holds the failOnWarnings flag from the compiler")
+  @ValueSource(booleans = {true, false})
+  @ParameterizedTest(name = "for compiler.isFailOnWarnings() = {0}")
+  void theCompilationResultHoldsTheFailOnWarningsFlagFromTheCompiler(boolean failOnWarnings)
+      throws IOException {
+    // Given
+    when(jctCompiler.isFailOnWarnings())
+        .thenReturn(failOnWarnings);
+
+    // Do not inline this, it will break in Mockito's stubber backend.
+    var fileObjects = Set.of(somePathFileObject(someBinaryName()));
+    when(fileManager.list(any(), any(), any(), anyBoolean()))
+        .thenReturn(fileObjects);
+
+    // When
+    var result = doCompile(null);
+
+    // Then
+    assertThat(result.isFailOnWarnings())
+        .isEqualTo(failOnWarnings);
+  }
+
+  static JavaFileObject somePathFileObject(String binaryName) {
+    var pathFileObject = mock(PathFileObject.class, withSettings().strictness(Strictness.LENIENT));
+    when(pathFileObject.getBinaryName()).thenReturn(binaryName);
+    return pathFileObject;
+  }
+
+  static Locale someLocale() {
+    return oneOf(
+        Locale.ENGLISH,
+        Locale.CHINESE,
+        Locale.JAPAN,
+        Locale.CANADA,
+        Locale.GERMANY
+    );
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/PathFileObjectTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/PathFileObjectTest.java
@@ -27,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import io.github.ascopes.jct.filemanagers.PathFileObject;
+import io.github.ascopes.jct.utils.FileUtils;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.charset.MalformedInputException;
@@ -222,6 +223,19 @@ class PathFileObjectTest {
 
     // Then
     assertThat(fileObject.getAccessLevel()).isNull();
+  }
+
+  @DisplayName(".getBinaryName() gets the binary name of the relative path")
+  @Test
+  void getBinaryNameGetsTheBinaryNameOfTheRelativePath() {
+    // Given
+    var relativePath = someRelativePath().resolve("Cat.java");
+    var expectedBinaryName = FileUtils.pathToBinaryName(relativePath);
+    var fileObject = new PathFileObject(someLocation(), someAbsolutePath(), relativePath);
+
+    // Then
+    assertThat(fileObject.getBinaryName())
+        .isEqualTo(expectedBinaryName);
   }
 
   @DisplayName(".getCharContent(...) returns the character content")

--- a/java-compiler-testing/src/test/resources/integration/specificclasses/Fibonacci.java
+++ b/java-compiler-testing/src/test/resources/integration/specificclasses/Fibonacci.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import static java.math.BigInteger.ONE;
+import static java.math.BigInteger.ZERO;
+
+import java.math.BigInteger;
+
+/**
+ * Command line app to calculate the nth number of the fibonacci sequence.
+ */
+public class Fibonacci {
+  public static void main(String[] args) {
+    if (args.length != 1) {
+      System.out.println("USAGE: java Fibonacci <n>");
+      System.out.println("    <n>    Fibonacci number to generate");
+    }
+
+    BigInteger n = new BigInteger(args[0], 10);
+    BigInteger a = ZERO;
+    BigInteger b = ONE;
+
+    for (BigInteger i = ZERO; i.compareTo(n) < 0; i = i.add(ONE)) {
+      BigInteger oldB = b;
+      b = a.add(b);
+      a = oldB;
+    }
+
+    System.out.println(a);
+  }
+}

--- a/java-compiler-testing/src/test/resources/integration/specificclasses/HelloWorld.java
+++ b/java-compiler-testing/src/test/resources/integration/specificclasses/HelloWorld.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Command line app that says hello to me.
+ */
+public class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello, World!");
+  }
+}

--- a/java-compiler-testing/src/test/resources/integration/specificclasses/Sum.java
+++ b/java-compiler-testing/src/test/resources/integration/specificclasses/Sum.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Command line app that sums together given integers.
+ */
+public class Sum {
+  public static void main(String[] args) {
+    long sum = 0;
+    for (String arg : args) {
+      sum += Integer.parseInt(arg);
+    }
+    System.out.println(sum);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     -->
     <argLine>
       -Dorg.slf4j.simpleLogger.log=INFO
-      -Dorg.slf4j.simpleLogger.log.io.github.ascopes.jct=DEBUG
+      -Dorg.slf4j.simpleLogger.log.io.github.ascopes.jct=TRACE
       -Xshare:off
       -XX:+TieredCompilation
       -XX:TieredStopAtLevel=1


### PR DESCRIPTION
Fix explicit class handling.

- GH-354: Fail if no compilation units are found/filtered classes not found 
    - Add new method: PathFileObject#getBinaryName
    - JctCompilationFactoryImpl will now error if no initial compilation units
      were found with a clearer error message.
    - JctCompilationFactoryImpl will now error if any of the explicitly provided
      class names are not found as compilation units.
    - JctCompilationFactoryImpl will now error if the list of provided class
      names is non-null but empty.
- Contributes to GH-294: Integration test compiling specific class names.
- API improvement that assists with GH-294: Allow call chaining on PackageContainerGroupAssert#allFilesExist (non-breaking API change).
- Fixes GH-356: Write tests for JctCompilationFactoryImpl  
    - Add test pack for JctCompilationFactoryImpl.
    - Add new helper test class for Mockito matchers used within
      collection-like types.
    - Add a new method TeeWriter#getContent that gets the lines of content
      within a TeeWriter, as this is easier to stub than #toString due to
      how Mockito works internally.
    - Add a new method TeeWriter#wrapOutputStream that wraps a given
      OutputStream and Charset in an OutputStreamWriter and inserts that
      into a new TeeWriter that is returned.
    - Fix regression in JctCompilationFactoryImpl where the locale was not
      being set during compilations.
    - Fix bug in JctCompilationFactory where the TeeWriter was not being flushed,
      so buffered content may not have been written to System.out properly
      in some edge cases.
    - Improve performance of JctCompilationFactoryImpl for explicit class name
      lookup by avoiding creating a distinct collection that is iteratively
      resized with O(n) space complexity.
- Fixes GH-354: Fix incorrect logic for filtering explicit class names that previously
  resulted in an exception being raised if annotation processing was not configured in
  a very specific way.
