### PR TITLE
Fix path assertions across multiple file systems

### DIFF
--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.5.1-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssert.java
@@ -47,7 +47,15 @@ public abstract class AbstractContainerGroupAssert<I extends AbstractContainerGr
    * <p>This is defined here to allow consistent behaviour across various fuzzy matching
    * operations in all implementations.
    */
-  protected static final int FUZZY_CUTOFF = 5;
+  protected static final int FUZZY_MAX_RESULTS = 5;
+
+  /**
+   * Default minimum fuzzy score to require to include results found using fuzzy matching.
+   *
+   * <p>This is defined here to allow consistent behaviour across various fuzzy matching
+   * operations in all implementations.
+   */
+  protected static final int FUZZY_MIN_SCORE = 75;
 
   /**
    * Initialize the container group assertions.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssert.java
@@ -91,14 +91,11 @@ public final class ModuleContainerGroupAssert
       return new PackageContainerGroupAssert(moduleGroup);
     }
 
+    var actualModules = actual.getModules().keySet();
     var closestMatches = FuzzySearch
-        .extractSorted(
-            module,
-            actual.getModules().keySet(),
-            ModuleLocation::getModuleName
-        )
+        .extractSorted(module, actualModules,ModuleLocation::getModuleName, FUZZY_MIN_SCORE)
         .stream()
-        .limit(FUZZY_CUTOFF)
+        .limit(FUZZY_MAX_RESULTS)
         .map(BoundExtractedResult::getReferent)
         .sorted()
         .collect(Collectors.toList());

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
@@ -92,6 +92,21 @@ public interface Container extends Closeable {
   PathFileObject getFileForOutput(String packageName, String relativeName);
 
   /**
+   * Get the inner path root of the container.
+   *
+   * <p>This will usually be the same as the {@link #getPathRoot() path root}, but for archives,
+   * this will point to the root directory of the archive for the virtual file system it is loaded
+   * in, rather than the location of the archive on the original file system.
+   *
+   * <p>It is worth noting that this operation may result in the archive being loaded into memory
+   * eagerly if it uses lazy loading, due to the need to load the archive to be able to determine
+   * an accurate handle to the inner root directory.
+   *
+   * @return the path root.
+   */
+  PathRoot getInnerPathRoot();
+
+  /**
    * Get a {@link JavaFileObject} for reading, if it exists.
    *
    * <p>If the file does not exist, {@code null} is returned.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -17,16 +17,17 @@ package io.github.ascopes.jct.containers;
 
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.workspaces.PathRoot;
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.List;
-import java.util.Set;
+import java.io.UnsupportedEncodingException;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.*;
 
 /**
  * Base interface representing a group of package-oriented paths.
@@ -37,156 +38,166 @@ import org.apiguardian.api.API.Status;
 @API(since = "0.0.1", status = Status.STABLE)
 public interface PackageContainerGroup extends ContainerGroup {
 
-  /**
-   * Add a container to this group.
-   *
-   * <p>The provided container will be closed when this group is closed.
-   *
-   * @param container the container to add.
-   */
-  void addPackage(Container container);
+    /**
+     * Add a container to this group.
+     *
+     * <p>The provided container will be closed when this group is closed.
+     *
+     * @param container the container to add.
+     */
+    void addPackage(Container container);
 
-  /**
-   * Add a path to this group.
-   *
-   * <p>Note that this will destroy the {@link #getClassLoader() classloader} if one is already
-   * allocated.
-   *
-   * <p>If the path points to some form of archive (such as a JAR), then this may open that archive
-   * in a new resource internally. If this occurs, then the resource will always be freed by this
-   * class by calling {@link #close()}.
-   *
-   * <p>Any other closable resources passed to this function will not be closed by this
-   * implementation. You must handle the lifecycle of those objects yourself.
-   *
-   * @param path the path to add.
-   */
-  void addPackage(PathRoot path);
+    /**
+     * Add a path to this group.
+     *
+     * <p>Note that this will destroy the {@link #getClassLoader() classloader} if one is already
+     * allocated.
+     *
+     * <p>If the path points to some form of archive (such as a JAR), then this may open that archive
+     * in a new resource internally. If this occurs, then the resource will always be freed by this
+     * class by calling {@link #close()}.
+     *
+     * <p>Any other closable resources passed to this function will not be closed by this
+     * implementation. You must handle the lifecycle of those objects yourself.
+     *
+     * @param path the path to add.
+     */
+    void addPackage(PathRoot path);
 
-  /**
-   * Get a class loader for this group of containers.
-   *
-   * <p>Note that adding additional containers to this group after accessing this class loader
-   * may result in the class loader being destroyed or re-created.
-   *
-   * @return the class loader.
-   */
-  ClassLoader getClassLoader();
+    /**
+     * Get a class loader for this group of containers.
+     *
+     * <p>Note that adding additional containers to this group after accessing this class loader
+     * may result in the class loader being destroyed or re-created.
+     *
+     * @return the class loader.
+     */
+    ClassLoader getClassLoader();
 
-  /**
-   * Find the first occurrence of a given path to a file in packages or modules.
-   *
-   * <p>Modules are treated as subdirectories.
-   *
-   * <pre><code>
-   *   // Using platform-specific separators.
-   *   containerGroup.getFile("foo/bar/baz.txt")...;
-   *
-   *   // Letting JCT infer the correct path separators to use (recommended).
-   *   containerGroup.getFile("foo", "bar", "baz.txt");
-   * </code></pre>
-   *
-   * @param fragment  the first part of the path.
-   * @param fragments any additional parts of the path.
-   * @return the first occurrence of the path in this group, or null if not found.
-   * @throws IllegalArgumentException if the provided path is absolute.
-   */
-  Path getFile(String fragment, String... fragments);
+    /**
+     * Find the first occurrence of a given path to a file in packages or modules.
+     *
+     * <p>Modules are treated as subdirectories.
+     *
+     * <pre><code>
+     *   // Using platform-specific separators.
+     *   containerGroup.getFile("foo/bar/baz.txt")...;
+     *
+     *   // Letting JCT infer the correct path separators to use (recommended).
+     *   containerGroup.getFile("foo", "bar", "baz.txt");
+     * </code></pre>
+     *
+     * @param fragment  the first part of the path.
+     * @param fragments any additional parts of the path.
+     * @return the first occurrence of the path in this group, or null if not found.
+     * @throws IllegalArgumentException if the provided path is absolute.
+     */
+    Path getFile(String fragment, String... fragments);
 
-  /**
-   * Get a {@link FileObject} that can have content read from it.
-   *
-   * <p>This will return {@code null} if no file is found matching the criteria.
-   *
-   * @param packageName  the package name of the file to read.
-   * @param relativeName the relative name of the file to read.
-   * @return the file object, or null if the file is not found.
-   */
-  PathFileObject getFileForInput(String packageName, String relativeName);
+    /**
+     * Get a {@link FileObject} that can have content read from it.
+     *
+     * <p>This will return {@code null} if no file is found matching the criteria.
+     *
+     * @param packageName  the package name of the file to read.
+     * @param relativeName the relative name of the file to read.
+     * @return the file object, or null if the file is not found.
+     */
+    PathFileObject getFileForInput(String packageName, String relativeName);
 
-  /**
-   * Get a {@link FileObject} that can have content written to it for the given file.
-   *
-   * <p>This will attempt to write to the first writeable path in this group. {@code null}
-   * will be returned if no writeable paths exist in this group.
-   *
-   * @param packageName  the name of the package the file is in.
-   * @param relativeName the relative name of the file within the package.
-   * @return the {@link FileObject} to write to, or null if this group has no paths that can be
-   *     written to.
-   */
-  PathFileObject getFileForOutput(String packageName, String relativeName);
+    /**
+     * Get a {@link FileObject} that can have content written to it for the given file.
+     *
+     * <p>This will attempt to write to the first writeable path in this group. {@code null}
+     * will be returned if no writeable paths exist in this group.
+     *
+     * @param packageName  the name of the package the file is in.
+     * @param relativeName the relative name of the file within the package.
+     * @return the {@link FileObject} to write to, or null if this group has no paths that can be
+     * written to.
+     */
+    PathFileObject getFileForOutput(String packageName, String relativeName);
 
-  /**
-   * Get a {@link JavaFileObject} that can have content read from it for the given file.
-   *
-   * <p>This will return {@code null} if no file is found matching the criteria.
-   *
-   * @param className the binary name of the class to read.
-   * @param kind      the kind of file to read.
-   * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
-   *     written to.
-   */
-  PathFileObject getJavaFileForInput(String className, Kind kind);
+    /**
+     * Get a {@link JavaFileObject} that can have content read from it for the given file.
+     *
+     * <p>This will return {@code null} if no file is found matching the criteria.
+     *
+     * @param className the binary name of the class to read.
+     * @param kind      the kind of file to read.
+     * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
+     * written to.
+     */
+    PathFileObject getJavaFileForInput(String className, Kind kind);
 
-  /**
-   * Get a {@link JavaFileObject} that can have content written to it for the given class.
-   *
-   * <p>This will attempt to write to the first writeable path in this group. {@code null}
-   * will be returned if no writeable paths exist in this group.
-   *
-   * @param className the name of the class.
-   * @param kind      the kind of the class file.
-   * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
-   *     written to.
-   */
-  PathFileObject getJavaFileForOutput(String className, Kind kind);
+    /**
+     * Get a {@link JavaFileObject} that can have content written to it for the given class.
+     *
+     * <p>This will attempt to write to the first writeable path in this group. {@code null}
+     * will be returned if no writeable paths exist in this group.
+     *
+     * @param className the name of the class.
+     * @param kind      the kind of the class file.
+     * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
+     * written to.
+     */
+    PathFileObject getJavaFileForOutput(String className, Kind kind);
 
-  /**
-   * Get the package-oriented location that this group of paths is for.
-   *
-   * @return the package-oriented location.
-   */
-  Location getLocation();
+    /**
+     * Get the package-oriented location that this group of paths is for.
+     *
+     * @return the package-oriented location.
+     */
+    Location getLocation();
 
-  /**
-   * Get the package containers in this group.
-   *
-   * <p>Returned packages are presented in the order that they were registered. This is the
-   * resolution order that the compiler will use.
-   *
-   * @return the containers.
-   */
-  List<Container> getPackages();
+    /**
+     * Get the package containers in this group.
+     *
+     * <p>Returned packages are presented in the order that they were registered. This is the
+     * resolution order that the compiler will use.
+     *
+     * @return the containers.
+     */
+    List<Container> getPackages();
 
-  /**
-   * Try to infer the binary name of a given file object.
-   *
-   * @param fileObject the file object to infer the binary name for.
-   * @return the binary name if known, or null otherwise.
-   */
-  String inferBinaryName(PathFileObject fileObject);
+    /**
+     * Try to infer the binary name of a given file object.
+     *
+     * @param fileObject the file object to infer the binary name for.
+     * @return the binary name if known, or null otherwise.
+     */
+    String inferBinaryName(PathFileObject fileObject);
 
-  /**
-   * Determine if this group has no paths registered.
-   *
-   * @return {@code true} if no paths are registered. {@code false} if paths are registered.
-   */
-  boolean isEmpty();
+    /**
+     * Determine if this group has no paths registered.
+     *
+     * @return {@code true} if no paths are registered. {@code false} if paths are registered.
+     */
+    boolean isEmpty();
 
-  /**
-   * List all the file objects that match the given criteria in this group.
-   *
-   * @param packageName the package name to look in.
-   * @param kinds       the kinds of file to look for.
-   * @param recurse     {@code true} to recurse subpackages, {@code false} to only consider the
-   *                    given package.
-   * @return thr file objects that were found.
-   * @throws IOException if the file lookup fails due to an IO exception.
-   */
-  Set<JavaFileObject> listFileObjects(
-      String packageName,
-      Set<? extends Kind> kinds,
-      boolean recurse
-  ) throws IOException;
+    /**
+     * List all the file objects that match the given criteria in this group.
+     *
+     * @param packageName the package name to look in.
+     * @param kinds       the kinds of file to look for.
+     * @param recurse     {@code true} to recurse subpackages, {@code false} to only consider the
+     *                    given package.
+     * @return thr file objects that were found.
+     * @throws IOException if the file lookup fails due to an IO exception.
+     */
+    Set<JavaFileObject> listFileObjects(
+            String packageName,
+            Set<? extends Kind> kinds,
+            boolean recurse
+    ) throws IOException;
+
+    /**
+     * List all files recursively in this container group, returning a multimap of each container and all files
+     * within that container.
+     *
+     * @return a multimap of containers mapping to collections of all files in that container.
+     * @since 0.6.0
+     */
+    @API(since = "0.6.0", status = Status.STABLE)
+    Map<Container, Collection<Path>> listAllFiles() throws IOException;
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
@@ -27,13 +27,7 @@ import io.github.ascopes.jct.utils.ToStringBuilder;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Locale;
-import java.util.ServiceLoader;
-import java.util.Set;
+import java.util.*;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
@@ -261,6 +255,16 @@ public abstract class AbstractPackageContainerGroup implements PackageContainerG
       container.listFileObjects(packageName, kinds, recurse, collection);
     }
     return collection;
+  }
+
+  @API(since = "0.6.0", status = Status.STABLE)
+  @Override
+  public Map<Container, Collection<Path>> listAllFiles() throws IOException {
+    var multimap = new LinkedHashMap<Container, Collection<Path>>();
+    for (var container : getPackages()) {
+      multimap.put(container, container.listAllFiles());
+    }
+    return Collections.unmodifiableMap(multimap);
   }
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
@@ -33,11 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
 import java.nio.file.spi.FileSystemProvider;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import javax.tools.JavaFileManager.Location;
@@ -326,7 +322,7 @@ public final class JarContainerImpl implements Container {
         }
       }
 
-      return allPaths;
+      return Collections.unmodifiableList(allPaths);
     }
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -103,6 +103,11 @@ public final class PathWrappingContainerImpl implements Container {
   }
 
   @Override
+  public PathRoot getInnerPathRoot() {
+    return root;
+  }
+
+  @Override
   public PathFileObject getJavaFileForInput(String binaryName, Kind kind) {
     var path = FileUtils.binaryNameToPath(root.getPath(), binaryName, kind);
     return Files.isRegularFile(path)

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -146,7 +146,7 @@ public final class PathWrappingContainerImpl implements Container {
   @Override
   public Collection<Path> listAllFiles() throws IOException {
     try (var walker = Files.walk(root.getPath(), FileVisitOption.FOLLOW_LINKS)) {
-      return walker.collect(Collectors.toList());
+      return walker.collect(Collectors.toUnmodifiableList());
     }
   }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/containers/impl/AbstractPackageContainerGroupTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/containers/impl/AbstractPackageContainerGroupTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.containers.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.github.ascopes.jct.containers.Container;
+import io.github.ascopes.jct.containers.impl.AbstractPackageContainerGroup;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link AbstractPackageContainerGroup} tests.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("AbstractPackageContainerGroup tests")
+class AbstractPackageContainerGroupTest {
+
+  @DisplayName("listAllFiles returns a multimap of all files in all containers")
+  @SuppressWarnings("resource")
+  @Test
+  void listAllFilesReturnsMultimapOfAllFilesInAllContainers() throws IOException {
+    // Given
+    var container1 = mock(Container.class, "container 1");
+    var container1Path1 = mock(Path.class, "container 1 - path 1");
+    var container1Path2 = mock(Path.class, "container 1 - path 2");
+    var container1Path3 = mock(Path.class, "container 1 - path 3");
+    var container1Path4 = mock(Path.class, "container 1 - path 4");
+    when(container1.listAllFiles())
+        .thenReturn(List.of(container1Path1, container1Path2, container1Path3, container1Path4));
+
+    var container2 = mock(Container.class, "container 2");
+    var container2Path1 = mock(Path.class, "container 2 - path 1");
+    var container2Path2 = mock(Path.class, "container 2 - path 2");
+    when(container2.listAllFiles())
+        .thenReturn(List.of(container2Path1, container2Path2));
+
+    var container3 = mock(Container.class, "container 3");
+    var container3Path1 = mock(Path.class, "container 3 - path 1");
+    var container3Path2 = mock(Path.class, "container 3 - path 2");
+    var container3Path3 = mock(Path.class, "container 3 - path 3");
+    when(container3.listAllFiles())
+        .thenReturn(List.of(container3Path1, container3Path2, container3Path3));
+
+    var packageContainerGroup = mock(AbstractPackageContainerGroup.class);
+    when(packageContainerGroup.listAllFiles())
+        .thenCallRealMethod();
+    when(packageContainerGroup.getPackages())
+        .thenReturn(List.of(container1, container2, container3));
+
+    // When
+    var allFiles = packageContainerGroup.listAllFiles();
+
+    // Then
+    assertThat(allFiles)
+        .hasSize(3)
+        .hasEntrySatisfying(container1, files -> assertThat(files)
+            .hasSize(4)
+            .containsExactly(container1Path1, container1Path2, container1Path3, container1Path4))
+        .hasEntrySatisfying(container2, files -> assertThat(files)
+            .hasSize(2)
+            .containsExactly(container2Path1, container2Path2))
+        .hasEntrySatisfying(container3, files -> assertThat(files)
+            .hasSize(3)
+            .containsExactly(container3Path1, container3Path2, container3Path3));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>0.5.1-SNAPSHOT</version>
+  <version>0.6.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>


### PR DESCRIPTION
Fixes the file-exists assertion logic to prevent it getting confused when
archive file systems (like JARs) sit on the paths.

- Add new API methods for gathering all files across all containers.
- Add new API methods for retrieving the root directory of an archive-based container correctly.
- ...bump to v0.6.0 as this is a breaking API change unfortunately.
- Fix assertions for file discovery in package container groups to avoid confusion making
  relative paths between various file systems.
- Make algorithm for matching files more concrete between different file system 
  implementations (specifically Windows-like paths using backslashes for delimiters).
