### PR TITLE
Print stacktraces to the console when errors occur in tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -299,8 +299,8 @@
             </consoleOutputReporter>
             <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
               <disable>false</disable>
-              <printStackTraceOnError>true</printStackTraceOnError>
-              <printStackTraceOnFailure>true</printStackTraceOnFailure>
+              <printStacktraceOnError>true</printStacktraceOnError>
+              <printStacktraceOnFailure>true</printStacktraceOnFailure>
               <usePhrasedFileName>false</usePhrasedFileName>
               <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
               <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
@@ -467,8 +467,8 @@
             </consoleOutputReporter>
             <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
               <disable>false</disable>
-              <printStackTraceOnError>true</printStackTraceOnError>
-              <printStackTraceOnFailure>true</printStackTraceOnFailure>
+              <printStacktraceOnError>true</printStacktraceOnError>
+              <printStacktraceOnFailure>true</printStacktraceOnFailure>
               <usePhrasedFileName>false</usePhrasedFileName>
               <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
               <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>

--- a/pom.xml
+++ b/pom.xml
@@ -299,6 +299,8 @@
             </consoleOutputReporter>
             <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
               <disable>false</disable>
+              <printStackTraceOnError>true</printStackTraceOnError>
+              <printStackTraceOnFailure>true</printStackTraceOnFailure>
               <usePhrasedFileName>false</usePhrasedFileName>
               <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
               <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
@@ -465,6 +467,8 @@
             </consoleOutputReporter>
             <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
               <disable>false</disable>
+              <printStackTraceOnError>true</printStackTraceOnError>
+              <printStackTraceOnFailure>true</printStackTraceOnFailure>
               <usePhrasedFileName>false</usePhrasedFileName>
               <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
               <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>


### PR DESCRIPTION
Enable writing stacktraces to the console when errors occur in tests running within Surefire or Failsafe.