### PR TITLE
GH-419: Deprecate RamFileSystemProvider for removal.

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
@@ -51,13 +51,6 @@ public enum PathStrategy {
    *
    * <p>Some non-Javac compiler implementations (such as ECJ) may also have some difficulties
    * dealing with these paths.
-   *
-   * The actual implementation used internally will be the first {@link RamFileSystemProvider} that
-   * is present when querying that interface with the Java 
-   * {@link java.util.ServiceLoader Service Loader mechanism}. By default, if no custom implementation
-   * is provided by the user, then an internal implementation is used. This internal implementation is
-   * subject to change at any time (as long as the change is non-breaking), but currently uses
-   * {@link com.google.common.jimfs.Jimfs Google's JIMFS}.
    */
   RAM_DIRECTORIES(RamDirectoryImpl::newRamDirectory),
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/RamFileSystemProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/RamFileSystemProvider.java
@@ -29,8 +29,11 @@ import org.apiguardian.api.API.Status;
  *
  * @author Ashley Scopes
  * @since 0.0.1 (0.0.1-M9)
+ * @deprecated this feature should never be needed by users of this library, and so has been
+ * deprecated for removal in v1.0.0.
  */
 @API(since = "0.0.1", status = Status.STABLE)
+@Deprecated(since = "0.6.0", forRemoval = true)
 public interface RamFileSystemProvider {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/JimfsFileSystemProviderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/JimfsFileSystemProviderImpl.java
@@ -31,6 +31,7 @@ import org.apiguardian.api.API.Status;
  * @since 0.0.1 (0.0.1-M9)
  */
 @API(since = "0.0.1", status = Status.INTERNAL)
+@SuppressWarnings("removal")
 public final class JimfsFileSystemProviderImpl implements RamFileSystemProvider {
 
   // We could initialise this lazily, but this class has fewer fields and initialisation

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
@@ -18,7 +18,6 @@ package io.github.ascopes.jct.workspaces.impl;
 import static io.github.ascopes.jct.utils.FileUtils.assertValidRootName;
 import static io.github.ascopes.jct.utils.IoExceptionUtils.uncheckedIo;
 
-import io.github.ascopes.jct.workspaces.RamFileSystemProvider;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
@@ -88,7 +87,7 @@ public final class RamDirectoryImpl extends AbstractManagedDirectory {
 
     assertValidRootName(name);
 
-    var fileSystem = RamFileSystemProvider.getInstance().createFileSystem(name);
+    var fileSystem = JimfsFileSystemProviderImpl.getInstance().createFileSystem(name);
     var path = fileSystem.getRootDirectories().iterator().next().resolve(name);
 
     // Ensure the base directory exists.

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -89,6 +89,7 @@ import org.junit.jupiter.api.extension.Extension;
  *    }
  * </code></pre>
  */
+@SuppressWarnings("removal")
 module io.github.ascopes.jct {
 
   ////////////////////

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/RamFileSystemProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/RamFileSystemProviderTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.parallel.Isolated;
  */
 @DisplayName("RamFileSystemProvider tests")
 @Isolated("messes with global ServiceLoader")
-@SuppressWarnings("Java9UndeclaredServiceUsage")
+@SuppressWarnings({"Java9UndeclaredServiceUsage", "removal"})
 class RamFileSystemProviderTest {
 
   @DisplayName(".getInstance() returns the first service provider instance if present")


### PR DESCRIPTION
RamFileSystemProvider realistically is not something we will ever expect the user to be making any use of, so can be safely deprecated and then removed on the v1.0.0 branch.