### PR TITLE
Implement JctCompiler.useRuntimeRelease()

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -521,6 +521,21 @@ public interface JctCompiler {
   }
 
   /**
+   * Request that the compiler uses a language version that corresponds to the
+   * runtime language version in use on the JVM running tests.
+   *
+   * <p>For example, running this on JRE 19 would set the release to "19".
+   *
+   * <p>This calls {@link #release(int) internally}.
+   *
+   * @return this compiler object for further call chaining.
+   */
+  @API(since = "1.1.0", status = Status.STABLE)
+  default JctCompiler useRuntimeRelease() {
+    return release(Runtime.version().feature());
+  }
+
+  /**
    * Get the current source version that is set, or {@code null} if left to the compiler to decide.
    * default.
    *

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
@@ -73,7 +73,7 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler {
    * @return the minimum supported version.
    * @since 1.0.0
    */
-  @API(since = "1.0.0", status = Status.STABLE)
+  @API(since = "1.0.0", status = Status.INTERNAL)
   public static int getEarliestSupportedVersionInt() {
     // Purposely do not hardcode members of the SourceVersion enum here other
     // than utility methods, as this prevents compilation problems on various
@@ -97,7 +97,7 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler {
    *
    * @return the maximum supported version.
    */
-  @API(since = "1.0.0", status = Status.STABLE)
+  @API(since = "1.0.0", status = Status.INTERNAL)
   public static int getLatestSupportedVersionInt() {
     return SourceVersion.latestSupported().ordinal();
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/JctCompilerTest.java
@@ -115,10 +115,10 @@ class JctCompilerTest {
     assertThat(result).isSameAs(compiler);
   }
 
-  @DisplayName("releaseVersion(int) should call releaseVersion(String)")
+  @DisplayName("release(int) should call release(String)")
   @ValueSource(ints = {11, 12, 13, 14, 15, 16, 17})
   @ParameterizedTest(name = "for version = {0}")
-  void releaseVersionIntCallsReleaseVersionString(int versionInt) {
+  void releaseIntCallsReleaseVersionString(int versionInt) {
     // Given
     var versionString = "" + versionInt;
     given(compiler.release(anyInt())).willCallRealMethod();
@@ -132,10 +132,10 @@ class JctCompilerTest {
     assertThat(result).isSameAs(compiler);
   }
 
-  @DisplayName("releaseVersion(int) throws an IllegalArgumentException for negative versions")
+  @DisplayName("release(int) throws an IllegalArgumentException for negative versions")
   @ValueSource(ints = {-1, -2, -5, -100_000})
   @ParameterizedTest(name = "for version = {0}")
-  void releaseVersionIntThrowsIllegalArgumentExceptionForNegativeVersions(int versionInt) {
+  void releaseIntThrowsIllegalArgumentExceptionForNegativeVersions(int versionInt) {
     // Given
     given(compiler.release(anyInt())).willCallRealMethod();
 
@@ -145,10 +145,10 @@ class JctCompilerTest {
         .hasMessage("Cannot provide a release version less than 0");
   }
 
-  @DisplayName("releaseVersion(SourceVersion) should call releaseVersion(String)")
+  @DisplayName("release(SourceVersion) should call release(String)")
   @MethodSource("sourceVersions")
   @ParameterizedTest(name = "for version = {0}")
-  void releaseVersionSourceVersionCallsReleaseVersionString(
+  void releaseSourceVersionCallsReleaseVersionString(
       SourceVersion versionEnum,
       String versionString
   ) {
@@ -164,10 +164,25 @@ class JctCompilerTest {
     assertThat(result).isSameAs(compiler);
   }
 
-  @DisplayName("sourceVersion(int) should call sourceVersion(String)")
+  @DisplayName(".useRuntimeRelease() should call .release(int) with the runtime feature version")
+  @Test
+  void useRuntimeReleaseShouldSetTheRuntimeFeatureVersion() {
+    // Given
+    given(compiler.useRuntimeRelease()).willCallRealMethod();
+    given(compiler.release(anyInt())).will(ctx -> compiler);
+
+    // When
+    var result = compiler.useRuntimeRelease();
+
+    // Then
+    then(compiler).should().release(Runtime.version().feature());
+    assertThat(result).isSameAs(compiler);
+  }
+
+  @DisplayName("source(int) should call source(String)")
   @ValueSource(ints = {11, 12, 13, 14, 15, 16, 17})
   @ParameterizedTest(name = "for version = {0}")
-  void sourceVersionIntCallsReleaseVersionString(int versionInt) {
+  void sourceIntCallsReleaseVersionString(int versionInt) {
     // Given
     var versionString = "" + versionInt;
     given(compiler.source(anyInt())).willCallRealMethod();
@@ -181,10 +196,10 @@ class JctCompilerTest {
     assertThat(result).isSameAs(compiler);
   }
 
-  @DisplayName("sourceVersion(int) throws an IllegalArgumentException for negative versions")
+  @DisplayName("source(int) throws an IllegalArgumentException for negative versions")
   @ValueSource(ints = {-1, -2, -5, -100_000})
   @ParameterizedTest(name = "for version = {0}")
-  void sourceVersionIntThrowsIllegalArgumentExceptionForNegativeVersions(int versionInt) {
+  void sourceIntThrowsIllegalArgumentExceptionForNegativeVersions(int versionInt) {
     // Given
     given(compiler.source(anyInt())).willCallRealMethod();
 
@@ -194,10 +209,10 @@ class JctCompilerTest {
         .hasMessage("Cannot provide a source version less than 0");
   }
 
-  @DisplayName("sourceVersion(SourceVersion) should call sourceVersion(String)")
+  @DisplayName("source(SourceVersion) should call source(String)")
   @MethodSource("sourceVersions")
   @ParameterizedTest(name = "for version = {0}")
-  void sourceVersionSourceVersionCallsReleaseVersionString(
+  void sourceSourceVersionCallsReleaseVersionString(
       SourceVersion versionEnum,
       String versionString
   ) {
@@ -213,10 +228,10 @@ class JctCompilerTest {
     assertThat(result).isSameAs(compiler);
   }
 
-  @DisplayName("targetVersion(int) should call targetVersion(String)")
+  @DisplayName("target(int) should call target(String)")
   @ValueSource(ints = {11, 12, 13, 14, 15, 16, 17})
   @ParameterizedTest(name = "for version = {0}")
-  void targetVersionIntCallsReleaseVersionString(int versionInt) {
+  void targetIntCallsReleaseVersionString(int versionInt) {
     // Given
     var versionString = "" + versionInt;
     given(compiler.target(anyInt())).willCallRealMethod();
@@ -230,10 +245,10 @@ class JctCompilerTest {
     assertThat(result).isSameAs(compiler);
   }
 
-  @DisplayName("targetVersion(int) throws an IllegalArgumentException for negative versions")
+  @DisplayName("target(int) throws an IllegalArgumentException for negative versions")
   @ValueSource(ints = {-1, -2, -5, -100_000})
   @ParameterizedTest(name = "for version = {0}")
-  void targetVersionIntThrowsIllegalArgumentExceptionForNegativeVersions(int versionInt) {
+  void targetIntThrowsIllegalArgumentExceptionForNegativeVersions(int versionInt) {
     // Given
     given(compiler.target(anyInt())).willCallRealMethod();
 
@@ -243,10 +258,10 @@ class JctCompilerTest {
         .hasMessage("Cannot provide a target version less than 0");
   }
 
-  @DisplayName("targetVersion(SourceVersion) should call targetVersion(String)")
+  @DisplayName("target(SourceVersion) should call target(String)")
   @MethodSource("sourceVersions")
   @ParameterizedTest(name = "for version = {0}")
-  void targetVersionSourceVersionCallsReleaseVersionString(
+  void targetSourceVersionCallsReleaseVersionString(
       SourceVersion versionEnum,
       String versionString
   ) {


### PR DESCRIPTION
Closes GH-496.

This sets the compiler to use the same language version as the current runtime feature version in the running JVM.
