### PR TITLE
Implement default file manager creation hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,6 @@ object. This is already defined for you. All you need to provide in your compile
 
 - A [Jsr199CompilerFactory](https://javadoc.io/doc/io.github.ascopes.jct/java-compiler-testing/latest/io.github.ascopes.jct/io/github/ascopes/jct/compilers/AbstractJctCompiler.html#compile(io.github.ascopes.jct.workspaces.Workspace)) to provide JavaCompiler objects.
 - A [default release](https://javadoc.io/static/io.github.ascopes.jct/java-compiler-testing/1.0.3/io.github.ascopes.jct/io/github/ascopes/jct/compilers/AbstractJctCompiler.html#getDefaultRelease()) that defines the default language version to use unless overridden.
-- A [JctFileManagerFactory](https://javadoc.io/static/io.github.ascopes.jct/java-compiler-testing/1.0.3/io.github.ascopes.jct/io/github/ascopes/jct/compilers/AbstractJctCompiler.html#getFileManagerFactory()) to create a file manager.
 - A [FlagBuilder](https://javadoc.io/static/io.github.ascopes.jct/java-compiler-testing/1.0.3/io.github.ascopes.jct/io/github/ascopes/jct/compilers/AbstractJctCompiler.html#getFlagBuilderFactory()) to translate the compiler configuration to command-line arguments.
 
 ### ECJ (Eclipse Java Compiler)

--- a/README.md
+++ b/README.md
@@ -424,4 +424,4 @@ While ECJ supports the same interfaces as Javac that are used to call the compil
 A number of issues were found while developing  [ascopes/java-compiler-testing#163](https://github.com/ascopes/java-compiler-testing/issues/163) with ECJ which prevents many features such as JPMS support from working correctly 
 ([eclipse-jdt/eclipse.jdt.core#958](https://github.com/eclipse-jdt/eclipse.jdt.core/issues/958)).
 
-Since it is unlikely these issues will be addressed in the near future, support for ECJ has been shelved for the forseeable future.
+Since it is unlikely these issues will be addressed in the near future, support for ECJ has been shelved for the foreseeable future.

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>1.0.4-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -23,6 +23,7 @@ import io.github.ascopes.jct.compilers.impl.JctCompilationImpl;
 import io.github.ascopes.jct.ex.JctCompilerException;
 import io.github.ascopes.jct.filemanagers.AnnotationProcessorDiscovery;
 import io.github.ascopes.jct.filemanagers.JctFileManagerFactory;
+import io.github.ascopes.jct.filemanagers.JctFileManagers;
 import io.github.ascopes.jct.filemanagers.LoggingMode;
 import io.github.ascopes.jct.workspaces.Workspace;
 import java.io.IOException;
@@ -432,9 +433,15 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   /**
    * Get the file manager factory to use for building AbstractJctCompiler file manager during compilation.
    *
+   * <p>Since v1.1.0, this method has provided a default implementation. Before this, it was
+   * abstract. The default implementation calls
+   * {@link JctFileManagers#newJctFileManagerFactory(JctCompiler)}.
+   *
    * @return the factory.
    */
-  public abstract JctFileManagerFactory getFileManagerFactory();
+  public JctFileManagerFactory getFileManagerFactory() {
+    return JctFileManagers.newJctFileManagerFactory(this);
+  }
 
   /**
    * Get the compilation factory to use for building a compilation.
@@ -444,7 +451,9 @@ public abstract class AbstractJctCompiler implements JctCompiler {
    *
    * <p>Some obscure compiler implementations with potentially satanic rituals for initialising
    * and configuring components correctly may need to provide a custom implementation here instead.
-   * In this case, this method should be overridden.
+   * In this case, this method should be overridden. Base classes are not provided for you to
+   * extend in this case as this is usually not something you want to be doing. Instead, you should
+   * implement {@link JctCompilationFactory} directly.
    *
    * @return the compilation factory.
    */

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.filemanagers;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.filemanagers.impl.JctFileManagerFactoryImpl;
+import io.github.ascopes.jct.filemanagers.impl.JctFileManagerImpl;
+import io.github.ascopes.jct.utils.UtilityClass;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Helpers to create instances of default implementations for file managers.
+ *
+ * @author Ashley Scopes
+ * @since 1.1.0
+ */
+@API(since = "1.1.0", status = Status.STABLE)
+public final class JctFileManagers extends UtilityClass {
+  private JctFileManagers() {
+    // Static-only class.
+  }
+
+  /**
+   * Create a new default implementation of a file manager.
+   *
+   * @param release the Java release to use for the file manager.
+   * @return the file manager instance.
+   */
+  public static JctFileManager newJctFileManager(String release) {
+    return new JctFileManagerImpl(release);
+  }
+
+  /**
+   * Create a new default implementation of a file manager factory.
+   *
+   * @param compiler the JctCompiler to bind any file managers to.
+   * @return the file manager factory instance.
+   */
+  public static JctFileManagerFactory newJctFileManagerFactory(JctCompiler compiler) {
+    return new JctFileManagerFactoryImpl(compiler);
+  }
+}

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
@@ -56,6 +56,18 @@ public final class JctFileManagerFactoryImpl implements JctFileManagerFactory {
     this.compiler = compiler;
   }
 
+  /**
+   * Get the compiler that was set on this file manager factory.
+   *
+   * @return the compiler
+   * @since 1.1.0
+   */
+  @API(since = "1.1.0", status = Status.INTERNAL)
+  @VisibleForTestingOnly
+  public JctCompiler getCompiler() {
+    return compiler;
+  }
+
   @Override
   public JctFileManager createFileManager(Workspace workspace) {
     var release = compiler.getEffectiveRelease();

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/UtilityClassTestTemplate.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/UtilityClassTestTemplate.java
@@ -69,6 +69,14 @@ public interface UtilityClassTestTemplate {
         .hasSuperclass(UtilityClass.class);
   }
 
+  @DisplayName("Class should not implement any interfaces")
+  @Test
+  default void classShouldNotImplementAnyInterfaces() {
+    assertThat(getTypeBeingTested().getInterfaces())
+        .withFailMessage("Expected utility class to not implement any interfaces")
+        .isEmpty();
+  }
+
   @DisplayName("Class should be final")
   @Test
   default void testClassIsFinal() {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagersTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagersTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.filemanagers;
+
+import static io.github.ascopes.jct.tests.helpers.Fixtures.someRelease;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.filemanagers.JctFileManagers;
+import io.github.ascopes.jct.filemanagers.impl.JctFileManagerFactoryImpl;
+import io.github.ascopes.jct.filemanagers.impl.JctFileManagerImpl;
+import io.github.ascopes.jct.tests.helpers.UtilityClassTestTemplate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link JctFileManagers} tests.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JctFileManagers tests")
+class JctFileManagersTest implements UtilityClassTestTemplate {
+
+  @Override
+  public Class<?> getTypeBeingTested() {
+    return JctFileManagers.class;
+  }
+
+  @DisplayName(".newJctFileManager(String) returns a new JctFileManagerImpl instance")
+  @Test
+  void newJctFileManagerReturnsNewJctFileManagerImplInstance() {
+    // Given
+    var release = someRelease();
+
+    // When
+    var fileManager = JctFileManagers.newJctFileManager(release);
+
+    // Then
+    assertThat(fileManager).isInstanceOf(JctFileManagerImpl.class);
+    assertThat(fileManager.getEffectiveRelease()).isEqualTo(release);
+  }
+
+  @DisplayName(
+      ".newJctFileManagerFactory(JctCompiler) returns a new JctFileManagerFactoryImpl instance"
+  )
+  @Test
+  void newJctFileManagerFactoryReturnsNewJctFileManagerFactoryImplInstance() {
+    // Given
+    var compiler = mock(JctCompiler.class);
+
+    // When
+    var fileManagerFactory = JctFileManagers.newJctFileManagerFactory(compiler);
+
+    // Then
+    assertThat(fileManagerFactory).isInstanceOf(JctFileManagerFactoryImpl.class);
+    assertThat(((JctFileManagerFactoryImpl) fileManagerFactory).getCompiler()).isSameAs(compiler);
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerFactoryImplTest.java
@@ -71,6 +71,13 @@ class JctFileManagerFactoryImplTest {
   @Spy
   JctFileManagerFactoryImpl factory;
 
+  @DisplayName(".getCompiler() returns the compiler")
+  @Test
+  void getCompilerReturnsTheCompiler() {
+    // Then
+    assertThat(factory.getCompiler()).isSameAs(compiler);
+  }
+
   @DisplayName("Created file managers use the effective release")
   @Test
   void createdFileManagersUseTheEffectiveRelease() {

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>1.0.4-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>


### PR DESCRIPTION
Fixes GH-522.

### Summary

Provides mechanisms for third-party compiler integrations to build instances of the default JctFileManager and JctFileManager factories.

### Additional details

- Implement a default implementation for `AbstractJctCompiler#getFileManagerFactory`, removing the `abstract` modifier.
- Implement a new class `JctFileManagers` which provides static methods for creating object instances of the default file manager implementations.

Non-breaking change, but a new feature, so bumping the minor version.

