### PR TITLE
Deprecate all platform class path features for v1.0.0

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -77,7 +77,11 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   private boolean fixJvmModulePathMismatch;
   private boolean inheritClassPath;
   private boolean inheritModulePath;
+
+  @Deprecated(forRemoval = true, since = "0.6.0")
+  @SuppressWarnings("DeprecatedIsStillUsed")
   private boolean inheritPlatformClassPath;
+
   private boolean inheritSystemModulePath;
   private LoggingMode fileManagerLoggingMode;
   private AnnotationProcessorDiscovery annotationProcessorDiscovery;
@@ -87,6 +91,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
    *
    * @param defaultName the printable default name to use for the compiler.
    */
+  @SuppressWarnings("removal")
   protected AbstractJctCompiler(String defaultName) {
     name = requireNonNull(defaultName, "name");
     annotationProcessors = new ArrayList<>();
@@ -335,12 +340,16 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
     return myself();
   }
 
+  @Deprecated(forRemoval = true, since = "0.6.0")
   @Override
+  @SuppressWarnings({"removal", "DeprecatedIsStillUsed"})
   public boolean isInheritPlatformClassPath() {
     return inheritPlatformClassPath;
   }
 
+  @Deprecated(forRemoval = true, since = "0.6.0")
   @Override
+  @SuppressWarnings({"removal", "DeprecatedIsStillUsed"})
   public A inheritPlatformClassPath(boolean inheritPlatformClassPath) {
     this.inheritPlatformClassPath = inheritPlatformClassPath;
     return myself();

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -90,9 +90,15 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
   boolean DEFAULT_INHERIT_MODULE_PATH = true;
 
   /**
-   * Default setting for inclusion of the current platform class path ({@code true}).
+   * Default setting for inclusion of the current platform class path ({@code false}).
+   *
+   * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+   *    should not be used. This will be removed in v1.0.0, and has been changed to default to
+   *    {@code false} as of v0.6.0
    */
-  boolean DEFAULT_INHERIT_PLATFORM_CLASS_PATH = true;
+  @Deprecated(forRemoval = true, since = "0.6.0")
+  @SuppressWarnings("DeprecatedIsStillUsed")
+  boolean DEFAULT_INHERIT_PLATFORM_CLASS_PATH = false;
 
   /**
    * Default setting for inclusion of the system module path ({@code true}).
@@ -727,7 +733,11 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * {@link #DEFAULT_INHERIT_PLATFORM_CLASS_PATH}.
    *
    * @return whether the platform class path is being inherited or not.
+   * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+   * should not be used. This will be removed in v1.0.0.
    */
+  @Deprecated(forRemoval = true, since = "0.6.0")
+  @SuppressWarnings("DeprecatedIsStillUsed")
   boolean isInheritPlatformClassPath();
 
   /**
@@ -740,7 +750,10 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    *
    * @param inheritPlatformClassPath {@code true} to include it, or {@code false} to exclude it.
    * @return this compiler object for further call chaining.
+   * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+   * should not be used. This will be removed in v1.0.0.
    */
+  @Deprecated(forRemoval = true, since = "0.6.0")
   C inheritPlatformClassPath(boolean inheritPlatformClassPath);
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -251,8 +251,12 @@ public interface JctFileManager extends JavaFileManager {
    *
    * @return the location, or {@code null} if the location is not present in the file manager.
    * @since 0.1.0
+   * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+   *    should not be used. This will be removed in v1.0.0.
    */
+  @Deprecated(forRemoval = true, since = "0.6.0")
   @Nullable
+  @SuppressWarnings("DeprecatedIsStillUsed")
   default PackageContainerGroup getPlatformClassPathGroup() {
     return getPackageContainerGroup(StandardLocation.PLATFORM_CLASS_PATH);
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmPlatformClassPathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmPlatformClassPathConfigurer.java
@@ -33,10 +33,14 @@ import org.slf4j.LoggerFactory;
  *
  * @author Ashley Scopes
  * @since 0.0.1 (0.0.1-M7)
+ * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+ * should not be used. This will be removed in v1.0.0.
  */
 @API(since = "0.0.1", status = Status.STABLE)
-public final class JctFileManagerJvmPlatformClassPathConfigurer implements
-    JctFileManagerConfigurer {
+@Deprecated(forRemoval = true, since = "0.6.0")
+@SuppressWarnings("DeprecatedIsStillUsed")
+public final class JctFileManagerJvmPlatformClassPathConfigurer
+    implements JctFileManagerConfigurer {
 
   private static final Logger LOGGER = LoggerFactory
       .getLogger(JctFileManagerJvmPlatformClassPathConfigurer.class);
@@ -53,6 +57,7 @@ public final class JctFileManagerJvmPlatformClassPathConfigurer implements
   }
 
   @Override
+  @SuppressWarnings("removal")
   public JctFileManager configure(JctFileManager fileManager) {
     LOGGER.debug("Configuring JVM platform class path");
 
@@ -69,6 +74,7 @@ public final class JctFileManagerJvmPlatformClassPathConfigurer implements
   }
 
   @Override
+  @SuppressWarnings("removal")
   public boolean isEnabled() {
     return compiler.isInheritPlatformClassPath();
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
@@ -74,6 +74,7 @@ public final class JctFileManagerFactoryImpl implements JctFileManagerFactory {
    * @return the chain to use.
    */
   @VisibleForTestingOnly
+  @SuppressWarnings("removal")
   public JctFileManagerConfigurerChain createConfigurerChain(Workspace workspace) {
     // The order here is important. Do not adjust it without testing extensively first!
     return new JctFileManagerConfigurerChain()

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/SpecialLocationUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/SpecialLocationUtils.java
@@ -121,11 +121,18 @@ public final class SpecialLocationUtils extends UtilityClass {
    *
    * @return a list across the paths.
    */
+  @Deprecated(forRemoval = true, since = "0.6.0")
+  @SuppressWarnings("DeprecatedIsStillUsed")
   public static List<Path> currentPlatformClassPathLocations() {
     var mxBean = ManagementFactory.getRuntimeMXBean();
 
     if (mxBean.isBootClassPathSupported()) {
-      LOGGER.trace("Platform (boot) classpath is supported on this JVM, so will be inspected");
+      LOGGER.warn(
+          "Warning: platform (boot) class path locations were found on this JVM, but this "
+              + "feature is deprecated for removal in v1.0.0 of the java-compiler-testing API. "
+              + "Consider disabling platform classpath discovery explicitly to prevent tests "
+              + "having differing behaviour for v1.0.0."
+      );
       return createPaths(mxBean.getBootClassPath());
     }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
@@ -513,7 +513,11 @@ public interface Workspace extends AutoCloseable {
    * @throws IllegalArgumentException if the path does not exist.
    * @see #addPackage(Location, Path)
    * @see #createPlatformClassPathPackage()
+   * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+   * should not be used. This will be removed in v1.0.0.
    */
+  @Deprecated(forRemoval = true, since = "0.6.0")
+  @SuppressWarnings("DeprecatedIsStillUsed")
   default void addPlatformClassPathPackage(Path path) {
     addPackage(StandardLocation.PLATFORM_CLASS_PATH, path);
   }
@@ -756,7 +760,11 @@ public interface Workspace extends AutoCloseable {
    * @return the created test directory.
    * @see #createPackage(Location)
    * @see #addPlatformClassPathPackage(Path)
+   * @deprecated The platform class path has been mostly replaced by the use of system modules, so
+   * should not be used. This will be removed in v1.0.0.
    */
+  @Deprecated(forRemoval = true, since = "0.6.0")
+  @SuppressWarnings("DeprecatedIsStillUsed")
   default ManagedDirectory createPlatformClassPathPackage() {
     return createPackage(StandardLocation.PLATFORM_CLASS_PATH);
   }
@@ -850,7 +858,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for {@link StandardLocation#CLASS_OUTPUT class outputs}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getClassOutputModules() {
@@ -884,7 +892,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for {@link StandardLocation#SOURCE_OUTPUT source outputs}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getSourceOutputModules() {
@@ -939,7 +947,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#ANNOTATION_PROCESSOR_MODULE_PATH annotation processor module path}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getAnnotationProcessorPathModules() {
@@ -985,7 +993,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#NATIVE_HEADER_OUTPUT native header outputs}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getNativeHeaderOutputModules() {
@@ -1008,7 +1016,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#MODULE_SOURCE_PATH module source paths}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getSourcePathModules() {
@@ -1031,7 +1039,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#UPGRADE_MODULE_PATH upgrade module paths}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getUpgradeModulePathModules() {
@@ -1053,7 +1061,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for the {@link StandardLocation#SYSTEM_MODULES system modules}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getSystemModulePathModules() {
@@ -1075,7 +1083,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for the {@link StandardLocation#MODULE_PATH module paths}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getModulePathModules() {
@@ -1098,7 +1106,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#PATCH_MODULE_PATH patch module paths}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   *     found.
+   * found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getPatchModulePathModules() {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
@@ -285,6 +285,7 @@ class AbstractJctCompilerTest {
 
     @DisplayName("constructor initialises inheritPlatformClassPath to default value")
     @Test
+    @SuppressWarnings("removal")
     void constructorInitialisesInheritPlatformClassPathToDefaultValue() {
       // Then
       assertThatCompilerField("inheritPlatformClassPath")
@@ -1292,6 +1293,7 @@ class AbstractJctCompilerTest {
   @DisplayName(".isInheritPlatformClassPath() returns the expected values")
   @ValueSource(booleans = {true, false})
   @ParameterizedTest(name = "for inheritPlatformClassPath = {0}")
+  @SuppressWarnings("removal")
   void isInheritPlatformClassPathReturnsExpectedValue(boolean expected) {
     // Given
     setFieldOnCompiler("inheritPlatformClassPath", expected);
@@ -1307,6 +1309,7 @@ class AbstractJctCompilerTest {
     @DisplayName(".inheritPlatformClassPath(...) sets the expected values")
     @ValueSource(booleans = {true, false})
     @ParameterizedTest(name = "for inheritPlatformClassPath = {0}")
+    @SuppressWarnings("removal")
     void inheritPlatformClassPathSetsExpectedValue(boolean expected) {
       // When
       compiler.inheritPlatformClassPath(expected);
@@ -1317,6 +1320,7 @@ class AbstractJctCompilerTest {
 
     @DisplayName(".inheritPlatformClassPath(...) returns the compiler")
     @Test
+    @SuppressWarnings("removal")
     void inheritPlatformClassPathReturnsTheCompiler() {
       // When
       var result = compiler.inheritPlatformClassPath(true);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagerTest.java
@@ -152,6 +152,7 @@ class JctFileManagerTest {
   @DisplayName(".getPlatformClassPathGroup() makes the expected call")
   @MethodSource("outputContainerGroupResults")
   @ParameterizedTest(name = "when internal getter returns {0}")
+  @SuppressWarnings("removal")
   void getPlatformClassPathGroupMakesTheExpectedCall(PackageContainerGroup expected) {
     // Given
     when(fileManager.getPlatformClassPathGroup()).thenCallRealMethod();

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmPlatformClassPathConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmPlatformClassPathConfigurerTest.java
@@ -47,6 +47,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  */
 @DisplayName("JctFileManagerJvmPlatformClassPathConfigurer tests")
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("removal")
 class JctFileManagerJvmPlatformClassPathConfigurerTest {
 
   @Mock

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerFactoryImplTest.java
@@ -119,6 +119,7 @@ class JctFileManagerFactoryImplTest {
 
   @DisplayName("The configurer chain uses the expected configurers")
   @Test
+  @SuppressWarnings("removal")
   void createdFileManagersAreReturnedAsTheResultFromTheConfigurerChain() {
     // When
     var configurerChain = factory.createConfigurerChain(workspace);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/SpecialLocationsUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/SpecialLocationsUtilsTest.java
@@ -140,6 +140,7 @@ class SpecialLocationsUtilsTest implements UtilityClassTestTemplate {
 
   @DisplayName("currentPlatformClassPathLocations() returns the class path locations that exist")
   @Test
+  @SuppressWarnings("removal")
   void currentPlatformClassPathLocationsReturnsTheClassPathLocationsThatExist() throws IOException {
     // Given
     try (
@@ -163,6 +164,7 @@ class SpecialLocationsUtilsTest implements UtilityClassTestTemplate {
 
   @DisplayName("currentPlatformClassPathLocations() returns empty when boot path not supported")
   @Test
+  @SuppressWarnings("removal")
   void currentPlatformClassPathLocationsReturnsEmptyWhenBootPathNotSupported() {
     // Given
     try (var mx = new MockedMxBean<>(ManagementFactory::getRuntimeMXBean, RuntimeMXBean.class)) {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
@@ -215,6 +215,7 @@ class WorkspaceTest {
 
   @DisplayName(".addPlatformClassPathPackage(Path) calls addPackage(PLATFORM_CLASS_PATH, Path)")
   @Test
+  @SuppressWarnings("removal")
   void addPlatformClassPathPackageCallsAddPackage() {
     // Given
     doCallRealMethod().when(workspace).addPlatformClassPathPackage(any());
@@ -470,6 +471,7 @@ class WorkspaceTest {
 
   @DisplayName(".createPlatformClassPathPackage() calls createPackage(PLATFORM_CLASS_PATH)")
   @Test
+  @SuppressWarnings("removal")
   void createPlatformClassPathPackageCallsCreatePackage() {
     // Given
     doCallRealMethod().when(workspace).createPlatformClassPathPackage();


### PR DESCRIPTION
Platform class path functionality in the JVM was historically used before JPMS introduced system modules for the standard library. In lieu of that, the platform class path functionality is mostly deprecated, and has been reported to not work nicely in tests. Therefore, I am deprecating this with immediate effect for removal in v1.0.0.

Closes GH-396.