### PR TITLE
Remove TestTemplate from JavacCompilerTest

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -83,7 +83,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
 @ParameterizedTest(name = "for compiler \"{0}\"")
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.ANNOTATION_TYPE, ElementType.METHOD, ElementType.TYPE})
-@TestTemplate
 @Tags({
     @Tag("java-compiler-testing-test"),
     @Tag("javac-test")


### PR DESCRIPTION
### Summary

Relates to GH-499, where Gradle builds appear to be requiring a template invocation provider rather than inheriting it from the ParametrizedTest annotation.

I don't believe we need TestTemplate at all.
