### PR TITLE
Update JctFileManagers.java to deprecate newJctFileManager

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -183,7 +183,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @param kinds       the kinds of file to look for.
    * @param recurse     {@code true} to recurse subpackages, {@code false} to only consider the
    *                    given package.
-   * @return thr file objects that were found.
+   * @return the file objects that were found.
    * @throws IOException if the file lookup fails due to an IO error somewhere.
    */
   Set<JavaFileObject> listFileObjects(

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -104,7 +104,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    *   // brevity. See the java.lang.reflect documentation for full details.
    *
    *   ClassLoader cl = containerGroup.getClassLoader();
-   *   Class<?> cls = cl.loadClass("org.example.NumberAdder");
+   *   Class&lt;?&gt; cls = cl.loadClass("org.example.NumberAdder");
    *   Object adder = cls.getDeclaredConstructor().newInstance();
    *   Method addMethod = cls.getMethod("add", int.class, int.class);
    *   int result = (int) addMethod.invoke(adder, 9, 18);
@@ -147,8 +147,8 @@ public interface PackageContainerGroup extends ContainerGroup {
    * </code></pre>
    *
    * @return a class loader for the contents of this container group.
-   * @see java.lang.reflect.ClassLoader
-   * @see java.lang.reflect.Class
+   * @see java.lang.ClassLoader
+   * @see java.lang.Class
    * @see java.lang.reflect.Method
    * @see java.lang.reflect.Field
    * @see java.lang.reflect.Constructor

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -29,9 +29,14 @@ import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Base interface representing a group of package-oriented paths.
+ *
+ * <p><strong>Warning</strong>: container group APIs are not designed to allow reuse between
+ * compilation runs due the behaviour around providing access to class loaders. See the
+ * notes for {@link #getClassLoader} for more details.
  *
  * @author Ashley Scopes
  * @since 0.0.1
@@ -44,6 +49,9 @@ public interface PackageContainerGroup extends ContainerGroup {
    *
    * <p>The provided container will be closed when this group is closed.
    *
+   * <p>Note that this will destroy the {@link #getClassLoader class loader} if one is already
+   * allocated from a previous request.
+   *
    * @param container the container to add.
    */
   void addPackage(Container container);
@@ -51,12 +59,12 @@ public interface PackageContainerGroup extends ContainerGroup {
   /**
    * Add a path to this group.
    *
-   * <p>Note that this will destroy the {@link #getClassLoader() classloader} if one is already
-   * allocated.
+   * <p>Note that this will destroy the {@link #getClassLoader class loader} if one is already
+   * allocated from a previous request.
    *
    * <p>If the path points to some form of archive (such as a JAR), then this may open that archive
    * in a new resource internally. If this occurs, then the resource will always be freed by this
-   * class by calling {@link #close()}.
+   * class by calling {@link #close}.
    *
    * <p>Any other closable resources passed to this function will not be closed by this
    * implementation. You must handle the lifecycle of those objects yourself.
@@ -68,30 +76,116 @@ public interface PackageContainerGroup extends ContainerGroup {
   /**
    * Get a class loader for this group of containers.
    *
-   * <p>Note that adding additional containers to this group after accessing this class loader
-   * may result in the class loader being destroyed or re-created.
+   * <p>If a class loader has not yet been created, then calling this method is expected to create
+   * a class loader first.
    *
-   * @return the class loader.
+   * <p>This method is primarily provided to allow JCT to load components like annotation processors
+   * from provided class paths dynamically during compilation, but is also suitable for use by users
+   * to load classes compiled as part of test cases into memory to perform further tests on the results
+   * via standard reflection APIs.
+   *
+   * <p>While not strictly required, it is recommended that any implementations of this class provide
+   * a subclass of {@link java.net.URLClassLoader} to ensure similar behaviour to the internals
+   * within OpenJDK's {@code javac} implementation.
+   *
+   * <p><strong>Warning</strong>: adding additional containers to this group after accessing this 
+   * class loader may result in the class loader being destroyed or re-created. This can result
+   * in confusing behaviour where classes may get loaded multiple times. Generally this shouldn't
+   * be an issue since the class loader is only accessed once the files have been added, but this
+   * does mean that container group types should not be reused between compilation runs if possible.
+   * Due to how the JCT API works, this means that you should avoid calling this method prior to
+   * invoking the compiler itself, and likewise should try to avoid adding new packages to
+   * implementations of container groups after the compiler has been invoked.
+   *
+   * <p><strong>Example of usage with Java:</strong>
+   *
+   * <pre><code>
+   *   // Checked exception handling has been omitted from this example for
+   *   // brevity. See the java.lang.reflect documentation for full details.
+   *
+   *   ClassLoader cl = containerGroup.getClassLoader();
+   *   Class<?> cls = cl.loadClass("org.example.NumberAdder");
+   *   Object adder = cls.getDeclaredConstructor().newInstance();
+   *   Method addMethod = cls.getMethod("add", int.class, int.class);
+   *   int result = (int) addMethod.invoke(adder, 9, 18);
+   *
+   *   assertThat(result).isEqualTo(27);
+   * </code></pre>
+   *
+   * <p><strong>Example of usage with Groovy:</strong>
+   *
+   * <pre><code class="language-groovy">
+   *   // Groovy is a great option if you are writing lots of tests like this,
+   *   // since it will avoid much of the boilerplate around using the reflection
+   *   // APIs directly due to the ability to dynamically infer the types of
+   *   // objects at runtime. You also avoid having to deal with checked exceptions.
+   *
+   *   def cl = containerGroup.getClassLoader()
+   *   def cls = cl.loadClass("org.example.NumberAdder")
+   *   def adder = cls.getDeclaredConstructor().newInstance()
+   *   def result = adder.add(9, 18)
+   *
+   *   assertThat(result).isEqualTo(27)
+   * </code></pre>
+   *
+   * <p><strong>Example working with resources:</strong>
+   *
+   * <pre><code>
+   *   // Checked exception handling has been omitted from this example for
+   *   // brevity. See the java.lang.reflect documentation for full details.
+   *   //
+   *   // Consider the .getFile method on the PackageContainerGroup class instead
+   *   // to achieve the same outcome with simpler syntax.
+   *
+   *   ClassLoader cl = containerGroup.getClassLoader();
+   *   try (InputStream is = cl.getResourceAsStream("META-INF/spring.factories")) {
+   *     ByteArrayOutputStream baos = new ByteArrayOutputStream();
+   *     is.transferTo(baos);
+   *     String content = new String(baos.toByteArray(), ...);
+   *     ...
+   *    }
+   * </code></pre>
+   *
+   * @return a class loader for the contents of this container group.
+   * @see java.lang.reflect.ClassLoader
+   * @see java.lang.reflect.Class
+   * @see java.lang.reflect.Method
+   * @see java.lang.reflect.Field
+   * @see java.lang.reflect.Constructor
+   * @see java.net.URLClassLoader
    */
   ClassLoader getClassLoader();
 
   /**
    * Find the first occurrence of a given path to a file in packages or modules.
    *
-   * <p>Modules are treated as subdirectories.
+   * <p>Paths should be relative to the root of this package group. Absolute paths
+   * will be treated as erroneous inputs.
+   *
+   * <p>Modules are treated as subdirectories where supported.
+   *
+   * <p>This method accepts multiple strings to prevent users from having to
+   * hard-code OS-specific file path separators that may create flaky tests.
+   * For example, {@code .getFile("foo", "bar", "baz")} is equivalent to
+   * {@code .getFile("foo/bar/baz")} on most systems.
+   *
+   * <p>Unlike {@link #getClassLoader}, this will allow access to the files
+   * directly without needing to handle class loading exceptions.
    *
    * <pre><code>
+   *   // Letting JCT infer the correct path separators to use (recommended).
+   *   containerGroup.getFile("foo", "bar", "baz.txt")...;
+   *
    *   // Using platform-specific separators.
    *   containerGroup.getFile("foo/bar/baz.txt")...;
-   *
-   *   // Letting JCT infer the correct path separators to use (recommended).
-   *   containerGroup.getFile("foo", "bar", "baz.txt");
    * </code></pre>
    *
    * @param fragment  the first part of the path.
    * @param fragments any additional parts of the path.
    * @return the first occurrence of the path in this group, or null if not found.
    * @throws IllegalArgumentException if the provided path is absolute.
+   * @see java.nio.file.Path
+   * @see java.nio.file.Files
    */
   Path getFile(String fragment, String... fragments);
 
@@ -104,6 +198,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @param relativeName the relative name of the file to read.
    * @return the file object, or null if the file is not found.
    */
+  @Nullable
   PathFileObject getFileForInput(String packageName, String relativeName);
 
   /**
@@ -117,6 +212,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @return the {@link FileObject} to write to, or null if this group has no paths that can be
    *     written to.
    */
+  @Nullable
   PathFileObject getFileForOutput(String packageName, String relativeName);
 
   /**
@@ -129,6 +225,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
    *     written to.
    */
+  @Nullable
   PathFileObject getJavaFileForInput(String className, Kind kind);
 
   /**
@@ -142,6 +239,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @return the {@link JavaFileObject} to write to, or null if this group has no paths that can be
    *     written to.
    */
+  @Nullable
   PathFileObject getJavaFileForOutput(String className, Kind kind);
 
   /**
@@ -167,6 +265,7 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @param fileObject the file object to infer the binary name for.
    * @return the binary name if known, or null otherwise.
    */
+  @Nullable
   String inferBinaryName(PathFileObject fileObject);
 
   /**
@@ -178,6 +277,10 @@ public interface PackageContainerGroup extends ContainerGroup {
 
   /**
    * List all the file objects that match the given criteria in this group.
+   *
+   * <p>File objects are returned in an unordered collection, but lookup will be
+   * performed in a deterministic order corresponding to the same order as the
+   * containers returned by {@link #getPackages}.
    *
    * @param packageName the package name to look in.
    * @param kinds       the kinds of file to look for.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
@@ -40,7 +40,9 @@ public final class JctFileManagers extends UtilityClass {
    *
    * @param release the Java release to use for the file manager.
    * @return the file manager instance.
+   * @deprecated use {@link #newJctFileManagerFactory} instead.
    */
+  @Deprecated(forRemoval = true, since = "1.1.3")
   public static JctFileManager newJctFileManager(String release) {
     return new JctFileManagerImpl(release);
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagersTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/JctFileManagersTest.java
@@ -41,6 +41,7 @@ class JctFileManagersTest implements UtilityClassTestTemplate {
   }
 
   @DisplayName(".newJctFileManager(String) returns a new JctFileManagerImpl instance")
+  @SuppressWarnings("removal")
   @Test
   void newJctFileManagerReturnsNewJctFileManagerImplInstance() {
     // Given


### PR DESCRIPTION
Plan for removal of dead method that doesn't make a lot of sense to keep.

Fix documentation issue I spotted at the same time.