### PR TITLE
Make LoggingFileManagerProxy internal

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerLoggingProxyConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerLoggingProxyConfigurer.java
@@ -17,8 +17,8 @@ package io.github.ascopes.jct.filemanagers.config;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
-import io.github.ascopes.jct.filemanagers.LoggingFileManagerProxy;
 import io.github.ascopes.jct.filemanagers.LoggingMode;
+import io.github.ascopes.jct.filemanagers.impl.LoggingFileManagerProxy;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/LoggingFileManagerProxy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/LoggingFileManagerProxy.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.ascopes.jct.filemanagers;
+package io.github.ascopes.jct.filemanagers.impl;
 
+import io.github.ascopes.jct.filemanagers.JctFileManager;
 import io.github.ascopes.jct.utils.LoomPolyfill;
 import io.github.ascopes.jct.utils.ToStringBuilder;
 import java.lang.reflect.InvocationHandler;
@@ -40,10 +41,13 @@ import org.slf4j.LoggerFactory;
  *
  * <p>All logs are emitted with the {@code DEBUG} logging level.
  *
+ * <p>Since v2.0.0, this class is now an internal class that is not part of the
+ * public API.
+ *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
+@API(since = "0.0.1", status = Status.INTERNAL)
 public final class LoggingFileManagerProxy implements InvocationHandler {
 
   private final Logger logger;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerLoggingProxyConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerLoggingProxyConfigurerTest.java
@@ -23,9 +23,9 @@ import static org.mockito.Mockito.when;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
-import io.github.ascopes.jct.filemanagers.LoggingFileManagerProxy;
 import io.github.ascopes.jct.filemanagers.LoggingMode;
 import io.github.ascopes.jct.filemanagers.config.JctFileManagerLoggingProxyConfigurer;
+import io.github.ascopes.jct.filemanagers.impl.LoggingFileManagerProxy;
 import io.github.ascopes.jct.filemanagers.impl.JctFileManagerImpl;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/LoggingFileManagerProxyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/impl/LoggingFileManagerProxyTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.ascopes.jct.tests.unit.filemanagers;
+package io.github.ascopes.jct.tests.unit.filemanagers.impl;
 
 import static io.github.ascopes.jct.tests.helpers.Fixtures.oneOf;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.someBoolean;
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import io.github.ascopes.jct.filemanagers.JctFileManager;
-import io.github.ascopes.jct.filemanagers.LoggingFileManagerProxy;
+import io.github.ascopes.jct.filemanagers.impl.LoggingFileManagerProxy;
 import io.github.ascopes.jct.tests.helpers.Slf4jLoggerFake;
 import io.github.ascopes.jct.utils.LoomPolyfill;
 import java.lang.reflect.Array;


### PR DESCRIPTION
Make LoggingFileManagerProxy an internal part of the JCT library for v2.0.0.

Users who need fine-grained control of the logging proxy can already do so via the JctCompiler interface, so there is no need to expose this component as part of the API.