### PR TITLE
Remove generic arguments from JctCompiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ class ExampleTest {
 
   @DisplayName("I can compile a Hello World application")
   @JavacCompilerTest
-  void canCompileHelloWorld(JctCompiler<?, ?> compiler) {
+  void canCompileHelloWorld(JctCompiler compiler) {
     // Given
     workspace
         .createSourcePathPackage()
@@ -213,7 +213,7 @@ class JsonSchemaAnnotationProcessorTest {
   Workspace workspace;
 
   @JavacCompilerTest(minVersion = 11, maxVersion = 21)
-  void theJsonSchemaIsCreatedFromTheInputCode(JctCompiler<?, ?> compiler) {
+  void theJsonSchemaIsCreatedFromTheInputCode(JctCompiler compiler) {
     // Given
     workspace
         .createSourcePathPackage()
@@ -262,7 +262,7 @@ class ExampleTest {
 
   @DisplayName("I can compile a module that is using Lombok")
   @JavacCompilerTest(modules = true)
-  void canCompileModuleUsingLombok(JctCompiler<?, ?> compiler) {
+  void canCompileModuleUsingLombok(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace()) {
       // Given
       workspace

--- a/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctCompilationConfigurer.java
+++ b/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctCompilationConfigurer.java
@@ -28,7 +28,7 @@ import java.util.Locale;
 public class JctCompilationConfigurer implements JctCompilerConfigurer<RuntimeException> {
 
   @Override
-  public void configure(JctCompiler<?, ?> compiler) {
+  public void configure(JctCompiler compiler) {
     compiler
         .failOnWarnings(false)
         .showWarnings(false)  // ignore spam about the testing module being hidden

--- a/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctDogfoodTest.java
+++ b/acceptance-tests/acceptance-tests-dogfood/src/test/java/io/github/ascopes/jct/acceptancetests/dogfood/JctDogfoodTest.java
@@ -65,7 +65,7 @@ class JctDogfoodTest {
 
   @DisplayName("JCT can compile itself as a legacy module source")
   @JavacCompilerTest(minVersion = 11, configurers = JctCompilationConfigurer.class)
-  void jctCanCompileItselfAsLegacyModule(JctCompiler<?, ?> compiler) throws IOException {
+  void jctCanCompileItselfAsLegacyModule(JctCompiler compiler) throws IOException {
     // Given
     try (var workspace = Workspaces.newWorkspace()) {
       workspace
@@ -87,7 +87,7 @@ class JctDogfoodTest {
 
   @DisplayName("JCT can compile its unit tests as a legacy module source")
   @JavacCompilerTest(minVersion = 11, configurers = JctCompilationConfigurer.class)
-  void jctCanCompileUnitTestsAsLegacyModule(JctCompiler<?, ?> compiler) throws IOException {
+  void jctCanCompileUnitTestsAsLegacyModule(JctCompiler compiler) throws IOException {
     // Given
     try (var workspace = Workspaces.newWorkspace()) {
       workspace
@@ -109,7 +109,7 @@ class JctDogfoodTest {
 
   @DisplayName("JCT can compile itself and its unit tests as a multiple-module source")
   @JavacCompilerTest(minVersion = 11, configurers = JctCompilationConfigurer.class)
-  void jctCanCompileItselfAndUnitTestsAsMultiModule(JctCompiler<?, ?> compiler) throws IOException {
+  void jctCanCompileItselfAndUnitTestsAsMultiModule(JctCompiler compiler) throws IOException {
     // Given
     try (var workspace = Workspaces.newWorkspace()) {
       workspace

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -37,7 +37,7 @@ import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Common functionality for AbstractJctCompiler compiler that can be overridden and that produces a
+ * Common functionality for a compiler that can be overridden and that produces a
  * {@link JctCompilationImpl} as the compilation result.
  *
  * <p>Implementations should extend this class and override anything they require.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -37,7 +37,7 @@ import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Common functionality for a compiler that can be overridden and that produces a
+ * Common functionality for AbstractJctCompiler compiler that can be overridden and that produces a
  * {@link JctCompilationImpl} as the compilation result.
  *
  * <p>Implementations should extend this class and override anything they require.
@@ -50,13 +50,11 @@ import org.jspecify.annotations.Nullable;
  * the desired operations, and then apply it to instances of this class using
  * {@link #configure(JctCompilerConfigurer)}.
  *
- * @param <A> the type of the class extending this class.
  * @author Ashley Scopes
  * @since 0.0.1
  */
 @API(since = "0.0.1", status = Status.STABLE)
-public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
-    implements JctCompiler<A, JctCompilation> {
+public abstract class AbstractJctCompiler implements JctCompiler {
 
   private final List<Processor> annotationProcessors;
   private final List<String> annotationProcessorOptions;
@@ -122,10 +120,10 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public final <E extends Exception> A configure(JctCompilerConfigurer<E> configurer) throws E {
+  public final <E extends Exception> AbstractJctCompiler configure(JctCompilerConfigurer<E> configurer) throws E {
     requireNonNull(configurer, "configurer");
     configurer.configure(this);
-    return myself();
+    return this;
   }
 
   @Override
@@ -134,9 +132,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A name(String name) {
+  public AbstractJctCompiler name(String name) {
     this.name = requireNonNull(name, "name");
-    return myself();
+    return this;
   }
 
   @Override
@@ -145,9 +143,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A verbose(boolean enabled) {
+  public AbstractJctCompiler verbose(boolean enabled) {
     verbose = enabled;
-    return myself();
+    return this;
   }
 
   @Override
@@ -156,9 +154,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A previewFeatures(boolean enabled) {
+  public AbstractJctCompiler previewFeatures(boolean enabled) {
     previewFeatures = enabled;
-    return myself();
+    return this;
   }
 
   @Override
@@ -167,9 +165,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A showWarnings(boolean enabled) {
+  public AbstractJctCompiler showWarnings(boolean enabled) {
     showWarnings = enabled;
-    return myself();
+    return this;
   }
 
   @Override
@@ -178,9 +176,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A showDeprecationWarnings(boolean enabled) {
+  public AbstractJctCompiler showDeprecationWarnings(boolean enabled) {
     showDeprecationWarnings = enabled;
-    return myself();
+    return this;
   }
 
   @Override
@@ -189,9 +187,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A failOnWarnings(boolean enabled) {
+  public AbstractJctCompiler failOnWarnings(boolean enabled) {
     failOnWarnings = enabled;
-    return myself();
+    return this;
   }
 
   @Override
@@ -200,9 +198,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A compilationMode(CompilationMode compilationMode) {
+  public AbstractJctCompiler compilationMode(CompilationMode compilationMode) {
     this.compilationMode = compilationMode;
-    return myself();
+    return this;
   }
 
   @Override
@@ -211,10 +209,10 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A addAnnotationProcessorOptions(Iterable<String> annotationProcessorOptions) {
+  public AbstractJctCompiler addAnnotationProcessorOptions(Iterable<String> annotationProcessorOptions) {
     requireNonNullValues(annotationProcessorOptions, "annotationProcessorOptions");
     annotationProcessorOptions.forEach(this.annotationProcessorOptions::add);
-    return myself();
+    return this;
   }
 
   @Override
@@ -223,11 +221,11 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A addAnnotationProcessors(Iterable<? extends Processor> annotationProcessors) {
+  public AbstractJctCompiler addAnnotationProcessors(Iterable<? extends Processor> annotationProcessors) {
     requireNonNullValues(annotationProcessors, "annotationProcessors");
     annotationProcessors.forEach(this.annotationProcessors::add);
 
-    return myself();
+    return this;
   }
 
   @Override
@@ -236,10 +234,10 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A addCompilerOptions(Iterable<String> compilerOptions) {
+  public AbstractJctCompiler addCompilerOptions(Iterable<String> compilerOptions) {
     requireNonNullValues(compilerOptions, "compilerOptions");
     compilerOptions.forEach(this.compilerOptions::add);
-    return myself();
+    return this;
   }
 
   @Override
@@ -261,7 +259,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A release(@Nullable String release) {
+  public AbstractJctCompiler release(@Nullable String release) {
     this.release = release;
 
     if (release != null) {
@@ -269,7 +267,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
       target = null;
     }
 
-    return myself();
+    return this;
   }
 
   @Override
@@ -278,12 +276,12 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A source(@Nullable String source) {
+  public AbstractJctCompiler source(@Nullable String source) {
     this.source = source;
     if (source != null) {
       release = null;
     }
-    return myself();
+    return this;
   }
 
   @Override
@@ -292,12 +290,12 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A target(@Nullable String target) {
+  public AbstractJctCompiler target(@Nullable String target) {
     this.target = target;
     if (target != null) {
       release = null;
     }
-    return myself();
+    return this;
   }
 
   @Override
@@ -306,9 +304,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A fixJvmModulePathMismatch(boolean fixJvmModulePathMismatch) {
+  public AbstractJctCompiler fixJvmModulePathMismatch(boolean fixJvmModulePathMismatch) {
     this.fixJvmModulePathMismatch = fixJvmModulePathMismatch;
-    return myself();
+    return this;
   }
 
   @Override
@@ -317,9 +315,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A inheritClassPath(boolean inheritClassPath) {
+  public AbstractJctCompiler inheritClassPath(boolean inheritClassPath) {
     this.inheritClassPath = inheritClassPath;
-    return myself();
+    return this;
   }
 
   @Override
@@ -328,9 +326,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A inheritModulePath(boolean inheritModulePath) {
+  public AbstractJctCompiler inheritModulePath(boolean inheritModulePath) {
     this.inheritModulePath = inheritModulePath;
-    return myself();
+    return this;
   }
 
   @Override
@@ -339,9 +337,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A inheritSystemModulePath(boolean inheritSystemModulePath) {
+  public AbstractJctCompiler inheritSystemModulePath(boolean inheritSystemModulePath) {
     this.inheritSystemModulePath = inheritSystemModulePath;
-    return myself();
+    return this;
   }
 
   @Override
@@ -350,10 +348,10 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A locale(Locale locale) {
+  public AbstractJctCompiler locale(Locale locale) {
     requireNonNull(locale, "locale");
     this.locale = locale;
-    return myself();
+    return this;
   }
 
   @Override
@@ -362,10 +360,10 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A logCharset(Charset logCharset) {
+  public AbstractJctCompiler logCharset(Charset logCharset) {
     requireNonNull(logCharset, "logCharset");
     this.logCharset = logCharset;
-    return myself();
+    return this;
   }
 
   @Override
@@ -374,9 +372,9 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A fileManagerLoggingMode(LoggingMode fileManagerLoggingMode) {
+  public AbstractJctCompiler fileManagerLoggingMode(LoggingMode fileManagerLoggingMode) {
     this.fileManagerLoggingMode = requireNonNull(fileManagerLoggingMode, "fileManagerLoggingMode");
-    return myself();
+    return this;
   }
 
   @Override
@@ -385,10 +383,10 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A diagnosticLoggingMode(LoggingMode diagnosticLoggingMode) {
+  public AbstractJctCompiler diagnosticLoggingMode(LoggingMode diagnosticLoggingMode) {
     requireNonNull(diagnosticLoggingMode, "diagnosticLoggingMode");
     this.diagnosticLoggingMode = diagnosticLoggingMode;
-    return myself();
+    return this;
   }
 
   @Override
@@ -397,12 +395,12 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   }
 
   @Override
-  public A annotationProcessorDiscovery(AnnotationProcessorDiscovery annotationProcessorDiscovery) {
+  public AbstractJctCompiler annotationProcessorDiscovery(AnnotationProcessorDiscovery annotationProcessorDiscovery) {
     this.annotationProcessorDiscovery = requireNonNull(
         annotationProcessorDiscovery,
         "annotationProcessorDiscovery"
     );
-    return myself();
+    return this;
   }
 
   /**
@@ -432,7 +430,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   public abstract Jsr199CompilerFactory getCompilerFactory();
 
   /**
-   * Get the file manager factory to use for building a file manager during compilation.
+   * Get the file manager factory to use for building AbstractJctCompiler file manager during compilation.
    *
    * @return the factory.
    */
@@ -462,19 +460,7 @@ public abstract class AbstractJctCompiler<A extends AbstractJctCompiler<A>>
   @Override
   public abstract String getDefaultRelease();
 
-  /**
-   * Get this implementation of {@link AbstractJctCompiler}, cast to the type parameter {@link A}.
-   *
-   * @return this implementation of {@link AbstractJctCompiler}, cast to {@link A}.
-   */
-  protected final A myself() {
-    @SuppressWarnings("unchecked")
-    var me = (A) this;
-
-    return me;
-  }
-
-  /**
+  /*
    * Build the list of flags from this compiler object using the flag builder.
    *
    * <p>Implementations should not need to override this unless there is a special edge case

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -36,13 +36,11 @@ import org.apiguardian.api.API.Status;
  * sources. This is designed to provide functionality that {@code javac} does by default, for JDK
  * 17.
  *
- * @param <C> the implementation type. This is provided to allow call-chaining the implementation.
- * @param <R> the compilation type that gets returned once compilation completes.
  * @author Ashley Scopes
  * @since 0.0.1
  */
 @API(since = "0.0.1", status = Status.STABLE)
-public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilation> {
+public interface JctCompiler {
 
   /**
    * Default setting for deprecation warnings ({@code true}).
@@ -138,7 +136,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @see #compile(Workspace, String, String...)
    * @see #compile(Workspace, Collection)
    */
-  R compile(Workspace workspace);
+  JctCompilation compile(Workspace workspace);
 
   /**
    * Invoke the compilation and return the compilation result.
@@ -159,7 +157,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @see #compile(Workspace)
    * @see #compile(Workspace, Collection)
    */
-  default R compile(Workspace workspace, String firstClassName, String... additionalClassNames) {
+  default JctCompilation compile(Workspace workspace, String firstClassName, String... additionalClassNames) {
     return compile(workspace, IterableUtils.combineOneOrMore(firstClassName, additionalClassNames));
   }
 
@@ -182,7 +180,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @see #compile(Workspace)
    * @see #compile(Workspace, String, String...)
    */
-  R compile(Workspace workspace, Collection<String> classNames);
+  JctCompilation compile(Workspace workspace, Collection<String> classNames);
 
   /**
    * Apply a given configurer to this compiler that can throw a checked exception.
@@ -192,7 +190,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @return this compiler object for further call chaining.
    * @throws E any exception that may be thrown by the configurer.
    */
-  <E extends Exception> C configure(JctCompilerConfigurer<E> configurer) throws E;
+  <E extends Exception> JctCompiler configure(JctCompilerConfigurer<E> configurer) throws E;
 
   /**
    * Get the friendly printable name of this compiler object.
@@ -207,7 +205,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param name the name to set.
    * @return this compiler object for further call chaining.
    */
-  C name(String name);
+  JctCompiler name(String name);
 
   /**
    * Get an <strong>immutable snapshot view</strong> of the current annotation processor options
@@ -223,7 +221,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param annotationProcessorOptions the options to pass.
    * @return this compiler object for further call chaining.
    */
-  C addAnnotationProcessorOptions(Iterable<String> annotationProcessorOptions);
+  JctCompiler addAnnotationProcessorOptions(Iterable<String> annotationProcessorOptions);
 
   /**
    * Add options to pass to any annotation processors.
@@ -232,7 +230,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param annotationProcessorOptions additional options to pass.
    * @return this compiler object for further call chaining.
    */
-  default C addAnnotationProcessorOptions(
+  default JctCompiler addAnnotationProcessorOptions(
       String annotationProcessorOption,
       String... annotationProcessorOptions
   ) {
@@ -258,7 +256,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param annotationProcessors the processors to invoke.
    * @return this compiler object for further call chaining.
    */
-  C addAnnotationProcessors(Iterable<? extends Processor> annotationProcessors);
+  JctCompiler addAnnotationProcessors(Iterable<? extends Processor> annotationProcessors);
 
   /**
    * Add annotation processors to invoke.
@@ -270,7 +268,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param annotationProcessors additional processors to invoke.
    * @return this compiler object for further call chaining.
    */
-  default C addAnnotationProcessors(
+  default JctCompiler addAnnotationProcessors(
       Processor annotationProcessor,
       Processor... annotationProcessors
   ) {
@@ -291,7 +289,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param compilerOptions the options to add.
    * @return this compiler object for further call chaining.
    */
-  C addCompilerOptions(Iterable<String> compilerOptions);
+  JctCompiler addCompilerOptions(Iterable<String> compilerOptions);
 
   /**
    * Add command line options to pass to {@code javac}.
@@ -300,7 +298,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param compilerOptions additional options to add.
    * @return this compiler object for further call chaining.
    */
-  default C addCompilerOptions(String compilerOption, String... compilerOptions) {
+  default JctCompiler addCompilerOptions(String compilerOption, String... compilerOptions) {
     return addCompilerOptions(IterableUtils.combineOneOrMore(compilerOption, compilerOptions));
   }
 
@@ -331,7 +329,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param enabled {@code true} for verbose output, {@code false} for normal output.
    * @return this compiler for further call chaining.
    */
-  C verbose(boolean enabled);
+  JctCompiler verbose(boolean enabled);
 
   /**
    * Determine whether preview features are enabled or not.
@@ -352,7 +350,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param enabled {@code true} to enable preview features, or {@code false} to disable them.
    * @return this compiler object for further call chaining.
    */
-  C previewFeatures(boolean enabled);
+  JctCompiler previewFeatures(boolean enabled);
 
   /**
    * Determine whether warnings are enabled or not.
@@ -373,7 +371,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param enabled {@code true} to enable warnings. {@code false} to disable them.
    * @return this compiler object for further call chaining.
    */
-  C showWarnings(boolean enabled);
+  JctCompiler showWarnings(boolean enabled);
 
   /**
    * Determine whether deprecation warnings are enabled or not.
@@ -396,7 +394,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param enabled {@code true} to enable deprecation warnings. {@code false} to disable them.
    * @return this compiler object for further call chaining.
    */
-  C showDeprecationWarnings(boolean enabled);
+  JctCompiler showDeprecationWarnings(boolean enabled);
 
   /**
    * Determine whether warnings are being treated as errors or not.
@@ -420,7 +418,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    *                them.
    * @return this compiler object for further call chaining.
    */
-  C failOnWarnings(boolean enabled);
+  JctCompiler failOnWarnings(boolean enabled);
 
   /**
    * Get the compilation mode that is in use.
@@ -441,7 +439,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param compilationMode the compilation mode to use.
    * @return this compiler object for further call chaining.
    */
-  C compilationMode(CompilationMode compilationMode);
+  JctCompiler compilationMode(CompilationMode compilationMode);
 
   /**
    * Get the default release to use if no release or target version is specified.
@@ -485,7 +483,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param release the version to set.
    * @return this compiler object for further call chaining.
    */
-  C release(String release);
+  JctCompiler release(String release);
 
   /**
    * Set the release version.
@@ -498,7 +496,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param release the version to set.
    * @return this compiler object for further call chaining.
    */
-  default C release(int release) {
+  default JctCompiler release(int release) {
     if (release < 0) {
       throw new IllegalArgumentException("Cannot provide a release version less than 0");
     }
@@ -517,7 +515,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param release the version to set.
    * @return this compiler object for further call chaining.
    */
-  default C release(SourceVersion release) {
+  default JctCompiler release(SourceVersion release) {
     return release(Integer.toString(release.ordinal()));
   }
 
@@ -543,7 +541,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param source the version to set.
    * @return this compiler object for further call chaining.
    */
-  C source(String source);
+  JctCompiler source(String source);
 
   /**
    * Set the source version.
@@ -556,7 +554,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param source the version to set.
    * @return this compiler object for further call chaining.
    */
-  default C source(int source) {
+  default JctCompiler source(int source) {
     if (source < 0) {
       throw new IllegalArgumentException("Cannot provide a source version less than 0");
     }
@@ -575,7 +573,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param source the version to set.
    * @return this compiler object for further call chaining.
    */
-  default C source(SourceVersion source) {
+  default JctCompiler source(SourceVersion source) {
     return source(Integer.toString(source.ordinal()));
   }
 
@@ -600,7 +598,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param target the version to set.
    * @return this compiler object for further call chaining.
    */
-  C target(String target);
+  JctCompiler target(String target);
 
   /**
    * Set the target version.
@@ -613,7 +611,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param target the version to set.
    * @return this compiler object for further call chaining.
    */
-  default C target(int target) {
+  default JctCompiler target(int target) {
     if (target < 0) {
       throw new IllegalArgumentException("Cannot provide a target version less than 0");
     }
@@ -632,7 +630,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param target the version to set.
    * @return this compiler object for further call chaining.
    */
-  default C target(SourceVersion target) {
+  default JctCompiler target(SourceVersion target) {
     return target(Integer.toString(target.ordinal()));
   }
 
@@ -666,7 +664,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param fixJvmModulePathMismatch whether to enable the mismatch fixing or not.
    * @return this compiler object for further call chaining.
    */
-  C fixJvmModulePathMismatch(boolean fixJvmModulePathMismatch);
+  JctCompiler fixJvmModulePathMismatch(boolean fixJvmModulePathMismatch);
 
   /**
    * Get whether the class path is inherited from the caller JVM or not.
@@ -687,7 +685,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param inheritClassPath {@code true} to include it, or {@code false} to exclude it.
    * @return this compiler object for further call chaining.
    */
-  C inheritClassPath(boolean inheritClassPath);
+  JctCompiler inheritClassPath(boolean inheritClassPath);
 
   /**
    * Get whether the module path is inherited from the caller JVM or not.
@@ -708,7 +706,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param inheritModulePath {@code true} to include it, or {@code false} to exclude it.
    * @return this compiler object for further call chaining.
    */
-  C inheritModulePath(boolean inheritModulePath);
+  JctCompiler inheritModulePath(boolean inheritModulePath);
 
   /**
    * Get whether the system module path is inherited from the caller JVM or not.
@@ -729,7 +727,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param inheritSystemModulePath {@code true} to include it, or {@code false} to exclude it.
    * @return this compiler object for further call chaining.
    */
-  C inheritSystemModulePath(boolean inheritSystemModulePath);
+  JctCompiler inheritSystemModulePath(boolean inheritSystemModulePath);
 
   /**
    * Get the output locale.
@@ -750,7 +748,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param locale the locale to use.
    * @return this compiler for further call chaining.
    */
-  C locale(Locale locale);
+  JctCompiler locale(Locale locale);
 
   /**
    * Get the charset being used to write compiler logs with.
@@ -771,7 +769,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param logCharset the charset to use.
    * @return this compiler for further call chaining.
    */
-  C logCharset(Charset logCharset);
+  JctCompiler logCharset(Charset logCharset);
 
   /**
    * Get the current file manager logging mode.
@@ -792,7 +790,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param fileManagerLoggingMode the mode to use for file manager logging.
    * @return this compiler for further call chaining.
    */
-  C fileManagerLoggingMode(LoggingMode fileManagerLoggingMode);
+  JctCompiler fileManagerLoggingMode(LoggingMode fileManagerLoggingMode);
 
   /**
    * Get the current diagnostic logging mode.
@@ -813,7 +811,7 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param diagnosticLoggingMode the mode to use for diagnostic capture.
    * @return this compiler for further call chaining.
    */
-  C diagnosticLoggingMode(LoggingMode diagnosticLoggingMode);
+  JctCompiler diagnosticLoggingMode(LoggingMode diagnosticLoggingMode);
 
   /**
    * Get how to perform annotation processor discovery.
@@ -844,5 +842,5 @@ public interface JctCompiler<C extends JctCompiler<C, R>, R extends JctCompilati
    * @param annotationProcessorDiscovery the processor discovery mode to use.
    * @return this compiler for further call chaining.
    */
-  C annotationProcessorDiscovery(AnnotationProcessorDiscovery annotationProcessorDiscovery);
+  JctCompiler annotationProcessorDiscovery(AnnotationProcessorDiscovery annotationProcessorDiscovery);
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
@@ -33,7 +33,7 @@ import org.apiguardian.api.API.Status;
  * <pre><code>
  * class MyAnnotationProcessorConfigurer implements JctCompilerConfigurer&lt;RuntimeException&gt; {
  *    {@literal @Override}
- *    public void configure(JctCompiler&lt;?, ?&gt; compiler) {
+ *    public void configure(JctCompiler compiler) {
  *      compiler
  *          .addAnnotationProcessors(new MyAnnotationProcessor())
  *          .addAnnotationProcessorOptions("MyAnnotationProcessor.debug=true");
@@ -78,7 +78,7 @@ import org.apiguardian.api.API.Status;
  *
  * <pre><code>
  *   {@literal @JavacCompilersTest(configurers = {MyAnnotationProcessorConfigurer.class})}
- *   void theCompilationSucceedsAsExpected(JctCompiler&lt;?, ?&gt; compiler) {
+ *   void theCompilationSucceedsAsExpected(JctCompiler compiler) {
  *     // ...
  *   }
  * </code></pre>
@@ -101,5 +101,5 @@ public interface JctCompilerConfigurer<E extends Exception> {
    * @param compiler the compiler.
    * @throws E any exception that may be thrown by the configurer.
    */
-  void configure(JctCompiler<?, ?> compiler) throws E;
+  void configure(JctCompiler compiler) throws E;
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
@@ -41,7 +41,7 @@ public final class JctCompilers extends UtilityClass {
    * @since 0.2.0
    */
   @API(status = Status.STABLE, since = "0.2.0")
-  public static JctCompiler<?, ?> newPlatformCompiler() {
+  public static JctCompiler newPlatformCompiler() {
     return new JavacJctCompilerImpl();
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
@@ -34,7 +34,7 @@ import org.apiguardian.api.API.Status;
  * @since 0.0.1
  */
 @API(since = "0.0.1", status = Status.INTERNAL)
-public final class JavacJctCompilerImpl extends AbstractJctCompiler<JavacJctCompilerImpl> {
+public final class JavacJctCompilerImpl extends AbstractJctCompiler {
 
   private static final String NAME = "JDK Compiler";
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationFactoryImpl.java
@@ -56,9 +56,9 @@ public final class JctCompilationFactoryImpl implements JctCompilationFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(JctCompilationFactoryImpl.class);
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
-  public JctCompilationFactoryImpl(JctCompiler<?, ?> compiler) {
+  public JctCompilationFactoryImpl(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurer.java
@@ -51,14 +51,14 @@ public final class JctFileManagerAnnotationProcessorClassPathConfigurer implemen
       StandardLocation.CLASS_PATH, StandardLocation.ANNOTATION_PROCESSOR_PATH
   );
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise the configurer with the desired compiler.
    *
    * @param compiler the compiler to wrap.
    */
-  public JctFileManagerAnnotationProcessorClassPathConfigurer(JctCompiler<?, ?> compiler) {
+  public JctFileManagerAnnotationProcessorClassPathConfigurer(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathConfigurer.java
@@ -40,14 +40,14 @@ public final class JctFileManagerJvmClassPathConfigurer implements JctFileManage
   private static final Logger LOGGER = LoggerFactory
       .getLogger(JctFileManagerJvmClassPathConfigurer.class);
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise the configurer with the desired compiler.
    *
    * @param compiler the compiler to wrap.
    */
-  public JctFileManagerJvmClassPathConfigurer(JctCompiler<?, ?> compiler) {
+  public JctFileManagerJvmClassPathConfigurer(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurer.java
@@ -44,14 +44,14 @@ public final class JctFileManagerJvmClassPathModuleConfigurer implements JctFile
   private static final Logger LOGGER = LoggerFactory
       .getLogger(JctFileManagerJvmClassPathModuleConfigurer.class);
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise the configurer with the desired compiler.
    *
    * @param compiler the compiler to wrap.
    */
-  public JctFileManagerJvmClassPathModuleConfigurer(JctCompiler<?, ?> compiler) {
+  public JctFileManagerJvmClassPathModuleConfigurer(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmModulePathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmModulePathConfigurer.java
@@ -40,14 +40,14 @@ public final class JctFileManagerJvmModulePathConfigurer implements JctFileManag
   private static final Logger LOGGER = LoggerFactory
       .getLogger(JctFileManagerJvmModulePathConfigurer.class);
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise the configurer with the desired compiler.
    *
    * @param compiler the compiler to wrap.
    */
-  public JctFileManagerJvmModulePathConfigurer(JctCompiler<?, ?> compiler) {
+  public JctFileManagerJvmModulePathConfigurer(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmSystemModulesConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmSystemModulesConfigurer.java
@@ -40,14 +40,14 @@ public final class JctFileManagerJvmSystemModulesConfigurer implements JctFileMa
   private static final Logger LOGGER = LoggerFactory
       .getLogger(JctFileManagerJvmSystemModulesConfigurer.class);
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise the configurer with the desired compiler.
    *
    * @param compiler the compiler to wrap.
    */
-  public JctFileManagerJvmSystemModulesConfigurer(JctCompiler<?, ?> compiler) {
+  public JctFileManagerJvmSystemModulesConfigurer(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerLoggingProxyConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerLoggingProxyConfigurer.java
@@ -37,14 +37,14 @@ public final class JctFileManagerLoggingProxyConfigurer implements JctFileManage
   private static final Logger LOGGER = LoggerFactory
       .getLogger(JctFileManagerLoggingProxyConfigurer.class);
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise this configurer.
    *
    * @param compiler the compiler to apply to the file manager.
    */
-  public JctFileManagerLoggingProxyConfigurer(JctCompiler<?, ?> compiler) {
+  public JctFileManagerLoggingProxyConfigurer(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
@@ -45,14 +45,14 @@ import org.apiguardian.api.API.Status;
 @API(since = "0.0.1", status = Status.INTERNAL)
 public final class JctFileManagerFactoryImpl implements JctFileManagerFactory {
 
-  private final JctCompiler<?, ?> compiler;
+  private final JctCompiler compiler;
 
   /**
    * Initialise this factory.
    *
    * @param compiler the compiler to pull configuration details from.
    */
-  public JctFileManagerFactoryImpl(JctCompiler<?, ?> compiler) {
+  public JctFileManagerFactoryImpl(JctCompiler compiler) {
     this.compiler = compiler;
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
@@ -64,7 +64,7 @@ import org.opentest4j.TestAbortedException;
  *     implements AnnotationConsumer&lt;MyCompilerTest&gt; {
  *
  *   {@literal @Override}
- *   protected JctCompiler&lt;?, ?&gt; initializeNewCompiler() {
+ *   protected JctCompiler initializeNewCompiler() {
  *     return new MyCompilerImpl();
  *   }
  *
@@ -95,18 +95,18 @@ import org.opentest4j.TestAbortedException;
  *
  * <pre><code>
  * {@literal @MyCompilerTest(minVersion=13, maxVersion=17)}
- * void testSomething(JctCompiler&lt;?, ?&gt; compiler) {
+ * void testSomething(JctCompiler compiler) {
  *   ...
  * }
  *
  * {@literal @MyCompilerTest(configurers=WerrorConfigurer.class)}
- * void testSomethingElse(JctCompiler&lt;?, ?&gt; compiler) {
+ * void testSomethingElse(JctCompiler compiler) {
  *   ...
  * }
  *
  * static class WerrorConfigurer implements JctCompilerConfigurer {
  *   {@literal @Override}
- *   public void configure(JctCompiler&lt;?, ?&gt; compiler) {
+ *   public void configure(JctCompiler compiler) {
  *     compiler.failOnErrors(true);
  *   }
  * }
@@ -188,7 +188,7 @@ public abstract class AbstractCompilersProvider implements ArgumentsProvider {
    *
    * @return the compiler object.
    */
-  protected abstract JctCompiler<?, ?> initializeNewCompiler();
+  protected abstract JctCompiler initializeNewCompiler();
 
   /**
    * Get the minimum supported compiler version.
@@ -208,13 +208,13 @@ public abstract class AbstractCompilersProvider implements ArgumentsProvider {
   @API(since = "1.0.0", status = Status.STABLE)
   protected abstract int maxSupportedVersion();
 
-  private JctCompiler<?, ?> createCompilerForVersion(int version) {
+  private JctCompiler createCompilerForVersion(int version) {
     var compiler = initializeNewCompiler();
     versionStrategy.configureCompiler(compiler, version);
     return compiler;
   }
 
-  private void applyConfigurers(JctCompiler<?, ?> compiler) {
+  private void applyConfigurers(JctCompiler compiler) {
     var classes = requireNonNull(configurerClasses);
 
     for (var configurerClass : classes) {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * <pre><code>
  *   class SomeTest {
  *     {@literal @JavacCompilerTest(minVersion = 11, maxVersion = 17)}
- *     void canCompileHelloWorld(JctCompiler&lt;?, ?&gt;> compiler) {
+ *     void canCompileHelloWorld(JctCompiler> compiler) {
  *       // Given
  *       try (var workspace = Workspaces.newWorkspace()) {
  *         workspace
@@ -140,7 +140,7 @@ public @interface JavacCompilerTest {
    * <pre><code>
    *   public class WerrorConfigurer implements JctCompilerConfigurer&lt;RuntimeException&gt; {
    *     {@literal @Override}
-   *     public void configure(JctCompiler&lt;?, ?&gt; compiler) {
+   *     public void configure(JctCompiler compiler) {
    *       compiler.failOnWarnings(true);
    *     }
    *   }
@@ -149,7 +149,7 @@ public @interface JavacCompilerTest {
    *
    *   class SomeTest {
    *     {@literal @JavacCompilerTest(configurers = WerrorConfigurer.class)}
-   *     void someTest(JctCompiler&lt;?, ?&gt; compiler) {
+   *     void someTest(JctCompiler compiler) {
    *       // ...
    *     }
    *   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
@@ -44,7 +44,7 @@ public final class JavacCompilersProvider extends AbstractCompilersProvider
   }
 
   @Override
-  protected JctCompiler<?, ?> initializeNewCompiler() {
+  protected JctCompiler initializeNewCompiler() {
     return new JavacJctCompilerImpl();
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JctExtension.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JctExtension.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
  *   Workspace workspace;
  *
  *   {@literal @JavacCompilerTest}
- *   void myTest(JctCompiler&lt;?, ?&gt; compiler) {
+ *   void myTest(JctCompiler compiler) {
  *     // Given
  *     workspace
  *        .createSourcePathPackage()

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
@@ -45,7 +45,7 @@ import org.apiguardian.api.API.Status;
  *   Workspace workspace;
  *
  *   {@literal @JavacCompilerTest}
- *   void myTest(JctCompiler&lt;?, ?&gt; compiler) {
+ *   void myTest(JctCompiler compiler) {
  *     ...
  *     var compilation = compiler.compile(workspace);
  *     ...

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/VersionStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/VersionStrategy.java
@@ -66,9 +66,9 @@ public enum VersionStrategy {
           .name(compiler.getName() + " (source and target = Java " + version + ")")
   );
 
-  private final BiConsumer<JctCompiler<?, ?>, Integer> versionSetter;
+  private final BiConsumer<JctCompiler, Integer> versionSetter;
 
-  VersionStrategy(BiConsumer<JctCompiler<?, ?>, Integer> versionSetter) {
+  VersionStrategy(BiConsumer<JctCompiler, Integer> versionSetter) {
     this.versionSetter = versionSetter;
   }
 
@@ -78,7 +78,7 @@ public enum VersionStrategy {
    * @param compiler the compiler to configure.
    * @param version  the version to set.
    */
-  public void configureCompiler(JctCompiler<?, ?> compiler, int version) {
+  public void configureCompiler(JctCompiler compiler, int version) {
     versionSetter.accept(compiler, version);
   }
 }

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -58,7 +58,7 @@ import java.net.spi.URLStreamHandlerProvider;
  *    class JsonSchemaAnnotationProcessorTest {
  *
  *      {@literal @JavacCompilerTest(minVersion=11, maxVersion=19)}
- *      void theJsonSchemaIsCreatedFromTheInputCode(JctCompiler&lt;?, ?&gt; compiler) {
+ *      void theJsonSchemaIsCreatedFromTheInputCode(JctCompiler compiler) {
  *
  *        try (var workspace = Workspaces.newWorkspace()) {
  *          // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/BasicLegacyCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/BasicLegacyCompilationIntegrationTest.java
@@ -35,7 +35,7 @@ class BasicLegacyCompilationIntegrationTest extends AbstractIntegrationTest {
 
   @DisplayName("I can compile a 'Hello, World!' program using a RAM directory")
   @JavacCompilerTest
-  void helloWorldJavacRamDirectory(JctCompiler<?, ?> compiler) {
+  void helloWorldJavacRamDirectory(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.RAM_DIRECTORIES)) {
       workspace
           .createPackage(StandardLocation.SOURCE_PATH)
@@ -55,7 +55,7 @@ class BasicLegacyCompilationIntegrationTest extends AbstractIntegrationTest {
 
   @DisplayName("I can compile a 'Hello, World!' program using a temp directory")
   @JavacCompilerTest
-  void helloWorldJavacTempDirectory(JctCompiler<?, ?> compiler) {
+  void helloWorldJavacTempDirectory(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.TEMP_DIRECTORIES)) {
       workspace
           .createPackage(StandardLocation.SOURCE_PATH)

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/BasicModuleCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/BasicModuleCompilationIntegrationTest.java
@@ -34,7 +34,7 @@ class BasicModuleCompilationIntegrationTest extends AbstractIntegrationTest {
 
   @DisplayName("I can compile a 'Hello, World!' module program using a RAM disk")
   @JavacCompilerTest(minVersion = 9)
-  void helloWorldRamDisk(JctCompiler<?, ?> compiler) {
+  void helloWorldRamDisk(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.RAM_DIRECTORIES)) {
       // Given
       workspace
@@ -62,7 +62,7 @@ class BasicModuleCompilationIntegrationTest extends AbstractIntegrationTest {
 
   @DisplayName("I can compile a 'Hello, World!' module program using a temporary directory")
   @JavacCompilerTest(minVersion = 9)
-  void helloWorldUsingTempDirectory(JctCompiler<?, ?> compiler) {
+  void helloWorldUsingTempDirectory(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.TEMP_DIRECTORIES)) {
       // Given
       workspace

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/BasicMultiModuleCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/BasicMultiModuleCompilationIntegrationTest.java
@@ -35,7 +35,7 @@ class BasicMultiModuleCompilationIntegrationTest extends AbstractIntegrationTest
 
   @DisplayName("I can compile a single module using multi-module layout using a RAM disk")
   @JavacCompilerTest(minVersion = 9)
-  void singleModuleInMultiModuleLayoutRamDisk(JctCompiler<?, ?> compiler) {
+  void singleModuleInMultiModuleLayoutRamDisk(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.RAM_DIRECTORIES)) {
       // Given
       workspace
@@ -63,7 +63,7 @@ class BasicMultiModuleCompilationIntegrationTest extends AbstractIntegrationTest
 
   @DisplayName("I can compile a single module using multi-module layout using a temp directory")
   @JavacCompilerTest(minVersion = 9)
-  void singleModuleInMultiModuleLayoutTempDirectory(JctCompiler<?, ?> compiler) {
+  void singleModuleInMultiModuleLayoutTempDirectory(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.TEMP_DIRECTORIES)) {
       // Given
       workspace
@@ -91,7 +91,7 @@ class BasicMultiModuleCompilationIntegrationTest extends AbstractIntegrationTest
 
   @DisplayName("I can compile multiple modules using multi-module layout using a RAM disk")
   @JavacCompilerTest(minVersion = 9)
-  void multipleModulesInMultiModuleLayoutRamDisk(JctCompiler<?, ?> compiler) {
+  void multipleModulesInMultiModuleLayoutRamDisk(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.RAM_DIRECTORIES)) {
       // Given
       workspace
@@ -137,7 +137,7 @@ class BasicMultiModuleCompilationIntegrationTest extends AbstractIntegrationTest
 
   @DisplayName("I can compile multiple modules using multi-module layout using a temp directory")
   @JavacCompilerTest(minVersion = 9)
-  void multipleModulesInMultiModuleLayoutTempDirectory(JctCompiler<?, ?> compiler) {
+  void multipleModulesInMultiModuleLayoutTempDirectory(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace(PathStrategy.TEMP_DIRECTORIES)) {
       // Given
       workspace

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest.java
@@ -33,7 +33,7 @@ class CompilingSpecificClassesIntegrationTest extends AbstractIntegrationTest {
 
   @DisplayName("Only the classes that I specify get compiled")
   @JavacCompilerTest
-  void onlyTheClassesSpecifiedGetCompiled(JctCompiler<?, ?> compiler) {
+  void onlyTheClassesSpecifiedGetCompiled(JctCompiler compiler) {
     try (var workspace = Workspaces.newWorkspace()) {
       workspace
           .createSourcePathPackage()

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/MultiTieredCompilationIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/compilation/MultiTieredCompilationIntegrationTest.java
@@ -37,7 +37,7 @@ class MultiTieredCompilationIntegrationTest extends AbstractIntegrationTest {
   )
   @JavacCompilerTest
   void compileSourcesToClassesAndProvideThemInClassPathToSecondCompilation(
-      JctCompiler<?, ?> compiler
+      JctCompiler compiler
   ) {
     try (
         var firstWorkspace = Workspaces.newWorkspace();
@@ -77,7 +77,7 @@ class MultiTieredCompilationIntegrationTest extends AbstractIntegrationTest {
   )
   @JavacCompilerTest
   void compileSourcesToClassesAndProvideThemInClassPathToSecondCompilationWithinJar(
-      JctCompiler<?, ?> compiler
+      JctCompiler compiler
   ) {
     try (
         var firstWorkspace = Workspaces.newWorkspace();

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
@@ -1641,7 +1641,7 @@ class AbstractJctCompilerTest {
   /// Helper methods and types ///
   ////////////////////////////////
 
-  class CompilerImpl extends AbstractJctCompiler<CompilerImpl> {
+  class CompilerImpl extends AbstractJctCompiler {
 
     private final String defaultRelease;
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilerTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JctCompilerTest {
 
   @Mock
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @DisplayName("addAnnotationProcessorOptions(String, String...) should call the expected method")
   @Test

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationFactoryImplTest.java
@@ -97,7 +97,7 @@ class JctCompilationFactoryImplTest {
   List<String> flags;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  JctCompiler<?, ?> jctCompiler;
+  JctCompiler jctCompiler;
 
   @InjectMocks
   JctCompilationFactoryImpl factory;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurerTest.java
@@ -46,7 +46,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JctFileManagerAnnotationProcessorClassPathConfigurerTest {
 
   @Mock
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock
   JctFileManager fileManager;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathConfigurerTest.java
@@ -50,7 +50,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JctFileManagerJvmClassPathConfigurerTest {
 
   @Mock
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock
   JctFileManagerImpl fileManager;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurerTest.java
@@ -51,7 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JctFileManagerJvmClassPathModuleConfigurerTest {
 
   @Mock(strictness = Strictness.LENIENT)
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock
   JctFileManagerImpl fileManager;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmModulePathConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmModulePathConfigurerTest.java
@@ -51,7 +51,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JctFileManagerJvmModulePathConfigurerTest {
 
   @Mock
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock
   JctFileManagerImpl fileManager;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmSystemModulesConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmSystemModulesConfigurerTest.java
@@ -50,7 +50,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class JctFileManagerJvmSystemModulesConfigurerTest {
 
   @Mock
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock
   JctFileManagerImpl fileManager;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerLoggingProxyConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerLoggingProxyConfigurerTest.java
@@ -54,7 +54,7 @@ class JctFileManagerLoggingProxyConfigurerTest {
   MockedStatic<LoggingFileManagerProxy> loggingFileManagerProxyStatic;
 
   @Mock
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock
   JctFileManager proxiedFileManager;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerFactoryImplTest.java
@@ -62,7 +62,7 @@ import org.mockito.stubbing.Answer;
 class JctFileManagerFactoryImplTest {
 
   @Mock(answer = Answers.RETURNS_MOCKS)
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @Mock(answer = Answers.RETURNS_MOCKS)
   Workspace workspace;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
@@ -113,7 +113,7 @@ class AbstractCompilersProviderTest {
     // When
     provider.configureInternals(10, 15, versionStrategy);
     var compilers = provider.provideArguments(mock(ExtensionContext.class))
-        .map(args -> (JctCompiler<?, ?>) args.get()[0])
+        .map(args -> (JctCompiler) args.get()[0])
         .collect(Collectors.toList());
 
     // Then
@@ -136,7 +136,7 @@ class AbstractCompilersProviderTest {
     // When
     provider.configureInternals(10, 17, versionStrategy);
     var compilers = provider.provideArguments(mock(ExtensionContext.class))
-        .map(args -> (JctCompiler<?, ?>) args.get()[0])
+        .map(args -> (JctCompiler) args.get()[0])
         .collect(Collectors.toList());
 
     // Then
@@ -159,7 +159,7 @@ class AbstractCompilersProviderTest {
     // When
     provider.configureInternals(15, 20, versionStrategy);
     var compilers = provider.provideArguments(mock(ExtensionContext.class))
-        .map(args -> (JctCompiler<?, ?>) args.get()[0])
+        .map(args -> (JctCompiler) args.get()[0])
         .collect(Collectors.toList());
 
     // Then
@@ -189,7 +189,7 @@ class AbstractCompilersProviderTest {
           FooConfigurer.class, BarConfigurer.class, BazConfigurer.class
       );
       var compilers = provider.provideArguments(mock(ExtensionContext.class))
-          .map(args -> (JctCompiler<?, ?>) args.get()[0])
+          .map(args -> (JctCompiler) args.get()[0])
           .collect(Collectors.toList());
 
       // Then
@@ -392,7 +392,7 @@ class AbstractCompilersProviderTest {
               "public class SomeConfigurer implements " + JctCompilerConfigurer.class.getName()
                   + "<" + RuntimeException.class.getName() + "> {",
               "  @Override",
-              "  public void configure(" + JctCompiler.class.getName() + "<?, ?> compiler) {",
+              "  public void configure(" + JctCompiler.class.getName() + " compiler) {",
               "    return;",
               "  }",
               "}"
@@ -489,7 +489,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    protected JctCompiler<?, ?> initializeNewCompiler() {
+    protected JctCompiler initializeNewCompiler() {
       return mock(withSettings()
               .name("mock compiler")
               .defaultAnswer(Answers.RETURNS_SELF));
@@ -519,7 +519,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing.
     }
   }
@@ -537,7 +537,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing.
     }
   }
@@ -555,7 +555,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing.
     }
   }
@@ -573,7 +573,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing; unreachable.
     }
   }
@@ -591,7 +591,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       throw new TestAbortedException("aborted!");
     }
   }
@@ -609,7 +609,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing; unreachable.
     }
   }
@@ -627,7 +627,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing.
     }
   }
@@ -645,7 +645,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       throw new RuntimeException("Some error here");
     }
   }
@@ -663,7 +663,7 @@ class AbstractCompilersProviderTest {
     }
 
     @Override
-    public void configure(JctCompiler<?, ?> compiler) {
+    public void configure(JctCompiler compiler) {
       // Do nothing.
     }
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/VersionStrategyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/VersionStrategyTest.java
@@ -44,7 +44,7 @@ class VersionStrategyTest {
   String baseName;
 
   @Mock(answer = Answers.RETURNS_SELF, strictness = Strictness.LENIENT)
-  JctCompiler<?, ?> compiler;
+  JctCompiler compiler;
 
   @BeforeEach
   void setUp() {


### PR DESCRIPTION
Fixes #488 by removing the unused generic arguments in JctCompiler and derived classes.