### PR TITLE
Add -proc:all to compilation by default.

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
@@ -43,6 +43,7 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
   private static final String ANNOTATION_OPT = "-A";
   private static final String PROC_NONE = "-proc:none";
   private static final String PROC_ONLY = "-proc:only";
+  private static final String PROC_ALL = "-proc:all";
 
   private final List<String> craftedFlags;
 
@@ -85,7 +86,9 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
         break;
 
       default:
-        // Do nothing. The default behaviour is to allow this.
+        // In Java 22, the default is to disable all annotation processing by default.
+        // Prior to Java 22, the default was to enable all annotation processing by default.
+        craftedFlags.add(PROC_ALL);
         break;
     }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JavacJctFlagBuilderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JavacJctFlagBuilderImplTest.java
@@ -189,16 +189,6 @@ class JavacJctFlagBuilderImplTest {
   @Nested
   class CompilationModeFlagTest {
 
-    @DisplayName(".compilationMode(COMPILATION_AND_ANNOTATION_PROCESSING) adds no flags")
-    @Test
-    void compilationAndAnnotationProcessingAddsNoFlags() {
-      // When
-      flagBuilder.compilationMode(CompilationMode.COMPILATION_AND_ANNOTATION_PROCESSING);
-
-      // Then
-      assertThat(flagBuilder.build()).isEmpty();
-    }
-
     @DisplayName(".compilationMode(COMPILATION_ONLY) adds -proc:none")
     @Test
     void compilationOnlyAddsProcNone() {
@@ -217,6 +207,16 @@ class JavacJctFlagBuilderImplTest {
 
       // Then
       assertThat(flagBuilder.build()).containsExactly("-proc:only");
+    }
+
+    @DisplayName(".compilationMode(COMPILATION_AND_ANNOTATION_PROCESSING) adds -proc:all")
+    @Test
+    void compilationAndAnnotationProcessingAddsProcAll() {
+      // When
+      flagBuilder.compilationMode(CompilationMode.COMPILATION_AND_ANNOTATION_PROCESSING);
+
+      // Then
+      assertThat(flagBuilder.build()).containsExactly("-proc:all");
     }
 
     @DisplayName(".compilationMode(...) returns the flag builder")


### PR DESCRIPTION
JDK 22 does not do this by default anymore, so we should add this to remain consistent between compiler versions.
