### PR TITLE
Implement path file object assertion tests

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PathFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PathFileObjectAssert.java
@@ -55,14 +55,29 @@ public final class PathFileObjectAssert
   }
 
   /**
-   * Perform an assertion on the file object's full path.
+   * Perform an assertion on the file object's absolute path.
    *
    * @return the assertions for the path.
    * @throws AssertionError if the file object is null.
+   * @deprecated use {@link #absolutePath()} instead.
    */
+  @Deprecated(forRemoval = true, since = "0.7.3")
+  @SuppressWarnings("removal")
   public AbstractPathAssert<?> fullPath() {
     isNotNull();
 
     return assertThat(actual.getFullPath());
+  }
+
+  /**
+   * Perform an assertion on the file object's absolute path.
+   *
+   * @return the assertions for the path.
+   * @throws AssertionError if the file object is null.
+   */
+  public AbstractPathAssert<?> absolutePath() {
+    isNotNull();
+
+    return assertThat(actual.getAbsolutePath());
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
@@ -90,7 +90,7 @@ public final class JarContainerImpl implements Container {
 
   @Override
   public boolean contains(PathFileObject fileObject) {
-    var path = fileObject.getFullPath();
+    var path = fileObject.getAbsolutePath();
     var root = holder.access().getPathRoot().getPath();
     return path.startsWith(root) && Files.isRegularFile(path);
   }
@@ -183,7 +183,7 @@ public final class JarContainerImpl implements Container {
     // we cannot then parse the URI back to a path without removing the `file://` bit first. Since
     // we assume we always have instances of PathJavaFileObject here, let's just cast to that and
     // get the correct path immediately.
-    var fullPath = javaFileObject.getFullPath();
+    var fullPath = javaFileObject.getAbsolutePath();
 
     if (fullPath.startsWith( holder.access().getPathRoot().getPath())) {
       return FileUtils.pathToBinaryName(javaFileObject.getRelativePath());

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -74,7 +74,7 @@ public final class PathWrappingContainerImpl implements Container {
 
   @Override
   public boolean contains(PathFileObject fileObject) {
-    var path = fileObject.getFullPath();
+    var path = fileObject.getAbsolutePath();
     return path.startsWith(root.getPath()) && Files.isRegularFile(path);
   }
 
@@ -143,7 +143,7 @@ public final class PathWrappingContainerImpl implements Container {
 
   @Override
   public String inferBinaryName(PathFileObject javaFileObject) {
-    return javaFileObject.getFullPath().startsWith(root.getPath())
+    return javaFileObject.getAbsolutePath().startsWith(root.getPath())
         ? FileUtils.pathToBinaryName(javaFileObject.getRelativePath())
         : null;
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/PathFileObjectAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/PathFileObjectAssertTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.assertions;
+
+import io.github.ascopes.jct.assertions.PathFileObjectAssert;
+import io.github.ascopes.jct.filemanagers.PathFileObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someAbsolutePath;
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someRelativePath;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link PathFileObjectAssert} tests.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("PathFileObjectAssert tests")
+class PathFileObjectAssertTest {
+
+  @DisplayName("PathFileObjectAssert#relativePath tests")
+  @Nested
+  class RelativePathTest {
+
+    @DisplayName(".relativePath() fails if the path file object is null")
+    @Test
+    void relativePathFailsIfThePathFileObjectIsNull() {
+      // Given
+      var assertions = new PathFileObjectAssert(null);
+
+      // Then
+      assertThatExceptionOfType(AssertionError.class)
+          .isThrownBy(assertions::relativePath);
+    }
+
+    @DisplayName(".relativePath() returns assertions on the relative path")
+    @Test
+    void relativePathReturnsAssertionsOnTheRelativePath() {
+      // Given
+      var path = someRelativePath();
+      var pathFileObject = mock(PathFileObject.class);
+      when(pathFileObject.getRelativePath()).thenReturn(path);
+      var assertions = new PathFileObjectAssert(pathFileObject);
+
+      // Then
+      assertThatNoException()
+          .isThrownBy(() -> assertions.relativePath().isSameAs(path));
+    }
+  }
+
+  @DisplayName("PathFileObjectAssert#fullPath tests")
+  @Nested
+  @SuppressWarnings("removal")
+  class FullPathTest {
+
+    @DisplayName(".fullPath() fails if the path file object is null")
+    @Test
+    void fullPathFailsIfThePathFileObjectIsNull() {
+      // Given
+      var assertions = new PathFileObjectAssert(null);
+
+      // Then
+      assertThatExceptionOfType(AssertionError.class)
+          .isThrownBy(assertions::fullPath);
+    }
+
+    @DisplayName(".fullPath() returns assertions on the absolute path")
+    @Test
+    void fullPathReturnsAssertionsOnTheFullPath() {
+      // Given
+      var path = someAbsolutePath();
+      var pathFileObject = mock(PathFileObject.class);
+      when(pathFileObject.getFullPath()).thenReturn(path);
+      var assertions = new PathFileObjectAssert(pathFileObject);
+
+      // Then
+      assertThatNoException()
+          .isThrownBy(() -> assertions.fullPath().isSameAs(path));
+    }
+  }
+
+  @DisplayName("PathFileObjectAssert#absolutePath tests")
+  @Nested
+  class AbsolutePathTest {
+
+    @DisplayName(".absolutePath() fails if the path file object is null")
+    @Test
+    void absolutePathFailsIfThePathFileObjectIsNull() {
+      // Given
+      var assertions = new PathFileObjectAssert(null);
+
+      // Then
+      assertThatExceptionOfType(AssertionError.class)
+          .isThrownBy(assertions::absolutePath);
+    }
+
+    @DisplayName(".absolutePath() returns assertions on the absolute path")
+    @Test
+    void absolutePathReturnsAssertionsOnTheAbsolutePath() {
+      // Given
+      var path = someAbsolutePath();
+      var pathFileObject = mock(PathFileObject.class);
+      when(pathFileObject.getAbsolutePath()).thenReturn(path);
+      var assertions = new PathFileObjectAssert(pathFileObject);
+
+      // Then
+      assertThatNoException()
+          .isThrownBy(() -> assertions.absolutePath().isSameAs(path));
+    }
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/PathFileObjectTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/PathFileObjectTest.java
@@ -202,6 +202,7 @@ class PathFileObjectTest {
   }
 
   @DisplayName(".equals(PathFileObject) returns true if the file object is the same instance")
+  @SuppressWarnings("EqualsWithItself")
   @Test
   void equalsReturnsTrueIfTheFileObjectIsTheSameInstance() {
     // Given
@@ -212,7 +213,20 @@ class PathFileObjectTest {
     var fileObject = new PathFileObject(location, rootPath, relativePath);
 
     // Then
-    assertThat(fileObject).isEqualTo(fileObject);
+    assertThat(fileObject.equals(fileObject)).isTrue();
+  }
+
+  @DisplayName(".getAbsolutePath() returns the absolute path")
+  @Test
+  void getAbsolutePathReturnsTheAbsolutePath() {
+    // Given
+    var rootPath = someAbsolutePath();
+    var relativePath = someRelativePath();
+    var fileObject = new PathFileObject(someLocation(), rootPath, relativePath);
+
+    // Then
+    assertThat(fileObject.getAbsolutePath())
+        .isEqualTo(rootPath.resolve(relativePath));
   }
 
   @DisplayName(".getAccessLevel() returns null")
@@ -310,6 +324,7 @@ class PathFileObjectTest {
 
   @DisplayName(".getFullPath() returns the full path")
   @Test
+  @SuppressWarnings("removal")
   void getFullPathReturnsTheFullPath() {
     // Given
     var rootPath = someAbsolutePath();


### PR DESCRIPTION
- Deprecate PathFileObject#getFullPath for removal in v1.0.0 as it is not immediately clear 
  what a "full path" means.
- Implement PathFileObject#getAbsolutePath to replace PathFileObject#getFullPath
- Implement PathFileObject assertion tests.
