### PR TITLE
Only allow deployments to Maven central from the main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,10 +18,10 @@ on:
         default: ""
         type: string
 
-
 jobs:
   maven-central:
-    name: Build and deploy code
+    name: Deploy to Maven Central
+    environment: maven-central
     runs-on: ubuntu-22.04
 
     permissions:


### PR DESCRIPTION
This uses an environment for the main branch now to prevent allowing deployments on non-main branches (configured in GitHub  repo settings)