### PR TITLE
Update memoyfilesystem with URL handling bugfixes

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
@@ -20,8 +20,6 @@ import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.util.Locale;
-import java.util.stream.Stream;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -54,25 +52,6 @@ public final class PackageContainerGroupUrlClassLoader extends URLClassLoader {
         .stream()
         .map(Container::getPathRoot)
         .map(PathRoot::getUrl)
-        .map(PackageContainerGroupUrlClassLoader::fixMemoryFileSystemUrls)
         .toArray(URL[]::new);
-  }
-
-  // This can be removed once https://github.com/marschall/memoryfilesystem/pull/145/files is
-  // addressed.
-  private static URL fixMemoryFileSystemUrls(URL url) {
-    if (url.getPath().endsWith("/") || isProbablyArchive(url)) {
-      return url;
-    }
-
-    return uncheckedIo(() -> new URL(
-        url.getProtocol(), url.getHost(), url.getPort(), url.getFile() + "/"
-    ));
-  }
-
-  private static boolean isProbablyArchive(URL url) {
-    return Stream
-        .of(".jar", ".war", ".ear", ".zip")
-        .anyMatch(url.getFile().toLowerCase(Locale.ROOT)::endsWith);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
@@ -91,11 +91,7 @@ public final class MemoryFileSystemProvider implements RamFileSystemProvider {
 
     @Override
     public URLStreamHandler createURLStreamHandler(String protocol) {
-      // This check can be removed once https://github.com/marschall/memoryfilesystem/pull/144 is
-      // addressed.
-      return com.github.marschall.memoryfilesystem.MemoryFileSystemProvider.SCHEME.equals(protocol)
-          ? factory.createURLStreamHandler(protocol)
-          : null;
+      return factory.createURLStreamHandler(protocol);
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
     <awaitility.version>4.2.0</awaitility.version>
     <fuzzywuzzy.version>1.4.0</fuzzywuzzy.version>
     <groovy.version>4.0.12</groovy.version>
-    <memoryfilesystem.version>2.6.0</memoryfilesystem.version>
+    <memoryfilesystem.version>2.6.1</memoryfilesystem.version>
     <jspecify.version>0.3.0</jspecify.version>
     <junit.version>5.9.3</junit.version>
     <mockito.version>5.3.1</mockito.version>


### PR DESCRIPTION
Address previously breaking issues in memoryfilesystem regarding URL handling
now that a fix has been released for the library.

This means I can remove some additional logic in JCT that was previously
working around these issues.

Issues fixed:

- URL protocol handler now will filter by the requested URL scheme correctly.
- URLs for directories now have a trailing forward slash, so URLClassLoader
  will not try to interpret it as a JAR and immediately ignore any files
  in subdirectories.