### PR TITLE
Add acceptance tests for Kotlin and syntatic sugar for Kotlin-based tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -250,6 +250,11 @@ ij_java_wrap_comments = true
 ij_java_wrap_first_method_in_call_chain = false
 ij_java_wrap_long_lines = false
 
+[*.kt]
+ij_kotlin_indent_size = 2
+ij_kotlin_continuation_indent_for_chained_calls = true
+ij_kotlin_continuation_indent_size = 4
+
 [*.properties]
 ij_properties_align_group_field_declarations = false
 ij_properties_keep_blank_lines = false

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-kotlin/pom.xml
+++ b/acceptance-tests/acceptance-tests-kotlin/pom.xml
@@ -44,9 +44,6 @@
     </argLine>
 
     <kotlin.version>1.9.21</kotlin.version>
-
-    <!-- Compiler configuration -->
-    <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
   </properties>
 
   <dependencies>

--- a/acceptance-tests/acceptance-tests-kotlin/pom.xml
+++ b/acceptance-tests/acceptance-tests-kotlin/pom.xml
@@ -16,7 +16,9 @@
     limitations under the License.
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -26,31 +28,25 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>acceptance-tests-google-error-prone</artifactId>
-  <name>JCT acceptance tests for Google ErrorProne</name>
-  <description>Acceptance tests for Google ErrorProne.</description>
+  <artifactId>acceptance-tests-kotlin</artifactId>
+  <name>JCT acceptance tests for Kotlin</name>
+  <description>Acceptance tests for invocation with Kotlin.</description>
 
   <properties>
     <argLine>
       -Dorg.slf4j.simpleLogger.log=INFO
       -Dorg.slf4j.simpleLogger.log.io.github.ascopes.jct=DEBUG
       -Xshare:off
-      --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
-      --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-      --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
-      --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
-
+      --add-opens=java.base/java.lang=ALL-UNNAMED
+      --add-opens=java.base/java.io=ALL-UNNAMED
       <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391 -->
       -DmvnArgLinePropagated=true
     </argLine>
 
-    <error-prone.version>2.23.0</error-prone.version>
+    <kotlin.version>1.9.21</kotlin.version>
+
+    <!-- Compiler configuration -->
+    <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
   </properties>
 
   <dependencies>
@@ -61,10 +57,15 @@
     </dependency>
 
     <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_core</artifactId>
-      <version>${error-prone.version}</version>
-      <scope>test</scope>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-stdlib</artifactId>
+      <version>${kotlin.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jetbrains.kotlin</groupId>
+      <artifactId>kotlin-test</artifactId>
+      <version>${kotlin.version}</version>
     </dependency>
 
     <dependency>
@@ -81,24 +82,36 @@
   </dependencies>
 
   <build>
+    <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+    <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-failsafe-plugin</artifactId>
       </plugin>
+
+      <plugin>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-maven-plugin</artifactId>
+        <version>${kotlin.version}</version>
+
+        <executions>
+          <execution>
+            <id>compile</id>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+          </execution>
+
+          <execution>
+            <id>test-compile</id>
+            <goals>
+              <goal>test-compile</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
-
-  <profiles>
-    <profile>
-      <!-- https://github.com/google/error-prone/issues/3710 -->
-      <id>${project.artifactId}-incompatible-jdk</id>
-      <activation>
-        <jdk>[,12)</jdk>
-      </activation>
-      <properties>
-        <maven.test.skip>true</maven.test.skip>
-      </properties>
-    </profile>
-  </profiles>
 </project>

--- a/acceptance-tests/acceptance-tests-kotlin/src/test/kotlin/io/github/ascopes/jct/acceptancetests/kotlin/KotlinTest.kt
+++ b/acceptance-tests/acceptance-tests-kotlin/src/test/kotlin/io/github/ascopes/jct/acceptancetests/kotlin/KotlinTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.acceptancetests.kotlin
+
+import io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilation
+import io.github.ascopes.jct.compilers.JctCompiler
+import io.github.ascopes.jct.junit.JavacCompilerTest
+import io.github.ascopes.jct.workspaces.Workspaces
+
+class KotlinTest {
+
+  @JavacCompilerTest
+  fun `I can compile a 'Hello, World!' application`(compiler: JctCompiler) {
+    Workspaces.newWorkspace().use { workspace ->
+      // Given
+      workspace
+          .createSourcePathPackage()
+          .createFile("org", "example", "HelloWorld.java")
+          .withContents(
+            """
+            package org.example;
+            
+            public class HelloWorld {
+              public static void main(String[] args) {
+                System.out.println("Hello, World!");
+              }
+            }
+            """
+          )
+
+      // When
+      val compilation = compiler.compile(workspace)
+
+      // Then
+      assertThatCompilation(compilation).isSuccessful
+    }
+  }
+}

--- a/acceptance-tests/acceptance-tests-kotlin/src/test/kotlin/io/github/ascopes/jct/acceptancetests/kotlin/KotlinTest.kt
+++ b/acceptance-tests/acceptance-tests-kotlin/src/test/kotlin/io/github/ascopes/jct/acceptancetests/kotlin/KotlinTest.kt
@@ -19,8 +19,18 @@ import io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilation
 import io.github.ascopes.jct.compilers.JctCompiler
 import io.github.ascopes.jct.junit.JavacCompilerTest
 import io.github.ascopes.jct.workspaces.Workspaces
+import org.assertj.core.api.Assumptions.assumeThat
+import org.junit.jupiter.api.BeforeEach
 
 class KotlinTest {
+
+  @BeforeEach
+  fun setUp() {
+    // Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391
+    assumeThat(System.getProperty("mvnArgLinePropagated", "false"))
+        .withFailMessage("Your IDE has not propagated the <argLine/> in the pom.xml")
+        .isEqualTo("true")
+  }
 
   @JavacCompilerTest
   fun `I can compile a 'Hello, World!' application`(compiler: JctCompiler) {

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 
@@ -47,6 +47,7 @@
     <module>acceptance-tests-google-auto-service</module>
     <module>acceptance-tests-google-auto-value</module>
     <module>acceptance-tests-immutables</module>
+    <module>acceptance-tests-kotlin</module>
     <module>acceptance-tests-lombok</module>
     <module>acceptance-tests-mapstruct</module>
     <module>acceptance-tests-micronaut</module>

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
@@ -834,4 +834,26 @@ public interface Workspace extends AutoCloseable {
   default Map<String, List<? extends PathRoot>> getModulePathModules() {
     return getModules(StandardLocation.MODULE_PATH);
   }
+
+  /**
+   * Fluent API that handles this workspace in a try-with-resources internally, ensuring that it
+   * is closed after the given operation exists.
+   *
+   * <p>This is designed to improve the API for Kotlin users. Java users should use a
+   * try-with-resources instead.
+   *
+   * @param workspaceOperation the operation to run.
+   * @throws Exception if an exception is thrown from within the given operation.
+   */
+  @API(since = "2.1.0", status = Status.STABLE)
+  default void use(WorkspaceOperation workspaceOperation) throws Exception {
+    try (var workspace = this) {
+      workspaceOperation.run(workspace);
+    }
+  }
+
+  @FunctionalInterface
+  interface WorkspaceOperation {
+    void run(Workspace workspace) throws Exception;
+  }
 }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/WorkspaceTest.java
@@ -18,8 +18,13 @@ package io.github.ascopes.jct.tests.unit.workspaces;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.someModuleName;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.someText;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doCallRealMethod;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -27,14 +32,18 @@ import static org.mockito.Mockito.when;
 
 import io.github.ascopes.jct.workspaces.PathRoot;
 import io.github.ascopes.jct.workspaces.Workspace;
+import io.github.ascopes.jct.workspaces.Workspace.WorkspaceOperation;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import javax.tools.StandardLocation;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.NotExtensible;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -627,5 +636,52 @@ class WorkspaceTest {
     verify(workspace).getModules(StandardLocation.MODULE_PATH);
     verifyNoMoreInteractions(workspace);
     assertThat(actual).isSameAs(expected);
+  }
+
+  @DisplayName(".use(WorkspaceOperation) tests")
+  @Nested
+  class UseTest {
+
+    @BeforeEach
+    void setUp() throws Exception {
+      doCallRealMethod().when(workspace).use(any());
+    }
+
+    @DisplayName(".use(WorkspaceOperation) calls the operation then closes")
+    @Test
+    void callsTheOperationThenCloses() throws Exception {
+      // Given
+      var operation = mock(WorkspaceOperation.class);
+      var ordered = inOrder(workspace, operation);
+      doNothing().when(operation).run(any());
+
+      // When
+      workspace.use(operation);
+
+      // Then
+      ordered.verify(operation).run(workspace);
+      ordered.verify(workspace).close();
+      ordered.verifyNoMoreInteractions();
+    }
+
+    @DisplayName(".use(WorkspaceOperation) throws any exception and then closes")
+    @Test
+    void throwsAnyExceptionThenCloses() throws Exception {
+      // Given
+      var exception = new Exception("bang");
+      var operation = mock(WorkspaceOperation.class);
+      var ordered = inOrder(workspace, operation);
+      doThrow(exception).when(operation).run(any());
+
+      // Then
+      assertThatException()
+          .isThrownBy(() -> workspace.use(operation))
+          .isSameAs(exception);
+
+      // Then
+      ordered.verify(operation).run(workspace);
+      ordered.verify(workspace).close();
+      ordered.verifyNoMoreInteractions();
+    }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>2.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>
@@ -553,6 +553,7 @@
                 <include>security-suppressions.xml</include>
                 <include>src/**/*.groovy</include>
                 <include>src/**/*.java</include>
+                <include>src/**/*.kt</include>
                 <include>scripts/**/*.sh</include>
               </includes>
             </licenseSet>


### PR DESCRIPTION
Add acceptance tests for Kotlin and syntatic sugar for Kotlin-based tests.

Closes GH-535.
