### PR TITLE
Rework internal exceptions to be tied to custom exception types

### DIFF
--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -16,7 +16,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
@@ -157,11 +157,11 @@ public final class JctCompilationAssert extends
    *
    * @param location the location to configure.
    * @return the assertions to perform.
-   * @throws AssertionError           if the compilation was null, or no group for the location
-   *                                  was found.
+   * @throws AssertionError           if the compilation was null, or no group for the location was
+   *                                  found.
    * @throws IllegalArgumentException if the location was
-   *                                  {@link Location#isModuleOrientedLocation() module-oriented}
-   *                                  or {@link Location#isOutputLocation() an output location}.
+   *                                  {@link Location#isModuleOrientedLocation() module-oriented} or
+   *                                  {@link Location#isOutputLocation() an output location}.
    * @throws NullPointerException     if the provided location object is null.
    */
   public PackageContainerGroupAssert packageGroup(Location location) {
@@ -193,8 +193,8 @@ public final class JctCompilationAssert extends
    *
    * @param location the location to configure.
    * @return the assertions to perform.
-   * @throws AssertionError           if the compilation was null, or no group for the location
-   *                                  was found.
+   * @throws AssertionError           if the compilation was null, or no group for the location was
+   *                                  found.
    * @throws IllegalArgumentException if the location is not
    *                                  {@link Location#isModuleOrientedLocation() module-oriented}.
    * @throws NullPointerException     if the provided location object is null.
@@ -228,8 +228,8 @@ public final class JctCompilationAssert extends
    *
    * @param location the location to configure.
    * @return the assertions to perform.
-   * @throws AssertionError           if the compilation was null, or no group for the location
-   *                                  was found.
+   * @throws AssertionError           if the compilation was null, or no group for the location was
+   *                                  found.
    * @throws IllegalArgumentException if the location is not
    *                                  {@link Location#isOutputLocation() an output location}.
    * @throws NullPointerException     if the provided location object is null.
@@ -256,8 +256,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the class package outputs.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert classOutputPackages() {
@@ -270,8 +269,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the class module outputs.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert classOutputModules() {
@@ -284,8 +282,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the source package outputs.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert sourceOutputPackages() {
@@ -298,8 +295,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the source module outputs.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert sourceOutputModules() {
@@ -312,8 +308,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the class path.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert classPathPackages() {
@@ -326,8 +321,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the source path.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert sourcePathPackages() {
@@ -340,8 +334,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the source path.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert moduleSourcePathModules() {
@@ -354,8 +347,7 @@ public final class JctCompilationAssert extends
    * <p>If not configured, the value being asserted on will be {@code null} in value.
    *
    * @return the assertions to perform on the module path.
-   * @throws AssertionError if the compilation was null, or no group for the location
-   *                        was found.
+   * @throws AssertionError if the compilation was null, or no group for the location was found.
    */
   @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert modulePathModules() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceAssert.java
@@ -34,7 +34,8 @@ import org.jspecify.annotations.Nullable;
  */
 @API(since = "0.0.1", status = Status.STABLE)
 public final class StackTraceAssert
-    extends AbstractListAssert<StackTraceAssert, List<? extends StackTraceElement>, StackTraceElement, StackTraceElementAssert> {
+    extends
+    AbstractListAssert<StackTraceAssert, List<? extends StackTraceElement>, StackTraceElement, StackTraceElementAssert> {
 
   /**
    * Initialize a new assertions object.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssert.java
@@ -46,7 +46,8 @@ import org.assertj.core.api.AbstractListAssert;
  */
 @API(since = "0.0.1", status = Status.STABLE)
 public final class TraceDiagnosticListAssert
-    extends AbstractListAssert<TraceDiagnosticListAssert, List<? extends TraceDiagnostic<? extends JavaFileObject>>, TraceDiagnostic<? extends JavaFileObject>, TraceDiagnosticAssert> {
+    extends
+    AbstractListAssert<TraceDiagnosticListAssert, List<? extends TraceDiagnostic<? extends JavaFileObject>>, TraceDiagnostic<? extends JavaFileObject>, TraceDiagnosticAssert> {
 
   /**
    * Initialize this assertion.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -121,7 +121,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   }
 
   @Override
-  public final <E extends Exception> AbstractJctCompiler configure(JctCompilerConfigurer<E> configurer) throws E {
+  public final <E extends Exception> AbstractJctCompiler configure(
+      JctCompilerConfigurer<E> configurer) throws E {
     requireNonNull(configurer, "configurer");
     configurer.configure(this);
     return this;
@@ -210,7 +211,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   }
 
   @Override
-  public AbstractJctCompiler addAnnotationProcessorOptions(Iterable<String> annotationProcessorOptions) {
+  public AbstractJctCompiler addAnnotationProcessorOptions(
+      Iterable<String> annotationProcessorOptions) {
     requireNonNullValues(annotationProcessorOptions, "annotationProcessorOptions");
     annotationProcessorOptions.forEach(this.annotationProcessorOptions::add);
     return this;
@@ -222,7 +224,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   }
 
   @Override
-  public AbstractJctCompiler addAnnotationProcessors(Iterable<? extends Processor> annotationProcessors) {
+  public AbstractJctCompiler addAnnotationProcessors(
+      Iterable<? extends Processor> annotationProcessors) {
     requireNonNullValues(annotationProcessors, "annotationProcessors");
     annotationProcessors.forEach(this.annotationProcessors::add);
 
@@ -396,7 +399,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   }
 
   @Override
-  public AbstractJctCompiler annotationProcessorDiscovery(AnnotationProcessorDiscovery annotationProcessorDiscovery) {
+  public AbstractJctCompiler annotationProcessorDiscovery(
+      AnnotationProcessorDiscovery annotationProcessorDiscovery) {
     this.annotationProcessorDiscovery = requireNonNull(
         annotationProcessorDiscovery,
         "annotationProcessorDiscovery"
@@ -431,7 +435,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   public abstract Jsr199CompilerFactory getCompilerFactory();
 
   /**
-   * Get the file manager factory to use for building AbstractJctCompiler file manager during compilation.
+   * Get the file manager factory to use for building AbstractJctCompiler file manager during
+   * compilation.
    *
    * <p>Since v1.1.0, this method has provided a default implementation. Before this, it was
    * abstract. The default implementation calls
@@ -451,8 +456,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
    *
    * <p>Some obscure compiler implementations with potentially satanic rituals for initialising
    * and configuring components correctly may need to provide a custom implementation here instead.
-   * In this case, this method should be overridden. Base classes are not provided for you to
-   * extend in this case as this is usually not something you want to be doing. Instead, you should
+   * In this case, this method should be overridden. Base classes are not provided for you to extend
+   * in this case as this is usually not something you want to be doing. Instead, you should
    * implement {@link JctCompilationFactory} directly.
    *
    * @return the compilation factory.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilationFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilationFactory.java
@@ -44,8 +44,8 @@ public interface JctCompilationFactory {
    * @return the compilation result that contains whether the compiler succeeded or failed, amongst
    *     other information.
    * @throws JctCompilerException if any prerequisites fail, such as no compilation units being
-   *    found, or if the underlying JSR-199 compiler raises an unhandled exception and cannot
-   *    complete when invoked.
+   *                              found, or if the underlying JSR-199 compiler raises an unhandled
+   *                              exception and cannot complete when invoked.
    */
   JctCompilation createCompilation(
       List<String> flags,

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -157,7 +157,8 @@ public interface JctCompiler {
    * @see #compile(Workspace)
    * @see #compile(Workspace, Collection)
    */
-  default JctCompilation compile(Workspace workspace, String firstClassName, String... additionalClassNames) {
+  default JctCompilation compile(Workspace workspace, String firstClassName,
+      String... additionalClassNames) {
     return compile(workspace, IterableUtils.combineOneOrMore(firstClassName, additionalClassNames));
   }
 
@@ -842,5 +843,6 @@ public interface JctCompiler {
    * @param annotationProcessorDiscovery the processor discovery mode to use.
    * @return this compiler for further call chaining.
    */
-  JctCompiler annotationProcessorDiscovery(AnnotationProcessorDiscovery annotationProcessorDiscovery);
+  JctCompiler annotationProcessorDiscovery(
+      AnnotationProcessorDiscovery annotationProcessorDiscovery);
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
@@ -99,8 +99,8 @@ public interface Container extends Closeable {
    * in, rather than the location of the archive on the original file system.
    *
    * <p>It is worth noting that this operation may result in the archive being loaded into memory
-   * eagerly if it uses lazy loading, due to the need to load the archive to be able to determine
-   * an accurate handle to the inner root directory.
+   * eagerly if it uses lazy loading, due to the need to load the archive to be able to determine an
+   * accurate handle to the inner root directory.
    *
    * @return the path root.
    * @since 0.0.6

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/OutputContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/OutputContainerGroup.java
@@ -32,8 +32,8 @@ import org.apiguardian.api.API.Status;
  * group. Operations on non-module packages should operate on this container group directly.
  *
  * <p>Note that each container group will usually only support one package container group
- * in the outputs. This is due to the JSR-199 API not providing a method for specifying which
- * output location to write files to for legacy-style packages.
+ * in the outputs. This is due to the JSR-199 API not providing a method for specifying which output
+ * location to write files to for legacy-style packages.
  *
  * @author Ashley Scopes
  * @since 0.0.1
@@ -81,7 +81,7 @@ public interface OutputContainerGroup extends PackageContainerGroup, ModuleConta
    * JSR-199 limitations.
    *
    * @return the list containing the package container, if it exists. Otherwise, an empty list is
-   * returned instead.
+   *     returned instead.
    */
   @Override
   List<Container> getPackages();

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -39,167 +39,167 @@ import org.apiguardian.api.API.Status;
 @API(since = "0.0.1", status = Status.STABLE)
 public interface PackageContainerGroup extends ContainerGroup {
 
-    /**
-     * Add a container to this group.
-     *
-     * <p>The provided container will be closed when this group is closed.
-     *
-     * @param container the container to add.
-     */
-    void addPackage(Container container);
+  /**
+   * Add a container to this group.
+   *
+   * <p>The provided container will be closed when this group is closed.
+   *
+   * @param container the container to add.
+   */
+  void addPackage(Container container);
 
-    /**
-     * Add a path to this group.
-     *
-     * <p>Note that this will destroy the {@link #getClassLoader() classloader} if one is already
-     * allocated.
-     *
-     * <p>If the path points to some form of archive (such as a JAR), then this may open that archive
-     * in a new resource internally. If this occurs, then the resource will always be freed by this
-     * class by calling {@link #close()}.
-     *
-     * <p>Any other closable resources passed to this function will not be closed by this
-     * implementation. You must handle the lifecycle of those objects yourself.
-     *
-     * @param path the path to add.
-     */
-    void addPackage(PathRoot path);
+  /**
+   * Add a path to this group.
+   *
+   * <p>Note that this will destroy the {@link #getClassLoader() classloader} if one is already
+   * allocated.
+   *
+   * <p>If the path points to some form of archive (such as a JAR), then this may open that archive
+   * in a new resource internally. If this occurs, then the resource will always be freed by this
+   * class by calling {@link #close()}.
+   *
+   * <p>Any other closable resources passed to this function will not be closed by this
+   * implementation. You must handle the lifecycle of those objects yourself.
+   *
+   * @param path the path to add.
+   */
+  void addPackage(PathRoot path);
 
-    /**
-     * Get a class loader for this group of containers.
-     *
-     * <p>Note that adding additional containers to this group after accessing this class loader
-     * may result in the class loader being destroyed or re-created.
-     *
-     * @return the class loader.
-     */
-    ClassLoader getClassLoader();
+  /**
+   * Get a class loader for this group of containers.
+   *
+   * <p>Note that adding additional containers to this group after accessing this class loader
+   * may result in the class loader being destroyed or re-created.
+   *
+   * @return the class loader.
+   */
+  ClassLoader getClassLoader();
 
-    /**
-     * Find the first occurrence of a given path to a file in packages or modules.
-     *
-     * <p>Modules are treated as subdirectories.
-     *
-     * <pre><code>
-     *   // Using platform-specific separators.
-     *   containerGroup.getFile("foo/bar/baz.txt")...;
-     *
-     *   // Letting JCT infer the correct path separators to use (recommended).
-     *   containerGroup.getFile("foo", "bar", "baz.txt");
-     * </code></pre>
-     *
-     * @param fragment  the first part of the path.
-     * @param fragments any additional parts of the path.
-     * @return the first occurrence of the path in this group, or null if not found.
-     * @throws IllegalArgumentException if the provided path is absolute.
-     */
-    Path getFile(String fragment, String... fragments);
+  /**
+   * Find the first occurrence of a given path to a file in packages or modules.
+   *
+   * <p>Modules are treated as subdirectories.
+   *
+   * <pre><code>
+   *   // Using platform-specific separators.
+   *   containerGroup.getFile("foo/bar/baz.txt")...;
+   *
+   *   // Letting JCT infer the correct path separators to use (recommended).
+   *   containerGroup.getFile("foo", "bar", "baz.txt");
+   * </code></pre>
+   *
+   * @param fragment  the first part of the path.
+   * @param fragments any additional parts of the path.
+   * @return the first occurrence of the path in this group, or null if not found.
+   * @throws IllegalArgumentException if the provided path is absolute.
+   */
+  Path getFile(String fragment, String... fragments);
 
-    /**
-     * Get a {@link FileObject} that can have content read from it.
-     *
-     * <p>This will return {@code null} if no file is found matching the criteria.
-     *
-     * @param packageName  the package name of the file to read.
-     * @param relativeName the relative name of the file to read.
-     * @return the file object, or null if the file is not found.
-     */
-    PathFileObject getFileForInput(String packageName, String relativeName);
+  /**
+   * Get a {@link FileObject} that can have content read from it.
+   *
+   * <p>This will return {@code null} if no file is found matching the criteria.
+   *
+   * @param packageName  the package name of the file to read.
+   * @param relativeName the relative name of the file to read.
+   * @return the file object, or null if the file is not found.
+   */
+  PathFileObject getFileForInput(String packageName, String relativeName);
 
-    /**
-     * Get a {@link FileObject} that can have content written to it for the given file.
-     *
-     * <p>This will attempt to write to the first writeable path in this group. {@code null}
-     * will be returned if no writeable paths exist in this group.
-     *
-     * @param packageName  the name of the package the file is in.
-     * @param relativeName the relative name of the file within the package.
-     * @return the {@link FileObject} to write to, or null if this group has no paths that can be
-     * written to.
-     */
-    PathFileObject getFileForOutput(String packageName, String relativeName);
+  /**
+   * Get a {@link FileObject} that can have content written to it for the given file.
+   *
+   * <p>This will attempt to write to the first writeable path in this group. {@code null}
+   * will be returned if no writeable paths exist in this group.
+   *
+   * @param packageName  the name of the package the file is in.
+   * @param relativeName the relative name of the file within the package.
+   * @return the {@link FileObject} to write to, or null if this group has no paths that can be
+   *     written to.
+   */
+  PathFileObject getFileForOutput(String packageName, String relativeName);
 
-    /**
-     * Get a {@link JavaFileObject} that can have content read from it for the given file.
-     *
-     * <p>This will return {@code null} if no file is found matching the criteria.
-     *
-     * @param className the binary name of the class to read.
-     * @param kind      the kind of file to read.
-     * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
-     * written to.
-     */
-    PathFileObject getJavaFileForInput(String className, Kind kind);
+  /**
+   * Get a {@link JavaFileObject} that can have content read from it for the given file.
+   *
+   * <p>This will return {@code null} if no file is found matching the criteria.
+   *
+   * @param className the binary name of the class to read.
+   * @param kind      the kind of file to read.
+   * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
+   *     written to.
+   */
+  PathFileObject getJavaFileForInput(String className, Kind kind);
 
-    /**
-     * Get a {@link JavaFileObject} that can have content written to it for the given class.
-     *
-     * <p>This will attempt to write to the first writeable path in this group. {@code null}
-     * will be returned if no writeable paths exist in this group.
-     *
-     * @param className the name of the class.
-     * @param kind      the kind of the class file.
-     * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
-     * written to.
-     */
-    PathFileObject getJavaFileForOutput(String className, Kind kind);
+  /**
+   * Get a {@link JavaFileObject} that can have content written to it for the given class.
+   *
+   * <p>This will attempt to write to the first writeable path in this group. {@code null}
+   * will be returned if no writeable paths exist in this group.
+   *
+   * @param className the name of the class.
+   * @param kind      the kind of the class file.
+   * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
+   *     written to.
+   */
+  PathFileObject getJavaFileForOutput(String className, Kind kind);
 
-    /**
-     * Get the package-oriented location that this group of paths is for.
-     *
-     * @return the package-oriented location.
-     */
-    Location getLocation();
+  /**
+   * Get the package-oriented location that this group of paths is for.
+   *
+   * @return the package-oriented location.
+   */
+  Location getLocation();
 
-    /**
-     * Get the package containers in this group.
-     *
-     * <p>Returned packages are presented in the order that they were registered. This is the
-     * resolution order that the compiler will use.
-     *
-     * @return the containers.
-     */
-    List<Container> getPackages();
+  /**
+   * Get the package containers in this group.
+   *
+   * <p>Returned packages are presented in the order that they were registered. This is the
+   * resolution order that the compiler will use.
+   *
+   * @return the containers.
+   */
+  List<Container> getPackages();
 
-    /**
-     * Try to infer the binary name of a given file object.
-     *
-     * @param fileObject the file object to infer the binary name for.
-     * @return the binary name if known, or null otherwise.
-     */
-    String inferBinaryName(PathFileObject fileObject);
+  /**
+   * Try to infer the binary name of a given file object.
+   *
+   * @param fileObject the file object to infer the binary name for.
+   * @return the binary name if known, or null otherwise.
+   */
+  String inferBinaryName(PathFileObject fileObject);
 
-    /**
-     * Determine if this group has no paths registered.
-     *
-     * @return {@code true} if no paths are registered. {@code false} if paths are registered.
-     */
-    boolean isEmpty();
+  /**
+   * Determine if this group has no paths registered.
+   *
+   * @return {@code true} if no paths are registered. {@code false} if paths are registered.
+   */
+  boolean isEmpty();
 
-    /**
-     * List all the file objects that match the given criteria in this group.
-     *
-     * @param packageName the package name to look in.
-     * @param kinds       the kinds of file to look for.
-     * @param recurse     {@code true} to recurse subpackages, {@code false} to only consider the
-     *                    given package.
-     * @return thr file objects that were found.
-     * @throws IOException if the file lookup fails due to an IO error somewhere.
-     */
-    Set<JavaFileObject> listFileObjects(
-            String packageName,
-            Set<? extends Kind> kinds,
-            boolean recurse
-    ) throws IOException;
+  /**
+   * List all the file objects that match the given criteria in this group.
+   *
+   * @param packageName the package name to look in.
+   * @param kinds       the kinds of file to look for.
+   * @param recurse     {@code true} to recurse subpackages, {@code false} to only consider the
+   *                    given package.
+   * @return thr file objects that were found.
+   * @throws IOException if the file lookup fails due to an IO error somewhere.
+   */
+  Set<JavaFileObject> listFileObjects(
+      String packageName,
+      Set<? extends Kind> kinds,
+      boolean recurse
+  ) throws IOException;
 
-    /**
-     * List all files recursively in this container group, returning a multimap of each container and all files
-     * within that container.
-     *
-     * @return a multimap of containers mapping to collections of all files in that container.
-     * @throws IOException if the file lookup fails due to an IO error somewhere.
-     * @since 0.6.0
-     */
-    @API(since = "0.6.0", status = Status.STABLE)
-    Map<Container, Collection<Path>> listAllFiles() throws IOException;
+  /**
+   * List all files recursively in this container group, returning a multimap of each container and
+   * all files within that container.
+   *
+   * @return a multimap of containers mapping to collections of all files in that container.
+   * @throws IOException if the file lookup fails due to an IO error somewhere.
+   * @since 0.6.0
+   */
+  @API(since = "0.6.0", status = Status.STABLE)
+  Map<Container, Collection<Path>> listAllFiles() throws IOException;
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.github.ascopes.jct.containers.Container;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.utils.Lazy;
@@ -140,7 +141,7 @@ public abstract class AbstractPackageContainerGroup implements PackageContainerG
       }
     }
 
-    if (exceptions.size() > 0) {
+    if (!exceptions.isEmpty()) {
       var newEx = new IOException("Containers failed to close in " + location.getName());
       exceptions.forEach(newEx::addSuppressed);
       throw newEx;
@@ -230,7 +231,7 @@ public abstract class AbstractPackageContainerGroup implements PackageContainerG
   @Override
   public <S> ServiceLoader<S> getServiceLoader(Class<S> service) {
     if (location instanceof ModuleLocation) {
-      throw new UnsupportedOperationException("Cannot load services from specific modules");
+      throw new JctIllegalInputException("Cannot load services from specific modules");
     }
 
     return ServiceLoader.load(service, classLoaderLazy.access());

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImpl.java
@@ -19,6 +19,7 @@ import io.github.ascopes.jct.containers.ContainerGroup;
 import io.github.ascopes.jct.containers.ModuleContainerGroup;
 import io.github.ascopes.jct.containers.OutputContainerGroup;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.utils.ModuleDiscoverer;
 import io.github.ascopes.jct.workspaces.PathRoot;
@@ -71,7 +72,7 @@ public final class ContainerGroupRepositoryImpl implements AutoCloseable {
    *
    * @param location the location to add.
    * @param pathRoot the path root to register with the location.
-   * @throws IllegalStateException if the location is an output location and is misconfigured.
+   * @throws JctIllegalInputException if the location is an output location and is misconfigured.
    */
   public void addPath(Location location, PathRoot pathRoot) {
     if (location instanceof ModuleLocation) {
@@ -101,26 +102,26 @@ public final class ContainerGroupRepositoryImpl implements AutoCloseable {
    *
    * @param from the location to copy from.
    * @param to   the location to copy to.
-   * @throws IllegalArgumentException if either location is a {@link ModuleLocation}, or if the two
+   * @throws JctIllegalInputException if either location is a {@link ModuleLocation}, or if the two
    *                                  locations are not the same orientation (i.e. output-oriented,
    *                                  module-oriented).
    */
   public void copyContainers(Location from, Location to) {
     if (from instanceof ModuleLocation || to instanceof ModuleLocation) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Cannot currently transfer individual modules to other locations"
       );
     }
 
     if (from.isOutputLocation() && !to.isOutputLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Expected " + from.getName() + " and " + to.getName() + " to both be "
               + "output locations"
       );
     }
 
     if (from.isModuleOrientedLocation() && !to.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Expected " + from.getName() + " and " + to.getName() + " to both be "
               + "module-oriented locations"
       );
@@ -140,13 +141,13 @@ public final class ContainerGroupRepositoryImpl implements AutoCloseable {
    * Create an empty location if it does not already exist.
    *
    * @param location the location to create.
-   * @throws IllegalArgumentException if the input is a module location.
+   * @throws JctIllegalInputException if the input is a module location.
    */
   public void createEmptyLocation(Location location) {
     if (location instanceof ModuleLocation) {
-      throw new IllegalArgumentException("Cannot ensure a module location exists");
+      throw new JctIllegalInputException("Cannot ensure a module location exists");
     } else if (location.isOutputLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Cannot create an empty output location. It must be created by "
               + "registering at least one file system path to enable output to."
       );

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
@@ -19,6 +19,7 @@ import static io.github.ascopes.jct.utils.IoExceptionUtils.uncheckedIo;
 import static java.util.Objects.requireNonNull;
 
 import io.github.ascopes.jct.containers.Container;
+import io.github.ascopes.jct.ex.JctNotImplementedException;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.filemanagers.impl.PathFileObjectImpl;
 import io.github.ascopes.jct.utils.FileUtils;
@@ -130,7 +131,7 @@ public final class JarContainerImpl implements Container {
 
   @Override
   public PathFileObject getFileForOutput(String packageName, String relativeName) {
-    throw new UnsupportedOperationException("Cannot handle output files in JARs");
+    throw new JctNotImplementedException("Cannot handle output files in JARs");
   }
 
   @Override
@@ -160,7 +161,7 @@ public final class JarContainerImpl implements Container {
 
   @Override
   public PathFileObject getJavaFileForOutput(String className, Kind kind) {
-    throw new UnsupportedOperationException("Cannot handle output source files in JARs");
+    throw new JctNotImplementedException("Cannot handle output source files in JARs");
   }
 
   @Override
@@ -191,7 +192,7 @@ public final class JarContainerImpl implements Container {
     // get the correct path immediately.
     var fullPath = javaFileObject.getAbsolutePath();
 
-    if (fullPath.startsWith( holder.access().getPathRoot().getPath())) {
+    if (fullPath.startsWith(holder.access().getPathRoot().getPath())) {
       return FileUtils.pathToBinaryName(javaFileObject.getRelativePath());
     }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ModuleContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ModuleContainerGroupImpl.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 import io.github.ascopes.jct.containers.Container;
 import io.github.ascopes.jct.containers.ModuleContainerGroup;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.utils.StringUtils;
@@ -56,15 +57,15 @@ public final class ModuleContainerGroupImpl implements ModuleContainerGroup {
    *
    * @param location the module-oriented location.
    * @param release  the release to use for Multi-Release JARs.
-   * @throws UnsupportedOperationException if the {@code location} is not module-oriented, or is
-   *                                       output-oriented.
+   * @throws JctIllegalInputException if the {@code location} is not module-oriented, or is
+   *                                  output-oriented.
    */
   public ModuleContainerGroupImpl(Location location, String release) {
     this.location = requireNonNull(location, "location");
     this.release = requireNonNull(release, "release");
 
     if (location.isOutputLocation()) {
-      throw new UnsupportedOperationException(
+      throw new JctIllegalInputException(
           "Cannot use output-oriented locations such as "
               + StringUtils.quoted(location.getName())
               + " with this container"
@@ -72,7 +73,7 @@ public final class ModuleContainerGroupImpl implements ModuleContainerGroup {
     }
 
     if (!location.isModuleOrientedLocation()) {
-      throw new UnsupportedOperationException(
+      throw new JctIllegalInputException(
           "Cannot use package-oriented locations such as "
               + StringUtils.quoted(location.getName())
               + " with this container"
@@ -138,7 +139,7 @@ public final class ModuleContainerGroupImpl implements ModuleContainerGroup {
   @Override
   public PackageContainerGroup getModule(String name) {
     if (name.isEmpty()) {
-      throw new IllegalArgumentException("Cannot have module sources with no valid module name");
+      throw new JctIllegalInputException("Cannot have module sources with no valid module name");
     }
 
     return modules.get(new ModuleLocation(location, name));

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
@@ -20,6 +20,7 @@ import static io.github.ascopes.jct.utils.IoExceptionUtils.uncheckedIo;
 import io.github.ascopes.jct.containers.Container;
 import io.github.ascopes.jct.containers.OutputContainerGroup;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.utils.StringUtils;
@@ -65,7 +66,7 @@ public final class OutputContainerGroupImpl
     modules = new HashMap<>();
 
     if (location.isModuleOrientedLocation()) {
-      throw new UnsupportedOperationException(
+      throw new JctIllegalInputException(
           "Cannot use module-oriented locations such as "
               + StringUtils.quoted(location.getName())
               + " with this container"
@@ -73,7 +74,7 @@ public final class OutputContainerGroupImpl
     }
 
     if (!location.isOutputLocation()) {
-      throw new UnsupportedOperationException(
+      throw new JctIllegalInputException(
           "Cannot use non-output locations such as "
               + StringUtils.quoted(location.getName())
               + " with this container"
@@ -173,7 +174,7 @@ public final class OutputContainerGroupImpl
 
     if (packages.isEmpty()) {
       // This *shouldn't* be reachable in most cases.
-      throw new IllegalStateException(
+      throw new JctIllegalInputException(
           "Cannot add module " + moduleLocation + " to outputs. No output path has been "
               + "provided for this location! Please register a package path to output generated "
               + "modules to first before running the compiler."
@@ -193,9 +194,9 @@ public final class OutputContainerGroupImpl
   }
 
   @SuppressWarnings("resource")
-  private IllegalStateException packageAlreadySpecified(PathRoot newPathRoot) {
+  private JctIllegalInputException packageAlreadySpecified(PathRoot newPathRoot) {
     var existingPathRoot = getPackages().iterator().next().getPathRoot();
-    return new IllegalStateException(
+    return new JctIllegalInputException(
         "Cannot add a new package (" + newPathRoot + ") to this output container group because " +
             "a package has already been specified (" + existingPathRoot + ")"
     );

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupImpl.java
@@ -15,6 +15,7 @@
  */
 package io.github.ascopes.jct.containers.impl;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.utils.StringUtils;
 import javax.tools.JavaFileManager.Location;
 import org.apiguardian.api.API;
@@ -44,7 +45,7 @@ public final class PackageContainerGroupImpl extends AbstractPackageContainerGro
     super(location, release);
 
     if (location.isOutputLocation()) {
-      throw new UnsupportedOperationException(
+      throw new JctIllegalInputException(
           "Cannot use output locations such as "
               + StringUtils.quoted(location.getName())
               + " with this container"
@@ -52,7 +53,7 @@ public final class PackageContainerGroupImpl extends AbstractPackageContainerGro
     }
 
     if (location.isModuleOrientedLocation()) {
-      throw new UnsupportedOperationException(
+      throw new JctIllegalInputException(
           "Cannot use module-oriented locations such as "
               + StringUtils.quoted(location.getName())
               + " with this container"

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctIllegalInputException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctIllegalInputException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.ex;
+
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * Exception raised if an illegal input is provided to a method.
+ *
+ * @author Ashley Scopes
+ * @since 1.1.0
+ */
+@API(since = "1.1.0", status = Status.STABLE)
+public final class JctIllegalInputException extends JctException {
+
+  /**
+   * Initialise the exception.
+   *
+   * @param message the message to report.
+   */
+  public JctIllegalInputException(String message) {
+    super(message);
+  }
+
+  /**
+   * Initialise the exception with a cause.
+   *
+   * @param message the message to report.
+   * @param cause   the cause of the exception.
+   */
+  public JctIllegalInputException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotFoundException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotFoundException.java
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.greeter;
+package io.github.ascopes.jct.ex;
 
-public class Greeter {
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
 
-  public static String greet(String name) {
-    return "Hello, " + name + "!";
+/**
+ * Exception raised if an element is not found.
+ *
+ * @author Ashley Scopes
+ * @since 1.1.0
+ */
+@API(since = "1.1.0", status = Status.STABLE)
+public final class JctNotFoundException extends JctException {
+
+  /**
+   * Initialise the exception.
+   *
+   * @param message the message to report.
+   */
+  public JctNotFoundException(String message) {
+    super(message);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotImplementedException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotImplementedException.java
@@ -13,11 +13,26 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.example.greeter;
+package io.github.ascopes.jct.ex;
 
-public class Greeter {
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
 
-  public static String greet(String name) {
-    return "Hello, " + name + "!";
+/**
+ * Exception that is raised if an internal feature is not implemented.
+ *
+ * @author Ashley Scopes
+ * @since 1.1.0
+ */
+@API(since = "1.1.0", status = Status.STABLE)
+public final class JctNotImplementedException extends JctException {
+
+  /**
+   * Initialise the exception.
+   *
+   * @param message the message to report.
+   */
+  public JctNotImplementedException(String message) {
+    super(message);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
@@ -30,6 +30,7 @@ import org.apiguardian.api.API.Status;
  */
 @API(since = "1.1.0", status = Status.STABLE)
 public final class JctFileManagers extends UtilityClass {
+
   private JctFileManagers() {
     // Static-only class.
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/ModuleLocation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/ModuleLocation.java
@@ -15,6 +15,7 @@
  */
 package io.github.ascopes.jct.filemanagers;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.utils.ToStringBuilder;
 import java.util.Objects;
 import javax.tools.JavaFileManager.Location;
@@ -40,7 +41,7 @@ public final class ModuleLocation implements Location {
    *
    * @param parent     the parent location.
    * @param moduleName the module name.
-   * @throws IllegalArgumentException if the parent location is not an output location or a
+   * @throws JctIllegalInputException if the parent location is not an output location or a
    *                                  module-oriented location.
    */
   public ModuleLocation(Location parent, String moduleName) {
@@ -48,7 +49,7 @@ public final class ModuleLocation implements Location {
     Objects.requireNonNull(moduleName, "moduleName");
 
     if (!parent.isOutputLocation() && !parent.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "The parent of a module location must be either an output location "
               + "or be module-oriented, but got "
               + parent.getName()

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurer.java
@@ -16,6 +16,7 @@
 package io.github.ascopes.jct.filemanagers.config;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.AnnotationProcessorDiscovery;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import java.util.Map;
@@ -84,7 +85,7 @@ public final class JctFileManagerAnnotationProcessorClassPathConfigurer implemen
         return fileManager;
 
       default:
-        throw new IllegalStateException("Cannot configure annotation processor discovery");
+        throw new JctIllegalInputException("Cannot configure annotation processor discovery");
     }
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurerChain.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurerChain.java
@@ -30,8 +30,8 @@ import org.slf4j.LoggerFactory;
  * A chain of configurers to apply to a file manager.
  *
  * <p>While not designed for concurrent use, all operations are shielded by a
- * lock to guard against potentially confusing behaviour, should this component
- * be shared across multiple physical and virtual threads.
+ * lock to guard against potentially confusing behaviour, should this component be shared across
+ * multiple physical and virtual threads.
  *
  * @author Ashley Scopes
  * @since 0.0.1

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImpl.java
@@ -21,6 +21,8 @@ import io.github.ascopes.jct.containers.ModuleContainerGroup;
 import io.github.ascopes.jct.containers.OutputContainerGroup;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.containers.impl.ContainerGroupRepositoryImpl;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
+import io.github.ascopes.jct.ex.JctNotFoundException;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
@@ -30,7 +32,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Set;
@@ -226,7 +227,7 @@ public final class JctFileManagerImpl implements JctFileManager {
       return null;
     }
 
-    throw new IllegalArgumentException(
+    throw new JctIllegalInputException(
         "File object " + fo + " is not compatible with this file manager"
     );
   }
@@ -270,7 +271,7 @@ public final class JctFileManagerImpl implements JctFileManager {
     var group = repository.getContainerGroup(location);
 
     if (group == null) {
-      throw new NoSuchElementException(
+      throw new JctNotFoundException(
           "No container group for location " + location.getName() + " exists in this file manager"
       );
     }
@@ -355,7 +356,7 @@ public final class JctFileManagerImpl implements JctFileManager {
 
   private static void requireOutputOrModuleOrientedLocation(Location location) {
     if (!location.isOutputLocation() && !location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be output or module-oriented"
       );
     }
@@ -363,7 +364,7 @@ public final class JctFileManagerImpl implements JctFileManager {
 
   private static void requireModuleOrientedLocation(Location location) {
     if (!location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be module-oriented"
       );
     }
@@ -371,7 +372,7 @@ public final class JctFileManagerImpl implements JctFileManager {
 
   private static void requireOutputLocation(Location location) {
     if (!location.isOutputLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be an output location"
       );
     }
@@ -379,7 +380,7 @@ public final class JctFileManagerImpl implements JctFileManager {
 
   private void requirePackageLocation(Location location) {
     if (location.isModuleOrientedLocation() || location.isOutputLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be an input package location"
       );
     }
@@ -387,7 +388,7 @@ public final class JctFileManagerImpl implements JctFileManager {
 
   private void requirePackageOrientedLocation(Location location) {
     if (location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be package-oriented"
       );
     }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/PathFileObjectImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/PathFileObjectImpl.java
@@ -17,6 +17,7 @@ package io.github.ascopes.jct.filemanagers.impl;
 
 import static java.util.Objects.requireNonNull;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.utils.FileUtils;
 import io.github.ascopes.jct.utils.ToStringBuilder;
@@ -88,7 +89,7 @@ public final class PathFileObjectImpl implements PathFileObject {
     requireNonNull(relativePath, "relativePath");
 
     if (!rootPath.isAbsolute()) {
-      throw new IllegalArgumentException("Expected rootPath to be absolute, but got " + rootPath);
+      throw new JctIllegalInputException("Expected rootPath to be absolute, but got " + rootPath);
     }
 
     this.location = location;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
@@ -20,6 +20,7 @@ import static java.util.Objects.requireNonNull;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.compilers.JctCompilerConfigurer;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.ex.JctJunitConfigurerException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InaccessibleObjectException;
@@ -41,7 +42,7 @@ import org.opentest4j.TestAbortedException;
  * <p>Each implementation is expected to provide:
  *
  * <ul>
- *   <li>A method {@link #initializeNewCompiler} that returns new instances of a 
+ *   <li>A method {@link #initializeNewCompiler} that returns new instances of a
  *       {@link JctCompiler};</li>
  *   <li>A minimum acceptable language level for the compiler, as an integer;</li>
  *   <li>A maximum acceptable language level for the compiler, as an integer;</li>
@@ -167,17 +168,19 @@ public abstract class AbstractCompilersProvider implements ArgumentsProvider {
    *
    * <p>This is expected to be called from an implementation of {@link AnnotationConsumer}.
    *
-   * <p>The minimum compiler version will be set to the {@code min} parameter, or {@link #minSupportedVersion}, 
-   * whichever is greater. This means annotations can pass {@link Integer#MIN_VALUE} as a default value safely.
+   * <p>The minimum compiler version will be set to the {@code min} parameter, or
+   * {@link #minSupportedVersion}, whichever is greater. This means annotations can pass
+   * {@link Integer#MIN_VALUE} as a default value safely.
    *
-   * <p>The maximum compiler version will be set to the {@code max} parameter, or {@link #maxSupportedVersion}, 
-   * whichever is smaller. This means annotations can pass {@link Integer#MAX_VALUE} as a default value safely.
+   * <p>The maximum compiler version will be set to the {@code max} parameter, or
+   * {@link #maxSupportedVersion}, whichever is smaller. This means annotations can pass
+   * {@link Integer#MAX_VALUE} as a default value safely.
    *
-   * <p>If implementations do not support specifying custom compiler configurers, then an empty array must be
-   * passed for the {@code configurerClasses} parameter.
+   * <p>If implementations do not support specifying custom compiler configurers, then an empty
+   * array must be passed for the {@code configurerClasses} parameter.
    *
-   * <p>If implementations do not support changing the version strategy, then it is suggested to pass
-   * {@link VersionStrategy#RELEASE} as the value for the {@code versionStrategy} parameter.
+   * <p>If implementations do not support changing the version strategy, then it is suggested to
+   * pass {@link VersionStrategy#RELEASE} as the value for the {@code versionStrategy} parameter.
    *
    * @param min               the inclusive minimum compiler version to use.
    * @param max               the inclusive maximum compiler version to use.
@@ -194,11 +197,11 @@ public abstract class AbstractCompilersProvider implements ArgumentsProvider {
     max = Math.min(max, maxSupportedVersion());
 
     if (max < 8 || min < 8) {
-      throw new IllegalArgumentException("Cannot use a Java version less than Java 8");
+      throw new JctIllegalInputException("Cannot use a Java version less than Java 8");
     }
 
     if (min > max) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Cannot set min version to a version higher than the max version"
       );
     }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -85,7 +85,7 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
     @Tag("javac-test")
 })
 @Target({
-    ElementType.ANNOTATION_TYPE, 
+    ElementType.ANNOTATION_TYPE,
     ElementType.METHOD,
 })
 @TestTemplate

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
@@ -26,16 +26,15 @@ import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
 /**
- * Annotation for a {@link Workspace} field in a test class. This will ensure it gets
- * initialised and closed correctly between tests.
+ * Annotation for a {@link Workspace} field in a test class. This will ensure it gets initialised
+ * and closed correctly between tests.
  *
  * <p>Use static-fields to keep a workspace object alive for the duration of all the tests
  * (providing the same semantics as initialising and closing resources using the
- * {@link org.junit.jupiter.api.BeforeAll} and {@link org.junit.jupiter.api.AfterAll}
- * annotations).
- *
- * You must extend your test class with the {@link JctExtension} extension for this annotation
- * to be detected and handled.
+ * {@link org.junit.jupiter.api.BeforeAll} and {@link org.junit.jupiter.api.AfterAll} annotations).
+ * <p>
+ * You must extend your test class with the {@link JctExtension} extension for this annotation to be
+ * detected and handled.
  *
  * <p>Example usage:
  *

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentation.java
@@ -92,7 +92,7 @@ public final class TraceDiagnosticRepresentation implements Representation {
     }
 
     builder.append("\n\n");
-    
+
     var snippet = extractSnippet(diagnostic);
 
     if (snippet != null) {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
@@ -18,6 +18,7 @@ package io.github.ascopes.jct.utils;
 import static io.github.ascopes.jct.utils.IterableUtils.combineOneOrMore;
 import static java.util.stream.Collectors.toUnmodifiableList;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -63,7 +64,7 @@ public final class FileUtils extends UtilityClass {
    *
    * @param path the path to obtain a URL for.
    * @return the URL.
-   * @throws IllegalArgumentException if the path does not support being represented as a URL.
+   * @throws JctIllegalInputException if the path does not support being represented as a URL.
    */
   public static URL retrieveRequiredUrl(Path path) {
     try {
@@ -76,7 +77,7 @@ public final class FileUtils extends UtilityClass {
       // we enforce that URLs must be able to be generated for the path. Users are far less likely
       // to want to use custom FileSystem objects that do not have URL protocol handlers than they
       // are to want to assume that our classloaders we expose are instances of URLClassLoader.
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Cannot obtain a URL for the given path "
               + StringUtils.quoted(path)
               + ", this is likely due to no URL protocol implementation for this file system. "
@@ -104,26 +105,26 @@ public final class FileUtils extends UtilityClass {
    * the directory we are running from.
    *
    * @param name the directory name to check.
-   * @throws IllegalArgumentException if the name is invalid.
+   * @throws JctIllegalInputException if the name is invalid.
    * @throws NullPointerException     if the name is {@code null}.
    */
   public static void assertValidRootName(@Nullable String name) {
     Objects.requireNonNull(name, "name");
 
     if (name.isBlank()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Directory name cannot be blank: " + StringUtils.quoted(name)
       );
     }
 
     if (!name.equals(name.trim())) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Directory name cannot begin or end in spaces: " + StringUtils.quoted(name)
       );
     }
 
     if (name.contains("/") || name.contains("\\") || name.contains("..") || name.contains("_")) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Invalid file name provided: " + StringUtils.quoted(name)
       );
     }
@@ -134,11 +135,11 @@ public final class FileUtils extends UtilityClass {
    *
    * @param path the relative path to convert.
    * @return the expected binary name.
-   * @throws IllegalArgumentException if the path is absolute.
+   * @throws JctIllegalInputException if the path is absolute.
    */
   public static String pathToBinaryName(Path path) {
     if (path.isAbsolute()) {
-      throw new IllegalArgumentException("Path cannot be absolute: " + StringUtils.quoted(path));
+      throw new JctIllegalInputException("Path cannot be absolute: " + StringUtils.quoted(path));
     }
 
     var count = path.getNameCount();

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IterableUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IterableUtils.java
@@ -18,6 +18,7 @@ package io.github.ascopes.jct.utils;
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,9 +72,7 @@ public final class IterableUtils extends UtilityClass {
   public static <T> List<T> combineOneOrMore(T first, T... rest) {
     var list = new ArrayList<T>(1 + rest.length);
     list.add(first);
-    for (var item : rest) {
-      list.add(item);
-    }
+    list.addAll(Arrays.asList(rest));
     return Collections.unmodifiableList(list);
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/Lazy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/Lazy.java
@@ -15,9 +15,10 @@
  */
 package io.github.ascopes.jct.utils;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.Objects;
 import java.util.function.Supplier;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -54,7 +55,7 @@ public final class Lazy<T> {
    * @param initializer the initializer to call.
    */
   public Lazy(Supplier<T> initializer) {
-    this.initializer = Objects.requireNonNull(initializer, "initializer must not be null");
+    this.initializer = requireNonNull(initializer, "initializer must not be null");
     lock = new ReentrantLock();
     data = null;
   }
@@ -95,7 +96,7 @@ public final class Lazy<T> {
       }
     }
 
-    return Objects.requireNonNull(data, "cannot store null data in Lazy");
+    return requireNonNull(data, "cannot store null data in Lazy");
   }
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathRoot.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathRoot.java
@@ -42,7 +42,7 @@ public interface PathRoot {
    * some compiled outputs into a JAR to use them as inputs to another build.
    *
    * @return the byte contents of the JAR.
-   * @throws UncheckedIOException if the JAR cannot be created.
+   * @throws UncheckedIOException          if the JAR cannot be created.
    * @throws UnsupportedOperationException if the operation is not supported.
    * @since 0.4.0
    */

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
@@ -694,7 +694,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for {@link StandardLocation#CLASS_OUTPUT class outputs}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   * found.
+   *     found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getClassOutputModules() {
@@ -728,7 +728,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for {@link StandardLocation#SOURCE_OUTPUT source outputs}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   * found.
+   *     found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getSourceOutputModules() {
@@ -783,7 +783,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#ANNOTATION_PROCESSOR_MODULE_PATH annotation processor module path}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   * found.
+   *     found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getAnnotationProcessorPathModules() {
@@ -806,7 +806,7 @@ public interface Workspace extends AutoCloseable {
    * {@link StandardLocation#MODULE_SOURCE_PATH module source paths}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   * found.
+   *     found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getSourcePathModules() {
@@ -828,7 +828,7 @@ public interface Workspace extends AutoCloseable {
    * Get the module path roots for the {@link StandardLocation#MODULE_PATH module paths}.
    *
    * @return the roots in a map of module names to lists of roots, or an empty map if none were
-   * found.
+   *     found.
    * @since 0.1.0
    */
   default Map<String, List<? extends PathRoot>> getModulePathModules() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
@@ -18,6 +18,7 @@ package io.github.ascopes.jct.workspaces.impl;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Objects.requireNonNull;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.workspaces.ManagedDirectory;
 import io.github.ascopes.jct.workspaces.PathRoot;
@@ -77,7 +78,7 @@ public final class WorkspaceImpl implements Workspace {
         }
       }
 
-      if (exceptions.size() > 0) {
+      if (!exceptions.isEmpty()) {
         var newEx = new IllegalStateException("One or more components failed to close");
         exceptions.forEach(newEx::addSuppressed);
         throw newEx;
@@ -98,11 +99,11 @@ public final class WorkspaceImpl implements Workspace {
     requireNonNull(path, "path");
 
     if (location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException("Location must not be module-oriented");
+      throw new JctIllegalInputException("Location must not be module-oriented");
     }
 
     if (!Files.exists(path)) {
-      throw new IllegalArgumentException("Path " + path + " does not exist");
+      throw new JctIllegalInputException("Path " + path + " does not exist");
     }
 
     var dir = new WrappingDirectoryImpl(path);
@@ -116,13 +117,13 @@ public final class WorkspaceImpl implements Workspace {
     requireNonNull(path, "path");
 
     if (!location.isModuleOrientedLocation() && !location.isOutputLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Cannot add a module to a non-module-oriented or non-output location"
       );
     }
 
     if (location instanceof ModuleLocation) {
-      throw new IllegalArgumentException("Cannot register a module within a module");
+      throw new JctIllegalInputException("Cannot register a module within a module");
     }
 
     addPackage(new ModuleLocation(location, moduleName), path);
@@ -133,7 +134,7 @@ public final class WorkspaceImpl implements Workspace {
     requireNonNull(location, "location");
 
     if (location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException("Location must not be module-oriented");
+      throw new JctIllegalInputException("Location must not be module-oriented");
     }
 
     // Needs to be unique, and JIMFS cannot hold a file system name containing stuff like
@@ -152,13 +153,13 @@ public final class WorkspaceImpl implements Workspace {
     requireNonNull(location, "moduleName");
 
     if (!location.isModuleOrientedLocation() && !location.isOutputLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Cannot add a module to a non-module-oriented or non-output location"
       );
     }
 
     if (location instanceof ModuleLocation) {
-      throw new IllegalArgumentException("Cannot register a module within a module");
+      throw new JctIllegalInputException("Cannot register a module within a module");
     }
 
     return createPackage(new ModuleLocation(location, moduleName));
@@ -175,11 +176,11 @@ public final class WorkspaceImpl implements Workspace {
   @Override
   public List<? extends PathRoot> getModule(Location location, String moduleName) {
     if (location instanceof ModuleLocation) {
-      throw new IllegalArgumentException("Use .getPackages(ModuleLocation) for module locations");
+      throw new JctIllegalInputException("Use .getPackages(ModuleLocation) for module locations");
     }
 
     if (!location.isOutputLocation() && !location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be module-oriented or an output location"
       );
     }
@@ -191,11 +192,11 @@ public final class WorkspaceImpl implements Workspace {
   @Override
   public Map<String, List<? extends PathRoot>> getModules(Location location) {
     if (location instanceof ModuleLocation) {
-      throw new IllegalArgumentException("Cannot pass a ModuleLocation to this method");
+      throw new JctIllegalInputException("Cannot pass a ModuleLocation to this method");
     }
 
     if (!location.isOutputLocation() && !location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must be module-oriented or an output location"
       );
     }
@@ -226,7 +227,7 @@ public final class WorkspaceImpl implements Workspace {
   @Override
   public List<? extends PathRoot> getPackages(Location location) {
     if (location.isModuleOrientedLocation()) {
-      throw new IllegalArgumentException(
+      throw new JctIllegalInputException(
           "Location " + location.getName() + " must not be module-oriented"
       );
     }

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import io.github.ascopes.jct.workspaces.impl.MemoryFileSystemProvider.MemoryFileSystemUrlHandlerProvider;
 import java.net.spi.URLStreamHandlerProvider;
 
@@ -43,8 +44,9 @@ import java.net.spi.URLStreamHandlerProvider;
  * <a target="_blank" href="https://github.com/ascopes/java-compiler-testing">on GitHub</a>.
  *
  * <p>Releases can be found on
- * <a target="_blank" href="https://repo1.maven.org/maven2/io/github/ascopes/jct/java-compiler-testing/">
- * Maven Central</a>.
+ * <a target="_blank"
+ * href="https://repo1.maven.org/maven2/io/github/ascopes/jct/java-compiler-testing/"> Maven
+ * Central</a>.
  *
  * <pre><code>
  *    import static io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilation;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/AbstractIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/integration/AbstractIntegrationTest.java
@@ -26,8 +26,8 @@ import java.nio.file.Path;
 public abstract class AbstractIntegrationTest {
 
   /**
-   * Get the resources directory for this test. This will be a directory named the full
-   * canonical class name.
+   * Get the resources directory for this test. This will be a directory named the full canonical
+   * class name.
    *
    * @return the resource directory path.
    */

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/JctCompilationAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/JctCompilationAssertTest.java
@@ -425,6 +425,7 @@ class JctCompilationAssertTest {
   @DisplayName("JctCompilationAssert.diagnostics(...) tests")
   @Nested
   class DiagnosticsTest {
+
     @DisplayName(".diagnostics() fails if the compilation is null")
     @Test
     void diagnosticsFailsIfCompilationIsNull() {
@@ -461,6 +462,7 @@ class JctCompilationAssertTest {
   @DisplayName("JctCompilationAssert.packageGroup(...) tests")
   @Nested
   class PackageGroupTest {
+
     @DisplayName(".packageGroup(...) fails if the compilation is null")
     @Test
     void packageGroupFailsIfCompilationIsNull() {
@@ -570,6 +572,7 @@ class JctCompilationAssertTest {
   @DisplayName("JctCompilationAssert.moduleGroup(...) tests")
   @Nested
   class ModuleGroupTest {
+
     @DisplayName(".moduleGroup(...) fails if the compilation is null")
     @Test
     void moduleGroupFailsIfCompilationIsNull() {
@@ -679,6 +682,7 @@ class JctCompilationAssertTest {
   @DisplayName("JctCompilationAssert.outputGroup(...) tests")
   @Nested
   class OutputGroupTest {
+
     @DisplayName(".outputGroup(...) fails if the compilation is null")
     @Test
     void outputGroupFailsIfCompilationIsNull() {
@@ -827,7 +831,7 @@ class JctCompilationAssertTest {
 
     // When
     var actualAssertions = assertions.sourceOutputPackages();
-    
+
     // Then
     verify(assertions).sourceOutputPackages();
     verify(assertions).outputGroup(StandardLocation.SOURCE_OUTPUT);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/LocationAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/LocationAssertTest.java
@@ -38,6 +38,7 @@ class LocationAssertTest {
   @DisplayName("LocationAssert.isModuleOrientedLocation(...) tests")
   @Nested
   class IsModuleOrientedLocationTest {
+
     @DisplayName(".isModuleOrientedLocation() fails if the location is null")
     @Test
     void failsIfTheLocationIsNull() {
@@ -84,6 +85,7 @@ class LocationAssertTest {
   @DisplayName("LocationAssert.isNotModuleOrientedLocation(...) tests")
   @Nested
   class IsNotModuleOrientedLocationTest {
+
     @DisplayName(".isNotModuleOrientedLocation() fails if the location is null")
     @Test
     void failsIfTheLocationIsNull() {
@@ -131,6 +133,7 @@ class LocationAssertTest {
   @DisplayName("LocationAssert.isOutputLocation(...) tests")
   @Nested
   class IsOutputLocationTest {
+
     @DisplayName(".isOutputLocation() fails if the location is null")
     @Test
     void failsIfTheLocationIsNull() {
@@ -178,6 +181,7 @@ class LocationAssertTest {
   @DisplayName("LocationAssert.isNotOutputLocation(...) tests")
   @Nested
   class IsNotOutputLocationTest {
+
     @DisplayName(".isNotOutputLocation() fails if the location is null")
     @Test
     void failsIfTheLocationIsNull() {
@@ -225,6 +229,7 @@ class LocationAssertTest {
   @DisplayName("LocationAssert.name(...) tests")
   @Nested
   class NameTest {
+
     @DisplayName(".name() fails if the location is null")
     @Test
     void failsIfTheLocationIsNull() {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/PackageContainerGroupAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/PackageContainerGroupAssertTest.java
@@ -444,7 +444,6 @@ class PackageContainerGroupAssertTest {
           .withRelativeFile("zipc")
           .buildMock();
 
-
       var containerGroup = mock(PackageContainerGroup.class);
       when(containerGroup.getFile(any(), any(), any())).thenReturn(null);
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/StackTraceElementAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/assertions/StackTraceElementAssertTest.java
@@ -35,9 +35,11 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 @DisplayName("StackTraceElementAssert tests")
 class StackTraceElementAssertTest {
+
   @DisplayName("StackTraceElementAssert.fileName(...) tests")
   @Nested
   class FileNameTest {
+
     @DisplayName(".fileName() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -70,6 +72,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.lineNumber(...) tests")
   @Nested
   class LineNumberTest {
+
     @DisplayName(".lineNumber() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -102,6 +105,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.moduleName(...) tests")
   @Nested
   class ModuleNameTest {
+
     @DisplayName(".moduleName() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -134,6 +138,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.moduleVersion(...) tests")
   @Nested
   class ModuleVersionTest {
+
     @DisplayName(".moduleVersion() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -166,6 +171,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.classLoaderName(...) tests")
   @Nested
   class ClassLoaderNameTest {
+
     @DisplayName(".classLoaderName() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -198,6 +204,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.className(...) tests")
   @Nested
   class ClassNameTest {
+
     @DisplayName(".className() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -230,6 +237,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.methodName(...) tests")
   @Nested
   class MethodNameTest {
+
     @DisplayName(".methodName() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {
@@ -262,6 +270,7 @@ class StackTraceElementAssertTest {
   @DisplayName("StackTraceElementAssert.nativeMethod(...) tests")
   @Nested
   class NativeMethodTest {
+
     @DisplayName(".nativeMethod() fails if the stack trace element is null")
     @Test
     void failsIfStackTraceElementIsNull() {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/AbstractJctCompilerTest.java
@@ -352,7 +352,7 @@ class AbstractJctCompilerTest {
       when(flagBuilderFactory.createFlagBuilder()).thenReturn(flagBuilder);
       when(jsr199CompilerFactory.createCompiler()).thenReturn(jsr199Compiler);
       fileManagers.when(() -> JctFileManagers.newJctFileManagerFactory(any()))
-            .thenReturn(fileManagerFactory);
+          .thenReturn(fileManagerFactory);
       when(fileManagerFactory.createFileManager(any())).thenReturn(fileManager);
 
       // Default implementation. We can override this to make it throw exceptions, etc.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JctCompilationImplTest.java
@@ -47,7 +47,7 @@ import org.junit.jupiter.params.provider.ValueSource;
  */
 @DisplayName("JctCompilationImpl tests")
 class JctCompilationImplTest {
-  
+
   @DisplayName(".getArguments() returns the expected value")
   @ValueSource(ints = {0, 1, 2, 3, 5, 10, 100})
   @ParameterizedTest(name = "for argumentCount = {0}")
@@ -67,7 +67,7 @@ class JctCompilationImplTest {
         .asInstanceOf(iterable(String.class))
         .containsExactlyElementsOf(arguments);
   }
-  
+
   @DisplayName(".isSuccessful() returns the expected value")
   @ValueSource(booleans = {true, false})
   @ParameterizedTest(name = "for success = {0}")

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TeeWriterTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/diagnostics/TeeWriterTest.java
@@ -61,7 +61,7 @@ class TeeWriterTest {
 
     // Then
     assertThatThrownBy(() -> tee.write(text))
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(IOException.class)
         .hasMessage("TeeWriter is closed");
 
     assertThat(writer)
@@ -96,7 +96,7 @@ class TeeWriterTest {
 
     // Then
     assertThatThrownBy(tee::flush)
-        .isInstanceOf(IllegalStateException.class)
+        .isInstanceOf(IOException.class)
         .hasMessage("TeeWriter is closed");
 
     then(writer).shouldHaveNoInteractions();

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctIllegalInputExceptionTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctIllegalInputExceptionTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.ex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.github.ascopes.jct.ex.JctIllegalInputException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JctIllegalInputException}.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JctIllegalInputException tests")
+class JctIllegalInputExceptionTest {
+
+  @DisplayName("The message is set when no cause is given")
+  @Test
+  void messageIsSetWhenNoCauseGiven() {
+    // Given
+    var message = "foo bar baz";
+
+    // When
+    var ex = new JctIllegalInputException(message);
+
+    // Then
+    assertThat(ex)
+        .hasMessage("foo bar baz");
+  }
+
+  @DisplayName("The message is set when a cause is given")
+  @Test
+  void messageIsSetWhenCauseGiven() {
+    // Given
+    var message = "qux quxx quxxx";
+    var cause = mock(Throwable.class);
+
+    // When
+    var ex = new JctIllegalInputException(message, cause);
+
+    // Then
+    assertThat(ex)
+        .hasMessage("qux quxx quxxx");
+  }
+
+  @DisplayName("The cause is set when a cause is given")
+  @Test
+  void causeIsSetWhenCauseGiven() {
+    // Given
+    var message = "do ray me";
+    var cause = mock(Throwable.class);
+
+    // When
+    var ex = new JctIllegalInputException(message, cause);
+
+    // Then
+    assertThat(ex)
+        .hasCause(cause);
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctNotFoundExceptionTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctNotFoundExceptionTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.ex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.ascopes.jct.ex.JctNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JctNotFoundException}.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JctNotFoundException tests")
+class JctNotFoundExceptionTest {
+
+  @DisplayName("The message is set when no cause is given")
+  @Test
+  void messageIsSetWhenNoCauseGiven() {
+    // Given
+    var message = "foo bar baz";
+
+    // When
+    var ex = new JctNotFoundException(message);
+
+    // Then
+    assertThat(ex)
+        .hasMessage("foo bar baz");
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctNotImplementedTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/ex/JctNotImplementedTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.tests.unit.ex;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.github.ascopes.jct.ex.JctNotImplementedException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link JctNotImplementedException}.
+ *
+ * @author Ashley Scopes
+ */
+@DisplayName("JctNotImplementedException tests")
+class JctNotImplementedTest {
+
+  @DisplayName("The message is set when no cause is given")
+  @Test
+  void messageIsSetWhenNoCauseGiven() {
+    // Given
+    var message = "foo bar baz";
+
+    // When
+    var ex = new JctNotImplementedException(message);
+
+    // Then
+    assertThat(ex)
+        .hasMessage("foo bar baz");
+  }
+}

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/ModuleLocationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/ModuleLocationTest.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.tests.helpers.Fixtures;
 import java.util.Objects;
@@ -65,7 +66,7 @@ class ModuleLocationTest {
   void passingInputPackageOrientedLocationToConstructorRaisesException(StandardLocation location) {
     // Then
     assertThatThrownBy(() -> new ModuleLocation(location, "foo.bar"))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasMessage(
             "The parent of a module location must be either an output location or be "
                 + "module-oriented, but got %s",

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurerTest.java
@@ -23,6 +23,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.AnnotationProcessorDiscovery;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import io.github.ascopes.jct.filemanagers.config.JctFileManagerAnnotationProcessorClassPathConfigurer;
@@ -130,7 +131,7 @@ class JctFileManagerAnnotationProcessorClassPathConfigurerTest {
 
     // Then
     assertThatThrownBy(() -> configurer.configure(fileManager))
-        .isInstanceOf(IllegalStateException.class);
+        .isInstanceOf(JctIllegalInputException.class);
   }
 
   @DisplayName(".isEnabled() returns the expected value")

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/JctFileManagerImplTest.java
@@ -48,6 +48,8 @@ import io.github.ascopes.jct.containers.ModuleContainerGroup;
 import io.github.ascopes.jct.containers.OutputContainerGroup;
 import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.containers.impl.ContainerGroupRepositoryImpl;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
+import io.github.ascopes.jct.ex.JctNotFoundException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.filemanagers.PathFileObject;
 import io.github.ascopes.jct.filemanagers.impl.JctFileManagerImpl;
@@ -55,7 +57,6 @@ import io.github.ascopes.jct.tests.helpers.Fixtures;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
-import java.util.NoSuchElementException;
 import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -392,7 +393,7 @@ class JctFileManagerImplTest {
               someRelativePath().toString(),
               someJavaFileObject()
           ))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be an output location", name);
     }
 
@@ -588,7 +589,7 @@ class JctFileManagerImplTest {
               kind,
               someJavaFileObject()
           ))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be an output location", name);
     }
 
@@ -723,7 +724,7 @@ class JctFileManagerImplTest {
 
       // Then
       assertThatThrownBy(() -> fileManager.getLocationForModule(location, moduleName))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be output or module-oriented", location.getName());
     }
 
@@ -756,7 +757,7 @@ class JctFileManagerImplTest {
 
       // Then
       assertThatThrownBy(() -> fileManager.getLocationForModule(location, fileObject))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be output or module-oriented", location.getName());
     }
 
@@ -769,7 +770,7 @@ class JctFileManagerImplTest {
 
       // Then
       assertThatThrownBy(() -> fileManager.getLocationForModule(location, fileObject))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("File object %s is not compatible with this file manager", fileObject);
     }
 
@@ -827,7 +828,7 @@ class JctFileManagerImplTest {
     ) {
       // Then
       assertThatThrownBy(() -> fileManager.getModuleContainerGroup(location))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be module-oriented", location.getName());
 
       verifyNoInteractions(repository);
@@ -886,7 +887,7 @@ class JctFileManagerImplTest {
     ) {
       // Then
       assertThatThrownBy(() -> fileManager.getOutputContainerGroup(location))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be an output location", location.getName());
 
       verifyNoInteractions(repository);
@@ -944,7 +945,7 @@ class JctFileManagerImplTest {
     void getPackageContainerGroupThrowsExceptionForNonPackageContainerGroups(Location location) {
       // Then
       assertThatThrownBy(() -> fileManager.getPackageContainerGroup(location))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be an input package location", location.getName());
 
       verifyNoInteractions(repository);
@@ -1002,7 +1003,7 @@ class JctFileManagerImplTest {
 
       // Then
       assertThatThrownBy(() -> fileManager.getServiceLoader(location, Some.class))
-          .isInstanceOf(NoSuchElementException.class)
+          .isInstanceOf(JctNotFoundException.class)
           .hasMessage("No container group for location %s exists in this file manager",
               location.getName());
 
@@ -1083,7 +1084,7 @@ class JctFileManagerImplTest {
     void inferBinaryNameThrowsExceptionForModuleOrientedLocations(Location location) {
       // Then
       assertThatThrownBy(() -> fileManager.inferBinaryName(location, someJavaFileObject()))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be package-oriented", location.getName());
 
       verifyNoInteractions(repository);
@@ -1166,7 +1167,7 @@ class JctFileManagerImplTest {
     void inferModuleNameThrowsAnExceptionIfLocationIsNotPackageOriented(Location location) {
       // Then
       assertThatThrownBy(() -> fileManager.inferModuleName(location))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be package-oriented", location.getName());
     }
 
@@ -1288,7 +1289,7 @@ class JctFileManagerImplTest {
 
       // Then
       assertThatThrownBy(() -> fileManager.list(location, packageName, kinds, recurse))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be package-oriented", location.getName());
     }
 
@@ -1368,7 +1369,7 @@ class JctFileManagerImplTest {
     void listLocationsForModulesThrowsExceptionIfLocationIsPackageOriented(Location location) {
       // Then
       assertThatThrownBy(() -> fileManager.listLocationsForModules(location))
-          .isInstanceOf(IllegalArgumentException.class)
+          .isInstanceOf(JctIllegalInputException.class)
           .hasMessage("Location %s must be output or module-oriented", location.getName());
     }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/PathFileObjectImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/PathFileObjectImplTest.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.impl.PathFileObjectImpl;
 import io.github.ascopes.jct.utils.FileUtils;
 import java.io.BufferedReader;
@@ -88,7 +89,7 @@ class PathFileObjectImplTest {
 
     // Then
     assertThatThrownBy(() -> new PathFileObjectImpl(someLocation(), rootPath, someRelativePath()))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasMessage("Expected rootPath to be absolute, but got " + rootPath);
   }
 
@@ -437,7 +438,8 @@ class PathFileObjectImplTest {
     // Given
     var rootPath = someAbsolutePath();
     var relativePath = someRelativePath();
-    var fileObject = new PathFileObjectImpl(someLocation(), rootPath, rootPath.resolve(relativePath));
+    var fileObject = new PathFileObjectImpl(someLocation(), rootPath,
+        rootPath.resolve(relativePath));
 
     // Then
     assertThat(fileObject.getRelativePath()).isEqualTo(relativePath);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/AbstractCompilersProviderTest.java
@@ -30,6 +30,7 @@ import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.compilers.JctCompilerConfigurer;
 import io.github.ascopes.jct.compilers.JctCompilers;
 import io.github.ascopes.jct.containers.Container;
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.ex.JctJunitConfigurerException;
 import io.github.ascopes.jct.junit.AbstractCompilersProvider;
 import io.github.ascopes.jct.junit.VersionStrategy;
@@ -73,7 +74,7 @@ class AbstractCompilersProviderTest {
 
     // Then
     assertThatThrownBy(() -> provider.configureInternals(min, max, VersionStrategy.RELEASE))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasMessage("Cannot use a Java version less than Java 8");
   }
 
@@ -87,7 +88,7 @@ class AbstractCompilersProviderTest {
 
     // Then
     assertThatThrownBy(() -> provider.configureInternals(11, 10, VersionStrategy.RELEASE))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasMessage("Cannot set min version to a version higher than the max version");
   }
 
@@ -491,8 +492,8 @@ class AbstractCompilersProviderTest {
     @Override
     protected JctCompiler initializeNewCompiler() {
       return mock(withSettings()
-              .name("mock compiler")
-              .defaultAnswer(Answers.RETURNS_SELF));
+          .name("mock compiler")
+          .defaultAnswer(Answers.RETURNS_SELF));
     }
 
     @Override

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/JctExtensionTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/junit/JctExtensionTest.java
@@ -56,6 +56,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 @Isolated("This modifies global state in some test cases")
 class JctExtensionTest {
+
   @Mock
   ExtensionContext extensionContext;
 
@@ -134,6 +135,7 @@ class JctExtensionTest {
 
   @Disabled("This is just test data")
   static class StaticWorkspaceTestCase {
+
     @Managed
     static Workspace staticWorkspace1;
 
@@ -155,7 +157,7 @@ class JctExtensionTest {
 
     @Managed
     Workspace someIgnoredInstanceWorkspace;
-    
+
     @Test
     void testSomething() {
       // ...
@@ -224,7 +226,7 @@ class JctExtensionTest {
         instance3.workspace2,
         instance3.workspace3
     )).containsExactlyInAnyOrder(expectedWorkspace7, expectedWorkspace8, expectedWorkspace9);
-    
+
     assertThat(InstanceWorkspaceTestCase.someIgnoredStaticWorkspace).isNull();
     assertThat(InstanceWorkspaceTestCase.someInvalidStaticWorkspace).isNull();
   }
@@ -256,7 +258,7 @@ class JctExtensionTest {
     instance3.workspace3 = mock();
     instance3.someIgnoredInstanceWorkspace = mock();
     instance3.someInvalidInstanceWorkspace = mock();
-    
+
     when(extensionContext.getRequiredTestInstances())
         .thenReturn(testInstances);
 
@@ -297,6 +299,7 @@ class JctExtensionTest {
 
   @Disabled(value = "This is just test data")
   static class InstanceWorkspaceTestCase {
+
     @Managed
     Workspace workspace1;
 
@@ -388,21 +391,25 @@ class JctExtensionTest {
   }
 
   static class TestCaseBase1 {
+
     @Managed
     Workspace testCaseBase1Workspace;
   }
 
   static class TestCaseBase2 extends TestCaseBase1 {
+
     @Managed
     Workspace testCaseBase2Workspace;
   }
 
   static class TestCaseBase3 extends TestCaseBase2 {
+
     @Managed
     Workspace testCaseBase3Workspace;
   }
 
   static class TestCaseImpl extends TestCaseBase3 {
+
     @Managed
     Workspace testCaseImplWorkspace;
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
@@ -38,6 +38,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.tests.helpers.UtilityClassTestTemplate;
 import io.github.ascopes.jct.utils.FileUtils;
 import io.github.ascopes.jct.utils.StringUtils;
@@ -90,9 +91,9 @@ class FileUtilsTest implements UtilityClassTestTemplate {
     }
   }
 
-  @DisplayName("retrieveRequiredUrl with an invalid scheme throws an IllegalArgumentException")
+  @DisplayName("retrieveRequiredUrl with an invalid scheme throws an JctIllegalInputException")
   @Test
-  void retrieveRequiredUrlThrowsIllegalArgumentExceptionIfPathUsesUnknownUriScheme() {
+  void retrieveRequiredUrlThrowsJctIllegalInputExceptionIfPathUsesUnknownUriScheme() {
     // Given
     var uri = URI.create("some-crazy-random-scheme://foo/bar/baz.txt");
     var path = mock(Path.class);
@@ -100,7 +101,7 @@ class FileUtilsTest implements UtilityClassTestTemplate {
 
     // Then
     assertThatThrownBy(() -> retrieveRequiredUrl(path))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasCauseInstanceOf(MalformedURLException.class);
   }
 
@@ -166,7 +167,7 @@ class FileUtilsTest implements UtilityClassTestTemplate {
   void assertValidRootNameFailsForInvalidRootNames(String rootName, String expectedError) {
     // Then
     assertThatThrownBy(() -> assertValidRootName(rootName))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasMessage(expectedError + ": " + StringUtils.quoted(rootName));
   }
 
@@ -180,7 +181,7 @@ class FileUtilsTest implements UtilityClassTestTemplate {
 
     // Then
     assertThatThrownBy(() -> pathToBinaryName(path))
-        .isInstanceOf(IllegalArgumentException.class)
+        .isInstanceOf(JctIllegalInputException.class)
         .hasMessage("Path cannot be absolute: \"/foo/bar/baz\"");
   }
 

--- a/java-compiler-testing/src/test/resources/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest/Fibonacci.java
+++ b/java-compiler-testing/src/test/resources/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest/Fibonacci.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import static java.math.BigInteger.ONE;
 import static java.math.BigInteger.ZERO;
 
@@ -22,6 +23,7 @@ import java.math.BigInteger;
  * Command line app to calculate the nth number of the fibonacci sequence.
  */
 public class Fibonacci {
+
   public static void main(String[] args) {
     if (args.length != 1) {
       System.out.println("USAGE: java Fibonacci <n>");

--- a/java-compiler-testing/src/test/resources/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest/HelloWorld.java
+++ b/java-compiler-testing/src/test/resources/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest/HelloWorld.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Command line app that says hello to me.
  */
 public class HelloWorld {
+
   public static void main(String[] args) {
     System.out.println("Hello, World!");
   }

--- a/java-compiler-testing/src/test/resources/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest/Sum.java
+++ b/java-compiler-testing/src/test/resources/io/github/ascopes/jct/tests/integration/compilation/CompilingSpecificClassesIntegrationTest/Sum.java
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Command line app that sums together given integers.
  */
 public class Sum {
+
   public static void main(String[] args) {
     long sum = 0;
     for (String arg : args) {


### PR DESCRIPTION
Fixes GH-508.

### Summary

Replaces the usage of some more generic exceptions with custom exceptions internally to indicate whether an exception is derived from expected behaviour in JCT or from other
components.

### Additional details

Introduces three new exception types:

- JctNotFoundException - raised if an element cannot be found during a lookup operation.
- JctNotImplementedException - raised if an operation is not supported by JCT.
- JctIllegalInputException - something was wrong with the input to a function.


