### PR TITLE
Run JaCoCo on Java 20 builds

### DIFF
--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -156,23 +156,4 @@
       </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <id>coverage</id>
-      <activation>
-        <!-- JDK-20 EA does not support JaCoCo yet due to the use of ASM -->
-        <jdk>[,20)</jdk>
-      </activation>
-
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
 
     <!-- Plugins -->
     <gmaven-plugin.version>2.1.0</gmaven-plugin.version>
-    <jacoco-maven-plugin.version>0.8.8</jacoco-maven-plugin.version>
+    <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
     <license-maven-plugin.version>4.2</license-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.2.1</maven-checkstyle-plugin.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>


### PR DESCRIPTION
- Update JaCoCo from 0.8.8 to 0.8.9
    - Supports Java 20 bytecode
- Enable JaCoCo on Java 20 builds