### PR TITLE
Extract MockedStatic and MockedConstruction out of JUnit lifecycles

### DIFF
--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurerTest.java
@@ -18,6 +18,7 @@ package io.github.ascopes.jct.tests.unit.filemanagers.config;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.somePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -38,7 +39,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mock.Strictness;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -56,9 +56,6 @@ class JctFileManagerJvmClassPathModuleConfigurerTest {
   @Mock
   JctFileManagerImpl fileManager;
 
-  @Mock
-  MockedStatic<SpecialLocationUtils> specialLocationUtilsStatic;
-
   @InjectMocks
   JctFileManagerJvmClassPathModuleConfigurer configurer;
 
@@ -68,29 +65,31 @@ class JctFileManagerJvmClassPathModuleConfigurerTest {
   @Test
   void configureAddsTheClassPathToTheFileManagerModulePath() {
     // Given
-    var paths = List.of(
-        somePath(),
-        somePath(),
-        somePath(),
-        somePath(),
-        somePath()
-    );
+    try (var specialLocationUtilsStatic = mockStatic(SpecialLocationUtils.class)) {
+      var paths = List.of(
+          somePath(),
+          somePath(),
+          somePath(),
+          somePath(),
+          somePath()
+      );
 
-    specialLocationUtilsStatic.when(SpecialLocationUtils::currentClassPathLocations)
-        .thenReturn(paths);
+      specialLocationUtilsStatic.when(SpecialLocationUtils::currentClassPathLocations)
+          .thenReturn(paths);
 
-    // When
-    configurer.configure(fileManager);
+      // When
+      configurer.configure(fileManager);
 
-    // Then
-    var captor = ArgumentCaptor.forClass(WrappingDirectoryImpl.class);
+      // Then
+      var captor = ArgumentCaptor.forClass(WrappingDirectoryImpl.class);
 
-    verify(fileManager, times(paths.size()))
-        .addPath(eq(StandardLocation.MODULE_PATH), captor.capture());
+      verify(fileManager, times(paths.size()))
+          .addPath(eq(StandardLocation.MODULE_PATH), captor.capture());
 
-    assertThat(captor.getAllValues())
-        .map(WrappingDirectoryImpl::getPath)
-        .containsExactlyElementsOf(paths);
+      assertThat(captor.getAllValues())
+          .map(WrappingDirectoryImpl::getPath)
+          .containsExactlyElementsOf(paths);
+    }
   }
 
   @DisplayName(".configure(...) returns the input file manager")

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmSystemModulesConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmSystemModulesConfigurerTest.java
@@ -18,6 +18,7 @@ package io.github.ascopes.jct.tests.unit.filemanagers.config;
 import static io.github.ascopes.jct.tests.helpers.Fixtures.somePath;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -37,7 +38,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -55,9 +55,6 @@ class JctFileManagerJvmSystemModulesConfigurerTest {
   @Mock
   JctFileManagerImpl fileManager;
 
-  @Mock
-  MockedStatic<SpecialLocationUtils> specialLocationUtilsStatic;
-
   @InjectMocks
   JctFileManagerJvmSystemModulesConfigurer configurer;
 
@@ -65,28 +62,30 @@ class JctFileManagerJvmSystemModulesConfigurerTest {
   @Test
   void configureAddsTheSystemModulesToTheFileManager() {
     // Given
-    var paths = List.of(
-        somePath(),
-        somePath(),
-        somePath(),
-        somePath()
-    );
+    try (var specialLocationUtilsStatic = mockStatic(SpecialLocationUtils.class)) {
+      var paths = List.of(
+          somePath(),
+          somePath(),
+          somePath(),
+          somePath()
+      );
 
-    specialLocationUtilsStatic.when(SpecialLocationUtils::javaRuntimeLocations)
-        .thenReturn(paths);
+      specialLocationUtilsStatic.when(SpecialLocationUtils::javaRuntimeLocations)
+          .thenReturn(paths);
 
-    // When
-    configurer.configure(fileManager);
+      // When
+      configurer.configure(fileManager);
 
-    // Then
-    var captor = ArgumentCaptor.forClass(WrappingDirectoryImpl.class);
+      // Then
+      var captor = ArgumentCaptor.forClass(WrappingDirectoryImpl.class);
 
-    verify(fileManager, times(paths.size()))
-        .addPath(eq(StandardLocation.SYSTEM_MODULES), captor.capture());
+      verify(fileManager, times(paths.size()))
+          .addPath(eq(StandardLocation.SYSTEM_MODULES), captor.capture());
 
-    assertThat(captor.getAllValues())
-        .map(WrappingDirectoryImpl::getPath)
-        .containsExactlyElementsOf(paths);
+      assertThat(captor.getAllValues())
+          .map(WrappingDirectoryImpl::getPath)
+          .containsExactlyElementsOf(paths);
+    }
   }
 
   @DisplayName(".configure(...) returns the input file manager")


### PR DESCRIPTION
See https://github.com/ascopes/java-compiler-testing/issues/588 for full details.

The issue at https://github.com/mockito/mockito/issues/3156 advises against using MockedStatic and MockedConstruction with the MocktioExtension as it can cause unwanted side effects between tests.

This PR removes any such usages of that mechanism in ill-advisable ways.

Closes GH-588.