### PR TITLE
Add workaround for IDEA-317391 failing junit tests

### DIFF
--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -42,6 +42,9 @@
       --add-opens=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
       --add-opens=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
       --add-opens=jdk.compiler/com.sun.source.util=ALL-UNNAMED
+
+      <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391 -->
+      -DmvnArgLinePropagated=true
     </argLine>
     <checkerframework.version>3.32.0</checkerframework.version>
   </properties>

--- a/acceptance-tests/acceptance-tests-checkerframework/src/test/groovy/io/github/ascopes/jct/acceptancetests/checkerframework/CheckerNullTest.groovy
+++ b/acceptance-tests/acceptance-tests-checkerframework/src/test/groovy/io/github/ascopes/jct/acceptancetests/checkerframework/CheckerNullTest.groovy
@@ -31,8 +31,13 @@ class CheckerNullTest {
 
   @BeforeEach
   void setUp() {
+    // Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391
+    assumeThat(System.getProperty("mvnArgLinePropagated", "false"))
+        .withFailMessage("Your IDE has not propagated the <argLine/> in the pom.xml")
+        .isEqualTo("true");
+
     assumeThat(JRE.currentVersion())
-        .as("Checkerframework may misbehave on this JVM, so has been disabled")
+        .withFailMessage("Checkerframework may misbehave on this JVM, so has been disabled")
         .isIn(JRE.JAVA_16, JRE.JAVA_17, JRE.JAVA_18, JRE.JAVA_19, JRE.JAVA_20)
   }
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -45,6 +45,9 @@
       --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
       --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
       --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
+
+      <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391 -->
+      -DmvnArgLinePropagated=true
     </argLine>
 
     <error-prone.version>2.18.0</error-prone.version>

--- a/acceptance-tests/acceptance-tests-error-prone/src/test/groovy/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.groovy
+++ b/acceptance-tests/acceptance-tests-error-prone/src/test/groovy/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.groovy
@@ -18,12 +18,22 @@ package io.github.ascopes.jct.acceptancetests.errorprone
 import io.github.ascopes.jct.compilers.JctCompiler
 import io.github.ascopes.jct.junit.JavacCompilerTest
 import io.github.ascopes.jct.workspaces.Workspaces
+import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 
 import static io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilation
+import static org.assertj.core.api.Assumptions.assumeThat
 
 @DisplayName("Error-prone acceptance tests")
 class ErrorProneTest {
+
+  @BeforeAll
+  static void workAroundIdea317391() {
+    // Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391
+    assumeThat(System.getProperty("mvnArgLinePropagated", "false"))
+            .withFailMessage("Your IDE has not propagated the <argLine/> in the pom.xml")
+            .isEqualTo("true");
+  }
 
   @DisplayName("Happy paths work as expected")
   @JavacCompilerTest


### PR DESCRIPTION
Create a workaround to avoid failing tests when running multiple Maven modules at once. This can be removed once https://youtrack.jetbrains.com/issue/IDEA-317391 is fixed.