### PR TITLE
Replace JIMFS with MemoryFileSystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ testing anything related to the Java compiler. This includes Javac plugins and J
 processors.
 
 All test cases are designed to be as stateless as possible, with facilities to produce
-in-memory file systems (using Google's JIMFS API) or using OS-provided temporary directories.
+in-memory file systems or using OS-provided temporary directories.
 All file system mechanisms are complimented with a fluent API that enables writing expressive
 declarations without unnecessary boilerplate.
 

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>0.6.5-SNAPSHOT</version>
+    <version>0.7.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -40,8 +40,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.jimfs</groupId>
-      <artifactId>jimfs</artifactId>
+      <groupId>com.github.marschall</groupId>
+      <artifactId>memoryfilesystem</artifactId>
     </dependency>
 
     <dependency>

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
@@ -20,8 +20,12 @@ import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.Locale;
+import java.util.stream.Stream;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+
+import static io.github.ascopes.jct.utils.IoExceptionUtils.uncheckedIo;
 
 /**
  * An extension of the Java {@link URLClassLoader} that wraps around container groups.
@@ -50,6 +54,25 @@ public final class PackageContainerGroupUrlClassLoader extends URLClassLoader {
         .stream()
         .map(Container::getPathRoot)
         .map(PathRoot::getUrl)
+        .map(PackageContainerGroupUrlClassLoader::fixMemoryFileSystemUrls)
         .toArray(URL[]::new);
+  }
+
+  // This can be removed once https://github.com/marschall/memoryfilesystem/pull/145/files is
+  // addressed.
+  private static URL fixMemoryFileSystemUrls(URL url) {
+    if (url.getPath().endsWith("/") || isProbablyArchive(url)) {
+      return url;
+    }
+
+    return uncheckedIo(() -> new URL(
+        url.getProtocol(), url.getHost(), url.getPort(), url.getFile() + "/"
+    ));
+  }
+
+  private static boolean isProbablyArchive(URL url) {
+    return Stream
+        .of(".jar", ".war", ".ear", ".zip")
+        .anyMatch(url.getFile().toLowerCase(Locale.ROOT)::endsWith);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/RamFileSystemProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/RamFileSystemProvider.java
@@ -15,7 +15,7 @@
  */
 package io.github.ascopes.jct.workspaces;
 
-import io.github.ascopes.jct.workspaces.impl.JimfsFileSystemProviderImpl;
+import io.github.ascopes.jct.workspaces.impl.MemoryFileSystemProvider;
 import java.nio.file.FileSystem;
 import java.util.ServiceLoader;
 import org.apiguardian.api.API;
@@ -53,6 +53,6 @@ public interface RamFileSystemProvider {
     return ServiceLoader
         .load(RamFileSystemProvider.class)
         .findFirst()
-        .orElseGet(JimfsFileSystemProviderImpl::getInstance);
+        .orElseGet(MemoryFileSystemProvider::getInstance);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
@@ -174,7 +174,7 @@ public final class FileBuilderImpl implements FileBuilder {
 
     switch (scheme) {
       case "classpath":
-      case "jimfs":
+      case "memory":
       case "jrt":
       case "ram":
         return input;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/JimfsFileSystemProviderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/JimfsFileSystemProviderImpl.java
@@ -15,11 +15,11 @@
  */
 package io.github.ascopes.jct.workspaces.impl;
 
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Feature;
-import com.google.common.jimfs.Jimfs;
-import com.google.common.jimfs.PathType;
+import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
 import io.github.ascopes.jct.workspaces.RamFileSystemProvider;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -55,20 +55,12 @@ public final class JimfsFileSystemProviderImpl implements RamFileSystemProvider 
 
   @Override
   public FileSystem createFileSystem(String name) {
-    var config = Configuration
-        .builder(PathType.unix())
-        .setSupportedFeatures(
-            Feature.LINKS,
-            Feature.SYMBOLIC_LINKS,
-            Feature.FILE_CHANNEL,
-            Feature.SECURE_DIRECTORY_STREAM
-        )
-        .setAttributeViews("basic", "posix")
-        .setRoots("/")
-        .setWorkingDirectory("/")
-        .setPathEqualityUsesCanonicalForm(true)
-        .build();
-
-    return Jimfs.newFileSystem(config);
+    try {
+      return MemoryFileSystemBuilder.newLinux()
+          .setCurrentWorkingDirectory("/")
+          .build(name);
+    } catch (IOException e) {
+      throw new UncheckedIOException("could not create file system with name: " + name, e);
+    }
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
@@ -17,7 +17,6 @@ package io.github.ascopes.jct.workspaces.impl;
 
 import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
 import io.github.ascopes.jct.workspaces.RamFileSystemProvider;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileSystem;
@@ -25,31 +24,32 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 /**
- * RAM file system provider that uses JIMFS as the underlying file system implementation.
+ * RAM file system provider that uses {@code memoryfilesystem} as the underlying file system
+ * implementation.
  *
- * @author Ashley Scopes
- * @since 0.0.1
+ * @author Ashley Scopes, Philippe Marschall
+ * @since 0.7.0
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
+@API(since = "0.7.0", status = Status.INTERNAL)
 @SuppressWarnings("removal")
-public final class JimfsFileSystemProviderImpl implements RamFileSystemProvider {
+public final class MemoryFileSystemProvider implements RamFileSystemProvider {
 
   // We could initialise this lazily, but this class has fewer fields and initialisation
   // overhead than a lazy-loaded object would, so it doesn't really make sense to do it
   // here.
-  private static final JimfsFileSystemProviderImpl INSTANCE
-      = new JimfsFileSystemProviderImpl();
+  private static final MemoryFileSystemProvider INSTANCE
+      = new MemoryFileSystemProvider();
 
   /**
    * Get the singleton instance of this provider.
    *
    * @return the singleton instance.
    */
-  public static JimfsFileSystemProviderImpl getInstance() {
+  public static MemoryFileSystemProvider getInstance() {
     return INSTANCE;
   }
 
-  private JimfsFileSystemProviderImpl() {
+  private MemoryFileSystemProvider() {
     // Singleton object.
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
@@ -87,8 +88,11 @@ public final class RamDirectoryImpl extends AbstractManagedDirectory {
 
     assertValidRootName(name);
 
-    var fileSystem = MemoryFileSystemProvider.getInstance().createFileSystem(name);
-    var path = fileSystem.getRootDirectories().iterator().next().resolve(name);
+    // MemoryFileSystem needs unique FS names to work correctly, so use a UUID to enforce this.
+
+    var uniqueName = name + ":" + UUID.randomUUID();
+    var fileSystem = MemoryFileSystemProvider.getInstance().createFileSystem(uniqueName);
+    var path = fileSystem.getRootDirectories().iterator().next().resolve(uniqueName);
 
     // Ensure the base directory exists.
     uncheckedIo(() -> Files.createDirectories(path));

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
@@ -87,7 +87,7 @@ public final class RamDirectoryImpl extends AbstractManagedDirectory {
 
     assertValidRootName(name);
 
-    var fileSystem = JimfsFileSystemProviderImpl.getInstance().createFileSystem(name);
+    var fileSystem = MemoryFileSystemProvider.getInstance().createFileSystem(name);
     var path = fileSystem.getRootDirectories().iterator().next().resolve(name);
 
     // Ensure the base directory exists.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
@@ -90,7 +90,7 @@ public final class RamDirectoryImpl extends AbstractManagedDirectory {
 
     // MemoryFileSystem needs unique FS names to work correctly, so use a UUID to enforce this.
 
-    var uniqueName = name + ":" + UUID.randomUUID();
+    var uniqueName = name + "-" + UUID.randomUUID();
     var fileSystem = MemoryFileSystemProvider.getInstance().createFileSystem(uniqueName);
     var path = fileSystem.getRootDirectories().iterator().next().resolve(uniqueName);
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import javax.tools.JavaFileManager.Location;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -103,9 +103,9 @@ module io.github.ascopes.jct {
   /// DEPENDENCIES ///
   ////////////////////
 
+  requires com.github.marschall.memoryfilesystem;
   requires java.compiler;
   requires java.management;
-  requires com.github.marschall.memoryfilesystem;
   requires me.xdrop.fuzzywuzzy;
   requires static transitive org.apiguardian.api;
   requires org.assertj.core;

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -15,7 +15,9 @@
  */
 import io.github.ascopes.jct.junit.JctExtension;
 import io.github.ascopes.jct.workspaces.RamFileSystemProvider;
+import io.github.ascopes.jct.workspaces.impl.MemoryFileSystemProvider.MemoryFileSystemUrlHandlerProvider;
 import org.junit.jupiter.api.extension.Extension;
+import java.net.spi.URLStreamHandlerProvider;
 
 /**
  * A framework for performing exhaustive integration testing against Java compilers in modern Java
@@ -133,7 +135,7 @@ module io.github.ascopes.jct {
   /// SERVICE PROVIDER INTERFACES ///
   ///////////////////////////////////
 
-  provides Extension with JctExtension;
+  provides URLStreamHandlerProvider with MemoryFileSystemUrlHandlerProvider;
   uses RamFileSystemProvider;
 
   //////////////////////////////////////////////////////

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -105,7 +105,7 @@ module io.github.ascopes.jct {
 
   requires java.compiler;
   requires java.management;
-  requires jimfs;
+  requires com.github.marschall.memoryfilesystem;
   requires me.xdrop.fuzzywuzzy;
   requires static transitive org.apiguardian.api;
   requires org.assertj.core;

--- a/java-compiler-testing/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
+++ b/java-compiler-testing/src/main/resources/META-INF/services/java.net.spi.URLStreamHandlerProvider
@@ -1,0 +1,3 @@
+# For some reason this is not detected correctly if we use the JPMS mechanism to deal with this
+# file. We fall back to the old mechanism instead to avoid this problem.
+io.github.ascopes.jct.workspaces.impl.MemoryFileSystemProvider$MemoryFileSystemUrlHandlerProvider

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
@@ -22,14 +22,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
-import com.google.common.jimfs.Configuration;
-import com.google.common.jimfs.Feature;
-import com.google.common.jimfs.Jimfs;
-import com.google.common.jimfs.PathType;
+import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
 import io.github.ascopes.jct.diagnostics.TraceDiagnostic;
 import io.github.ascopes.jct.utils.LoomPolyfill;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystem;
@@ -502,15 +500,14 @@ public final class Fixtures {
     private TempFileSystem() {
       // Default to UNIX to keep behaviour consistent.
       var name = someText();
-      var config = Configuration
-          .builder(PathType.unix())
-          .setSupportedFeatures(Feature.LINKS, Feature.SYMBOLIC_LINKS, Feature.FILE_CHANNEL)
-          .setAttributeViews("basic", "posix")
-          .setRoots("/")
-          .setWorkingDirectory("/")
-          .build();
 
-      fs = Jimfs.newFileSystem(name, config);
+      try {
+        fs = MemoryFileSystemBuilder.newLinux()
+            .setCurrentWorkingDirectory("/")
+            .build(name);
+      } catch (IOException e) {
+        throw new UncheckedIOException("could not create file system with name: " + name, e);
+      }
       root = fs.getRootDirectories().iterator().next();
 
       try {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
@@ -86,7 +86,7 @@ class FileUtilsTest implements UtilityClassTestTemplate {
           .isNotNull()
           .isEqualTo(file.toUri().toURL())
           .asString()
-          .startsWith(fs.getScheme() + "://");
+          .startsWith(fs.getScheme() + ":");
     }
   }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/RamFileSystemProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/RamFileSystemProviderTest.java
@@ -23,7 +23,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.github.ascopes.jct.workspaces.RamFileSystemProvider;
-import io.github.ascopes.jct.workspaces.impl.JimfsFileSystemProviderImpl;
+import io.github.ascopes.jct.workspaces.impl.MemoryFileSystemProvider;
 import java.util.Optional;
 import java.util.ServiceLoader;
 import org.junit.jupiter.api.DisplayName;
@@ -99,6 +99,6 @@ class RamFileSystemProviderTest {
     // AssertJ needs to use service loaders internally, so we cannot keep it mocked for
     // any longer than needed.
     assertThat(result)
-        .isSameAs(JimfsFileSystemProviderImpl.getInstance());
+        .isSameAs(MemoryFileSystemProvider.getInstance());
   }
 }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/JarFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/JarFactoryImplTest.java
@@ -15,23 +15,21 @@
  */
 package io.github.ascopes.jct.tests.unit.workspaces.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
-
 import io.github.ascopes.jct.tests.helpers.Fixtures;
 import io.github.ascopes.jct.workspaces.impl.JarFactoryImpl;
-import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.Map;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 /**
  * {@link JarFactoryImpl} tests.
@@ -73,13 +71,14 @@ class JarFactoryImplTest {
       // Then
       assertThatThrownBy(() -> JarFactoryImpl.getInstance().createJarFrom(jarTarget, classesDir))
           .isInstanceOf(NoSuchFileException.class)
-          .hasMessage("/some-non-existent-directory/HelloWorld.jar");
+          .message()
+          .startsWith("/some-non-existent-directory");
     }
   }
 
   @DisplayName("An exception is raised if the input directory does not exist")
   @Test
-  void exceptionRaisedIfInputDirectoryDoesNotExist() throws IOException {
+  void exceptionRaisedIfInputDirectoryDoesNotExist() {
     // Given
     try (var fs = Fixtures.someTemporaryFileSystem()) {
       var classesDir = fs.getRootPath().resolve("target").resolve("classes");

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/JimfsFileSystemProviderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/JimfsFileSystemProviderImplTest.java
@@ -15,7 +15,6 @@
  */
 package io.github.ascopes.jct.tests.unit.workspaces.impl;
 
-
 import static io.github.ascopes.jct.tests.helpers.Fixtures.someText;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +30,7 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -68,7 +68,7 @@ class JimfsFileSystemProviderImplTest {
       // Then
       assertThat(fileSystem.getClass().getSimpleName())
           .as("file system implementation class")
-          .isEqualTo("JimfsFileSystem");
+          .isEqualTo("MemoryFileSystem");
       assertThat(fileSystem.getRootDirectories())
           .as("file system root directories")
           .hasSize(1);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/MemoryFileSystemProviderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/MemoryFileSystemProviderImplTest.java
@@ -25,7 +25,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SecureDirectoryStream;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
@@ -162,7 +161,6 @@ class MemoryFileSystemProviderImplTest {
       var dirs = new ArrayList<Path>();
 
       try (var dirStream = Files.newDirectoryStream(root)) {
-        assertThat(dirStream).isInstanceOf(SecureDirectoryStream.class);
         dirStream.forEach(dirs::add);
       }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/MemoryFileSystemProviderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/MemoryFileSystemProviderImplTest.java
@@ -18,7 +18,7 @@ package io.github.ascopes.jct.tests.unit.workspaces.impl;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.someText;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.github.ascopes.jct.workspaces.impl.JimfsFileSystemProviderImpl;
+import io.github.ascopes.jct.workspaces.impl.MemoryFileSystemProvider;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -30,39 +30,38 @@ import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 
 /**
- * {@link JimfsFileSystemProviderImpl} tests.
+ * {@link MemoryFileSystemProvider} tests.
  *
  * @author Ashley Scopes
  */
-@DisplayName("JimfsFileSystemProviderImpl tests")
-class JimfsFileSystemProviderImplTest {
+@DisplayName("MemoryFileSystemProviderImpl tests")
+class MemoryFileSystemProviderImplTest {
 
   @DisplayName("The class is a singleton")
   @Test
   void theClassIsSingleton() {
     // When
     var instances = Stream
-        .generate(JimfsFileSystemProviderImpl::getInstance)
+        .generate(MemoryFileSystemProvider::getInstance)
         .limit(10)
         .collect(Collectors.toList());
 
     // Then
     assertThat(instances)
         .withFailMessage("One or more calls provided a different object")
-        .allMatch(JimfsFileSystemProviderImpl.getInstance()::equals);
+        .allMatch(MemoryFileSystemProvider.getInstance()::equals);
   }
 
   @DisplayName("The provider will create a JIMFS file system")
   @Test
   void theProviderWillCreateJimfsFileSystem() throws IOException {
     // When
-    var instance = JimfsFileSystemProviderImpl.getInstance();
+    var instance = MemoryFileSystemProvider.getInstance();
     var fsName = someText();
     try (var fileSystem = instance.createFileSystem(fsName)) {
       // Then
@@ -79,7 +78,7 @@ class JimfsFileSystemProviderImplTest {
   @Test
   void theCreatedFileSystemSupportsHardLinks() throws IOException {
     // Given
-    var instance = JimfsFileSystemProviderImpl.getInstance();
+    var instance = MemoryFileSystemProvider.getInstance();
     var fsName = someText();
     try (var fileSystem = instance.createFileSystem(fsName)) {
       var root = fileSystem.getRootDirectories().iterator().next();
@@ -102,7 +101,7 @@ class JimfsFileSystemProviderImplTest {
   @Test
   void theCreatedFileSystemSupportsSymbolicLinks() throws IOException {
     // Given
-    var instance = JimfsFileSystemProviderImpl.getInstance();
+    var instance = MemoryFileSystemProvider.getInstance();
     var fsName = someText();
     try (var fileSystem = instance.createFileSystem(fsName)) {
       var root = fileSystem.getRootDirectories().iterator().next();
@@ -125,7 +124,7 @@ class JimfsFileSystemProviderImplTest {
   @Test
   void theCreatedFileSystemSupportsFileChannels() throws IOException {
     // Given
-    var instance = JimfsFileSystemProviderImpl.getInstance();
+    var instance = MemoryFileSystemProvider.getInstance();
     var fsName = someText();
     try (var fileSystem = instance.createFileSystem(fsName)) {
       var root = fileSystem.getRootDirectories().iterator().next();
@@ -152,7 +151,7 @@ class JimfsFileSystemProviderImplTest {
   @Test
   void theCreatedFileSystemSupportsDirectoryStreams() throws IOException {
     // Given
-    var instance = JimfsFileSystemProviderImpl.getInstance();
+    var instance = MemoryFileSystemProvider.getInstance();
     var fsName = someText();
     try (var fileSystem = instance.createFileSystem(fsName)) {
       var root = fileSystem.getRootDirectories().iterator().next();
@@ -177,7 +176,7 @@ class JimfsFileSystemProviderImplTest {
   @Test
   void theCreatedFileSystemSupportsUrls() throws IOException {
     // Given
-    var instance = JimfsFileSystemProviderImpl.getInstance();
+    var instance = MemoryFileSystemProvider.getInstance();
     var fsName = someText();
     try (var fileSystem = instance.createFileSystem(fsName)) {
       var root = fileSystem.getRootDirectories().iterator().next();

--- a/java-compiler-testing/src/test/java/module-info.java
+++ b/java-compiler-testing/src/test/java/module-info.java
@@ -34,4 +34,7 @@ open module io.github.ascopes.jct.testing {
   requires org.mockito;
   requires org.mockito.junit.jupiter;
   requires org.slf4j;
+
+  // Used for MemoryFileSystemProviderImplTest$MemoryFileSystemUrlHandlerProviderTest
+  uses java.net.spi.URLStreamHandlerProvider;
 }

--- a/java-compiler-testing/src/test/java/module-info.java
+++ b/java-compiler-testing/src/test/java/module-info.java
@@ -18,7 +18,7 @@ open module io.github.ascopes.jct.testing {
   requires transitive io.github.ascopes.jct;
   requires java.compiler;
   requires java.management;
-  requires jimfs;
+  requires com.github.marschall.memoryfilesystem;
   requires me.xdrop.fuzzywuzzy;
   requires net.bytebuddy;         // required for mockito to work with JPMS.
   requires net.bytebuddy.agent;   // required for mockito to work with JPMS.

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <fuzzywuzzy.version>1.4.0</fuzzywuzzy.version>
     <groovy.version>4.0.11</groovy.version>
-    <jimfs.version>1.2</jimfs.version>
+    <memoryfilesystem.version>2.6.0-SNAPSHOT</memoryfilesystem.version>
     <jspecify.version>0.3.0</jspecify.version>
     <junit.version>5.9.3</junit.version>
     <mockito.version>5.3.1</mockito.version>
@@ -172,9 +172,9 @@
     <dependencies>
       <dependency>
         <!-- In-memory file system -->
-        <groupId>com.google.jimfs</groupId>
-        <artifactId>jimfs</artifactId>
-        <version>${jimfs.version}</version>
+        <groupId>com.github.marschall</groupId>
+        <artifactId>memoryfilesystem</artifactId>
+        <version>${memoryfilesystem.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -136,12 +136,22 @@
       coverage agent is installed into the forked JVM running the tests. See
       https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html for info.
 
-      We also disable code sharing to prevent some other warnings during test runs.
+      We also disable code sharing to prevent some other warnings during test runs, and
+      force the SLF4J simple logger defaults to use in tests here.
+
+      URL support for the memory filesystem requires enablement by system property.
 
       Tired compilation is modified to reduce the amount of time the JVM wastes JITing
       code during tests.
+
+      Byte Buddy experimental support enables running ByteBuddy (used by Mockito) in JDK
+      experimental builds.
     -->
     <argLine>
+      -Dnet.bytebuddy.experimental=true
+      -Dorg.slf4j.simpleLogger.log=INFO
+      -Dorg.slf4j.simpleLogger.log.io.github.ascopes.jct=TRACE
+      -Djava.protocol.handler.pkgs=com.github.marschall.memoryfilesystem
       -Xshare:off
       -XX:+TieredCompilation
       -XX:TieredStopAtLevel=1
@@ -287,26 +297,6 @@
             <failIfNoTests>true</failIfNoTests>
             <runOrder>random</runOrder>
             <useModulePath>true</useModulePath>
-            
-            <systemPropertyVariables>
-
-              <!--
-                Byte Buddy experimental support enables running ByteBuddy (used by Mockito) in JDK
-                experimental builds.
-              -->
-              <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
-
-              <!--
-                We also force the SLF4J simple logger defaults to use in tests here.
-              -->
-              <org.slf4j.simpleLogger.log>INFO</org.slf4j.simpleLogger.log>
-              <org.slf4j.simpleLogger.log.io.github.ascopes.jct>TRACE</org.slf4j.simpleLogger.log.io.github.ascopes.jct>
-
-              <!--
-                Enable URL support for memoryfilesystem.
-              -->
-              <java.protocol.handler.pkgs>com.github.marschall.memoryfilesystem</java.protocol.handler.pkgs>
-            </systemPropertyVariables>
 
             <!--
               This block is needed to show @DisplayName and @ParameterizedTest

--- a/pom.xml
+++ b/pom.xml
@@ -132,23 +132,16 @@
     <hide-test-logs-in-console>true</hide-test-logs-in-console>
 
     <!--
-      This argument is pulled in by Surefire, and JaCoCo will amend it to ensure the
+      This argument is pulled in by Failsafe, and JaCoCo will amend it to ensure the
       coverage agent is installed into the forked JVM running the tests. See
       https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html for info.
 
-      We also disable code sharing to prevent some other warnings during test runs, and
-      force the SLF4J simple logger defaults to use in tests here.
+      We also disable code sharing to prevent some other warnings during test runs.
 
       Tired compilation is modified to reduce the amount of time the JVM wastes JITing
       code during tests.
-
-      Byte Buddy experimental support enables running ByteBuddy (used by Mockito) in JDK
-      experimental builds.
     -->
     <argLine>
-      -Dnet.bytebuddy.experimental=true
-      -Dorg.slf4j.simpleLogger.log=INFO
-      -Dorg.slf4j.simpleLogger.log.io.github.ascopes.jct=TRACE
       -Xshare:off
       -XX:+TieredCompilation
       -XX:TieredStopAtLevel=1
@@ -294,6 +287,26 @@
             <failIfNoTests>true</failIfNoTests>
             <runOrder>random</runOrder>
             <useModulePath>true</useModulePath>
+            
+            <systemPropertyVariables>
+
+              <!--
+                Byte Buddy experimental support enables running ByteBuddy (used by Mockito) in JDK
+                experimental builds.
+              -->
+              <net.bytebuddy.experimental>true</net.bytebuddy.experimental>
+
+              <!--
+                We also force the SLF4J simple logger defaults to use in tests here.
+              -->
+              <org.slf4j.simpleLogger.log>INFO</org.slf4j.simpleLogger.log>
+              <org.slf4j.simpleLogger.log.io.github.ascopes.jct>TRACE</org.slf4j.simpleLogger.log.io.github.ascopes.jct>
+
+              <!--
+                Enable URL support for memoryfilesystem.
+              -->
+              <java.protocol.handler.pkgs>com.github.marschall.memoryfilesystem</java.protocol.handler.pkgs>
+            </systemPropertyVariables>
 
             <!--
               This block is needed to show @DisplayName and @ParameterizedTest

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,6 @@
       -Dnet.bytebuddy.experimental=true
       -Dorg.slf4j.simpleLogger.log=INFO
       -Dorg.slf4j.simpleLogger.log.io.github.ascopes.jct=TRACE
-      -Djava.protocol.handler.pkgs=com.github.marschall.memoryfilesystem
       -Xshare:off
       -XX:+TieredCompilation
       -XX:TieredStopAtLevel=1

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>0.6.5-SNAPSHOT</version>
+  <version>0.7.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <fuzzywuzzy.version>1.4.0</fuzzywuzzy.version>
     <groovy.version>4.0.11</groovy.version>
-    <memoryfilesystem.version>2.6.0-SNAPSHOT</memoryfilesystem.version>
+    <memoryfilesystem.version>2.6.0</memoryfilesystem.version>
     <jspecify.version>0.3.0</jspecify.version>
     <junit.version>5.9.3</junit.version>
     <mockito.version>5.3.1</mockito.version>


### PR DESCRIPTION
Closes GH-311, swapping out JIMFS with MemoryFileSystem as the RAM file-system provider implementation internally.