### PR TITLE
Task/additional options

### DIFF
--- a/acceptance-tests/acceptance-tests-avaje-http/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-http/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-inject/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
+++ b/acceptance-tests/acceptance-tests-avaje-jsonb/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-checkerframework/pom.xml
+++ b/acceptance-tests/acceptance-tests-checkerframework/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dagger/pom.xml
+++ b/acceptance-tests/acceptance-tests-dagger/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-dogfood/pom.xml
+++ b/acceptance-tests/acceptance-tests-dogfood/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-factory/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-service/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-auto-value/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-google-error-prone/pom.xml
+++ b/acceptance-tests/acceptance-tests-google-error-prone/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-immutables/pom.xml
+++ b/acceptance-tests/acceptance-tests-immutables/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-lombok/pom.xml
+++ b/acceptance-tests/acceptance-tests-lombok/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-mapstruct/pom.xml
+++ b/acceptance-tests/acceptance-tests-mapstruct/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-micronaut/pom.xml
+++ b/acceptance-tests/acceptance-tests-micronaut/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader-jpms/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-serviceloader/pom.xml
+++ b/acceptance-tests/acceptance-tests-serviceloader/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/acceptance-tests-spring/pom.xml
+++ b/acceptance-tests/acceptance-tests-spring/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>acceptance-tests</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/acceptance-tests/pom.xml
+++ b/acceptance-tests/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>2.0.2-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import javax.annotation.processing.Processor;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -79,6 +80,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
   private boolean inheritSystemModulePath;
   private LoggingMode fileManagerLoggingMode;
   private AnnotationProcessorDiscovery annotationProcessorDiscovery;
+  private Set<DebuggingInfo> debuggingInfo;
+  private boolean parameterInfoEnabled;
 
   /**
    * Initialize this compiler.
@@ -108,6 +111,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
     inheritSystemModulePath = JctCompiler.DEFAULT_INHERIT_SYSTEM_MODULE_PATH;
     fileManagerLoggingMode = JctCompiler.DEFAULT_FILE_MANAGER_LOGGING_MODE;
     annotationProcessorDiscovery = JctCompiler.DEFAULT_ANNOTATION_PROCESSOR_DISCOVERY;
+    debuggingInfo = DEFAULT_DEBUGGING_INFO;
+    parameterInfoEnabled = DEFAULT_PARAMETER_INFO_ENABLED;
   }
 
   @Override
@@ -417,6 +422,29 @@ public abstract class AbstractJctCompiler implements JctCompiler {
     return this;
   }
 
+  @Override
+  public Set<DebuggingInfo> getDebuggingInfo() {
+    return debuggingInfo;
+  }
+
+  @Override
+  public JctCompiler debuggingInfo(Set<DebuggingInfo> debuggingInfo) {
+    requireNonNullValues(debuggingInfo, "debuggingInfo");
+    this.debuggingInfo = Set.copyOf(debuggingInfo);
+    return this;
+  }
+
+  @Override
+  public boolean isParameterInfoEnabled() {
+    return parameterInfoEnabled;
+  }
+
+  @Override
+  public JctCompiler parameterInfoEnabled(boolean parameterInfoEnabled) {
+    this.parameterInfoEnabled = parameterInfoEnabled;
+    return this;
+  }
+
   /**
    * Get the string representation of the compiler.
    *
@@ -504,6 +532,8 @@ public abstract class AbstractJctCompiler implements JctCompiler {
         .target(target)
         .verbose(verbose)
         .showWarnings(showWarnings)
+        .debuggingInfo(debuggingInfo)
+        .parameterInfoEnabled(parameterInfoEnabled)
         .build();
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/DebuggingInfo.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/DebuggingInfo.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 - 2023, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.compilers;
+
+import java.util.EnumSet;
+import java.util.Set;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+
+/**
+ * An enum representing the various types of debugger info that can be included in compilations.
+ *
+ * <p>This corresponds to the {@code -g} flag in the OpenJDK Javac implementation.
+ *
+ * @author Ashley Scopes
+ * @since 3.0.0
+ */
+@API(since = "3.0.0", status = Status.STABLE)
+public enum DebuggingInfo {
+  LINES,
+  VARS,
+  SOURCE;
+
+  /**
+   * Return a set of none of the debugger info flags.
+   *
+   * @return a set containing no debugger flags.
+   */
+  public static Set<DebuggingInfo> none() {
+    return EnumSet.noneOf(DebuggingInfo.class);
+  }
+
+  /**
+   * Return a set of the given debugger info flags.
+   *
+   * @param flag  the first flag.
+   * @param flags additional flags.
+   * @return the set of the debugger info flags.
+   */
+  public static Set<DebuggingInfo> just(DebuggingInfo flag, DebuggingInfo... flags) {
+    return EnumSet.of(flag, flags);
+  }
+
+  /**
+   * Return a set of all the debugger info flags.
+   *
+   * @return a set containing all the debugger flags.
+   */
+  public static Set<DebuggingInfo> all() {
+    return EnumSet.allOf(DebuggingInfo.class);
+  }
+}

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -26,6 +26,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.lang.model.SourceVersion;
 import org.apiguardian.api.API;
@@ -36,7 +37,7 @@ import org.apiguardian.api.API.Status;
  * sources.
  *
  * <p>JctCompiler objects are often a nexus that will manage configuring an underlying JSR-199
- * compiler internally in a platform agnostic way.
+ * compiler internally in a platform-agnostic way.
  *
  * @author Ashley Scopes
  * @since 0.0.1
@@ -123,6 +124,17 @@ public interface JctCompiler {
   Charset DEFAULT_LOG_CHARSET = StandardCharsets.UTF_8;
 
   /**
+   * Default debugging info to include in the compilation (all possible info).
+   */
+  Set<DebuggingInfo> DEFAULT_DEBUGGING_INFO = DebuggingInfo.all();
+
+  /**
+   * Default preference for including reflective parameter information in compiled classes
+   * ({@code true}).
+   */
+  boolean DEFAULT_PARAMETER_INFO_ENABLED = true;
+
+  /**
    * Invoke the compilation and return the compilation result.
    *
    * <p>The actual classes to compile will be dynamically discovered. If you wish to
@@ -149,8 +161,7 @@ public interface JctCompiler {
    * {@link #compile(Workspace)} instead.
    *
    * <p>Note that nested instance/static nested classes cannot be specified individually
-   * here. To compile them, you must also compile their outer class that they are defined
-   * within.
+   * here. To compile them, you must also compile their outer class that they are defined within.
    *
    * @param workspace            the workspace to compile.
    * @param firstClassName       the first class name to compile.
@@ -178,8 +189,7 @@ public interface JctCompiler {
    * {@link #compile(Workspace)} instead.
    *
    * <p>Note that nested instance/static nested classes cannot be specified individually
-   * here. To compile them, you must also compile their outer class that they are defined
-   * within.
+   * here. To compile them, you must also compile their outer class that they are defined within.
    *
    * @param workspace  the workspace to compile.
    * @param classNames the class names to compile.
@@ -216,14 +226,14 @@ public interface JctCompiler {
    * </code></pre>
    *
    * <p>Configurers take a type parameter that corresponds to an exception type. This
-   * is the exception type that can be thrown by the configurer, or {@link RuntimeException}
-   * if no checked exception is thrown. This mechanism allows configurers to propagate
-   * checked exceptions to their caller where needed.
+   * is the exception type that can be thrown by the configurer, or {@link RuntimeException} if no
+   * checked exception is thrown. This mechanism allows configurers to propagate checked exceptions
+   * to their caller where needed.
    *
    * <pre><code>
    *   class FileFlagConfigurer implements JctCompilerConfigurer&lt;IOException&gt; {
    *     private final Path path;
-   *     
+   *
    *     public FileFlagConfigurer(String... path) {
    *       this(Path.of(path));
    *     }
@@ -253,8 +263,8 @@ public interface JctCompiler {
    * @param <E>        any exception that may be thrown.
    * @param configurer the configurer to invoke.
    * @return this compiler object for further call chaining.
-   * @throws E any exception that may be thrown by the configurer. If no checked exception
-   *           is thrown, then this should be treated as {@link RuntimeException}.
+   * @throws E any exception that may be thrown by the configurer. If no checked exception is
+   *           thrown, then this should be treated as {@link RuntimeException}.
    */
   <E extends Exception> JctCompiler configure(JctCompilerConfigurer<E> configurer) throws E;
 
@@ -268,9 +278,8 @@ public interface JctCompiler {
   /**
    * Set the friendly name of this compiler.
    *
-   * <p>This will be used by the 
-   * {@link io.github.ascopes.jct.junit.JavacCompilerTest JUnit5 support}
-   * to name unit test cases.
+   * <p>This will be used by the
+   * {@link io.github.ascopes.jct.junit.JavacCompilerTest JUnit5 support} to name unit test cases.
    *
    * @param name the name to set.
    * @return this compiler object for further call chaining.
@@ -321,8 +330,8 @@ public interface JctCompiler {
    * Add annotation processors to invoke.
    *
    * <p><strong>Warning:</strong> This bypasses the discovery process of annotation processors
-   * provided in the annotation processor path and annotation processor module paths, as well as
-   * any other locations such as class paths and module paths.
+   * provided in the annotation processor path and annotation processor module paths, as well as any
+   * other locations such as class paths and module paths.
    *
    * @param annotationProcessors the processors to invoke.
    * @return this compiler object for further call chaining.
@@ -333,8 +342,8 @@ public interface JctCompiler {
    * Add annotation processors to invoke.
    *
    * <p><strong>Warning:</strong> This bypasses the discovery process of annotation processors
-   * provided in the annotation processor path and annotation processor module paths, as well as
-   * any other locations such as class paths and module paths.
+   * provided in the annotation processor path and annotation processor module paths, as well as any
+   * other locations such as class paths and module paths.
    *
    * @param annotationProcessor  the first processor to invoke.
    * @param annotationProcessors additional processors to invoke.
@@ -511,8 +520,8 @@ public interface JctCompiler {
    * Set the compilation mode to use for this compiler.
    *
    * <p>This allows you to override whether sources are compiled or annotation-processed
-   * without running the full compilation process. Tuning this may provide faster test
-   * cases in some situations.
+   * without running the full compilation process. Tuning this may provide faster test cases in some
+   * situations.
    *
    * <p>Unless otherwise changed or specified, implementations should default to
    * {@link #DEFAULT_COMPILATION_MODE}.
@@ -529,8 +538,8 @@ public interface JctCompiler {
    * the internal compiler implementation.
    *
    * <p>Generally, this value will be an integer within a string. The value is
-   * represented as a string to allow supporting compilers which may use non-integer
-   * version numbers.
+   * represented as a string to allow supporting compilers which may use non-integer version
+   * numbers.
    *
    * @return the default release version to use.
    */
@@ -540,8 +549,8 @@ public interface JctCompiler {
    * Get the effective release to use for the actual compilation.
    *
    * <p>Generally, this value will be an integer within a string. The value is
-   * represented as a string to allow supporting compilers which may use non-integer
-   * version numbers.
+   * represented as a string to allow supporting compilers which may use non-integer version
+   * numbers.
    *
    * <p>This may be determined from the {@link #getSource() source},
    * {@link #getTarget() target}, {@link #getRelease() release}, and
@@ -556,8 +565,8 @@ public interface JctCompiler {
    * default.
    *
    * <p>Generally, this value will be an integer within a string. The value is
-   * represented as a string to allow supporting compilers which may use non-integer
-   * version numbers.
+   * represented as a string to allow supporting compilers which may use non-integer version
+   * numbers.
    *
    * <p>Unless explicitly defined, the default setting is expected to be a sane compiler-specific
    * default.
@@ -572,8 +581,8 @@ public interface JctCompiler {
    * <p>This will clear any source and target version that is set.
    *
    * <p>Generally, this value will be an integer within a string. The value is
-   * represented as a string to allow supporting compilers which may use non-integer
-   * version numbers.
+   * represented as a string to allow supporting compilers which may use non-integer version
+   * numbers.
    *
    * <p>Unless explicitly defined, the default setting is expected to be a sane compiler-specific
    * default.
@@ -589,15 +598,15 @@ public interface JctCompiler {
    * <p>This will clear any source and target version that is set.
    *
    * <p>Generally, this value will be an integer within a string. The value is
-   * represented as a string to allow supporting compilers which may use non-integer
-   * version numbers.
+   * represented as a string to allow supporting compilers which may use non-integer version
+   * numbers.
    *
    * <p>Unless explicitly defined, the default setting is expected to be a sane compiler-specific
    * default.
    *
    * @param release the version to set.
    * @return this compiler object for further call chaining.
-   * @throws IllegalArgumentException if the version is less than 0.
+   * @throws IllegalArgumentException      if the version is less than 0.
    * @throws UnsupportedOperationException if the compiler does not support integer versions.
    */
   default JctCompiler release(int release) {
@@ -614,8 +623,8 @@ public interface JctCompiler {
    * <p>This will clear any source and target version that is set.
    *
    * <p>Generally, this value will be an integer within a string. The value is
-   * represented as a string to allow supporting compilers which may use non-integer
-   * version numbers.
+   * represented as a string to allow supporting compilers which may use non-integer version
+   * numbers.
    *
    * <p>Unless explicitly defined, the default setting is expected to be a sane compiler-specific
    * default.
@@ -629,18 +638,18 @@ public interface JctCompiler {
   }
 
   /**
-   * Request that the compiler uses a language version that corresponds to the
-   * runtime language version in use on the current JVM.
+   * Request that the compiler uses a language version that corresponds to the runtime language
+   * version in use on the current JVM.
    *
    * <p>For example, running this on JRE 19 would set the release to "19".
    *
    * <p>This calls {@link #release(int) internally}.
    *
    * @return this compiler object for further call chaining.
+   * @throws UnsupportedOperationException if the current JVM version does not correspond to a
+   *                                       supported Jave release version in the compiler, or if the
+   *                                       compiler does not support integral version numbers.
    * @since 1.1.0
-   * @throws UnsupportedOperationException if the current JVM version does not
-   *     correspond to a supported Jave release version in the compiler, or if the
-   *     compiler does not support integral version numbers.
    */
   @API(since = "1.1.0", status = Status.STABLE)
   default JctCompiler useRuntimeRelease() {
@@ -667,9 +676,9 @@ public interface JctCompiler {
    * default.
    *
    * <p>Source and target versions have mostly been replaced with the release version
-   * mechanism which controls both flags and can ensure other behaviours are consistent.
-   * This feature is still provided in case you have a specific use case that is not covered
-   * by this functionality.
+   * mechanism which controls both flags and can ensure other behaviours are consistent. This
+   * feature is still provided in case you have a specific use case that is not covered by this
+   * functionality.
    *
    * @param source the version to set.
    * @return this compiler object for further call chaining.
@@ -685,15 +694,14 @@ public interface JctCompiler {
    * default.
    *
    * <p>Source and target versions have mostly been replaced with the release version
-   * mechanism which controls both flags and can ensure other behaviours are consistent.
-   * This feature is still provided in case you have a specific use case that is not covered
-   * by this functionality.
+   * mechanism which controls both flags and can ensure other behaviours are consistent. This
+   * feature is still provided in case you have a specific use case that is not covered by this
+   * functionality.
    *
    * @param source the version to set.
    * @return this compiler object for further call chaining.
-   * @throws IllegalArgumentException if the version is less than 0.
-   * @throws UnsupportedOperationException if the compiler does not
-   *     support integer versions.
+   * @throws IllegalArgumentException      if the version is less than 0.
+   * @throws UnsupportedOperationException if the compiler does not support integer versions.
    */
   default JctCompiler source(int source) {
     if (source < 0) {
@@ -712,9 +720,9 @@ public interface JctCompiler {
    * default.
    *
    * <p>Source and target versions have mostly been replaced with the release version
-   * mechanism which controls both flags and can ensure other behaviours are consistent.
-   * This feature is still provided in case you have a specific use case that is not covered
-   * by this functionality.
+   * mechanism which controls both flags and can ensure other behaviours are consistent. This
+   * feature is still provided in case you have a specific use case that is not covered by this
+   * functionality.
    *
    * @param source the version to set.
    * @return this compiler object for further call chaining.
@@ -743,9 +751,9 @@ public interface JctCompiler {
    * default.
    *
    * <p>Source and target versions have mostly been replaced with the release version
-   * mechanism which controls both flags and can ensure other behaviours are consistent.
-   * This feature is still provided in case you have a specific use case that is not covered
-   * by this functionality.
+   * mechanism which controls both flags and can ensure other behaviours are consistent. This
+   * feature is still provided in case you have a specific use case that is not covered by this
+   * functionality.
    *
    * @param target the version to set.
    * @return this compiler object for further call chaining.
@@ -761,13 +769,13 @@ public interface JctCompiler {
    * default.
    *
    * <p>Source and target versions have mostly been replaced with the release version
-   * mechanism which controls both flags and can ensure other behaviours are consistent.
-   * This feature is still provided in case you have a specific use case that is not covered
-   * by this functionality.
+   * mechanism which controls both flags and can ensure other behaviours are consistent. This
+   * feature is still provided in case you have a specific use case that is not covered by this
+   * functionality.
    *
    * @param target the version to set.
    * @return this compiler object for further call chaining.
-   * @throws IllegalArgumentException if the version is less than 0.
+   * @throws IllegalArgumentException      if the version is less than 0.
    * @throws UnsupportedOperationException if the compiler does not support integer versions.
    */
   default JctCompiler target(int target) {
@@ -787,9 +795,9 @@ public interface JctCompiler {
    * default.
    *
    * <p>Source and target versions have mostly been replaced with the release version
-   * mechanism which controls both flags and can ensure other behaviours are consistent.
-   * This feature is still provided in case you have a specific use case that is not covered
-   * by this functionality.
+   * mechanism which controls both flags and can ensure other behaviours are consistent. This
+   * feature is still provided in case you have a specific use case that is not covered by this
+   * functionality.
    *
    * @param target the version to set.
    * @return this compiler object for further call chaining.
@@ -1009,4 +1017,44 @@ public interface JctCompiler {
    */
   JctCompiler annotationProcessorDiscovery(
       AnnotationProcessorDiscovery annotationProcessorDiscovery);
+
+  /**
+   * Get the debugging info that is enabled.
+   *
+   * <p>Unless otherwise changed or specified, implementations should default to
+   * {@link #DEFAULT_DEBUGGING_INFO}.
+   *
+   * @return the set of debugging info flags that are enabled.
+   * @since 3.0.0
+   */
+  Set<DebuggingInfo> getDebuggingInfo();
+
+  /**
+   * Set the debugging info level to use.
+   *
+   * @param debuggingInfoFlags the set of debugging info flags to enable.
+   * @return this compiler for further call chaining.
+   * @since 3.0.0
+   */
+  JctCompiler debuggingInfo(Set<DebuggingInfo> debuggingInfoFlags);
+
+  /**
+   * Determine if including reflective parameter info is enabled or not.
+   *
+   * <p>Unless otherwise changed or specified, implementations should default to
+   * {@link #DEFAULT_PARAMETER_INFO_ENABLED}.
+   *
+   * @return the parameter info inclusion preference.
+   * @since 3.0.0
+   */
+  boolean isParameterInfoEnabled();
+
+  /**
+   * Set whether to include parameter reflective info by default in compiled classes or not.
+   *
+   * @param parameterInfoEnabled whether to include the parameter reflective info or not.
+   * @return this compiler for further call chaining.
+   * @since 3.0.0
+   */
+  JctCompiler parameterInfoEnabled(boolean parameterInfoEnabled);
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
@@ -16,6 +16,7 @@
 package io.github.ascopes.jct.compilers;
 
 import java.util.List;
+import java.util.Set;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
@@ -99,6 +100,24 @@ public interface JctFlagBuilder {
    * @return this builder.
    */
   JctFlagBuilder target(@Nullable String version);
+
+  /**
+   * Add the debugging info flags.
+   *
+   * @param set the set of debugging info flags to enable.
+   * @return this builder.
+   * @since 3.0.0
+   */
+  JctFlagBuilder debuggingInfo(Set<DebuggingInfo> set);
+
+  /**
+   * Specify whether to include parameter reflection info in the compiled classes.
+   *
+   * @param enabled whether the parameter info is enabled or not.
+   * @return this builder.
+   * @since 3.0.0
+   */
+  JctFlagBuilder parameterInfoEnabled(boolean enabled);
 
   /**
    * Add annotation processor options.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
@@ -16,9 +16,11 @@
 package io.github.ascopes.jct.compilers.impl;
 
 import io.github.ascopes.jct.compilers.CompilationMode;
+import io.github.ascopes.jct.compilers.DebuggingInfo;
 import io.github.ascopes.jct.compilers.JctFlagBuilder;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
@@ -44,6 +46,11 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
   private static final String PROC_NONE = "-proc:none";
   private static final String PROC_ONLY = "-proc:only";
   private static final String PROC_ALL = "-proc:all";
+  private static final String DEBUG_LINES = "-g:lines";
+  private static final String DEBUG_VARS = "-g:vars";
+  private static final String DEBUG_SOURCE = "-g:source";
+  private static final String DEBUG_NONE = "-g:none";
+  private static final String PARAMETERS = "-parameters";
 
   private final List<String> craftedFlags;
 
@@ -116,6 +123,34 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
   }
 
   @Override
+  public JctFlagBuilder debuggingInfo(Set<DebuggingInfo> set) {
+    if (set.isEmpty()) {
+      craftedFlags.add(DEBUG_NONE);
+    } else {
+      for (var flag : set) {
+        switch (flag) {
+          case LINES:
+            craftedFlags.add(DEBUG_LINES);
+            break;
+          case SOURCE:
+            craftedFlags.add(DEBUG_SOURCE);
+            break;
+          case VARS:
+            craftedFlags.add(DEBUG_VARS);
+            break;
+        }
+      }
+    }
+
+    return this;
+  }
+
+  @Override
+  public JctFlagBuilder parameterInfoEnabled(boolean enabled) {
+    return addFlagIfTrue(enabled, PARAMETERS);
+  }
+
+  @Override
   public JavacJctFlagBuilderImpl annotationProcessorOptions(List<String> options) {
     options.forEach(option -> craftedFlags.add(ANNOTATION_OPT + option));
     return this;
@@ -141,6 +176,7 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
     return this;
   }
 
+  @SuppressWarnings("SameParameterValue")
   private JavacJctFlagBuilderImpl addFlagIfFalse(boolean condition, String flag) {
     return addFlagIfTrue(!condition, flag);
   }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/helpers/Fixtures.java
@@ -35,11 +35,14 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -453,6 +456,24 @@ public final class Fixtures {
    */
   public static <E extends Enum<E>> E oneOf(Class<E> cls) {
     return oneOf(cls.getEnumConstants());
+  }
+
+  /**
+   * Return some of the members of a given enum.
+   *
+   * @param cls the enum class.
+   * @param <E> the enum type.
+   * @return a set containing some of the enum members.
+   */
+  public static <E extends Enum<E>> Set<E> someOf(Class<E> cls) {
+    var set = new HashSet<E>();
+    var options = new ArrayList<>(Arrays.asList(cls.getEnumConstants()));
+
+    while (!options.isEmpty()) {
+      set.add(options.remove(someInt(options.size())));
+    }
+
+    return set;
   }
 
   /**

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JavacJctFlagBuilderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JavacJctFlagBuilderImplTest.java
@@ -21,6 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.github.ascopes.jct.compilers.CompilationMode;
+import io.github.ascopes.jct.compilers.DebuggingInfo;
 import io.github.ascopes.jct.compilers.impl.JavacJctFlagBuilderImpl;
 import io.github.ascopes.jct.tests.helpers.Fixtures;
 import java.util.List;
@@ -362,6 +363,58 @@ class JavacJctFlagBuilderImplTest {
       // Then
       assertThat(flagBuilder.target(someRelease()))
           .isSameAs(flagBuilder);
+    }
+  }
+
+  @DisplayName(".debuggingInfo(Set<DebuggingInfo>) tests")
+  @Nested
+  class DebuggingInfoTest {
+
+    @DisplayName("Setting .debuggingInfo with an empty set adds the '-g:none' flag")
+    @Test
+    void emptySetAddsGnoneFlag() {
+      // When
+      flagBuilder.debuggingInfo(DebuggingInfo.none());
+
+      // Then
+      assertThat(flagBuilder.build()).containsOnlyOnce("-g:none");
+    }
+
+    @DisplayName("Setting .debuggingInfo with some values set adds the '-g:xxx' flags")
+    @Test
+    void nonEmptySetAddsValues() {
+      // When
+      flagBuilder.debuggingInfo(DebuggingInfo.all());
+
+      // Then
+      assertThat(flagBuilder.build())
+          .doesNotContain("-g", "-g:none")
+          .containsOnlyOnce("-g:lines", "-g:source", "-g:vars");
+    }
+  }
+
+  @DisplayName(".parameterInfoEnabled(boolean) tests")
+  @Nested
+  class ParameterInfoEnabledTest {
+
+    @DisplayName("Setting .parameterInfoEnabled(true) adds the '-parameters' flag")
+    @Test
+    void trueAddsFlag() {
+      // When
+      flagBuilder.parameterInfoEnabled(true);
+
+      // Then
+      assertThat(flagBuilder.build()).containsOnlyOnce("-parameters");
+    }
+
+    @DisplayName("Setting .parameterInfoEnabled(false) does not add the '-parameters' flag")
+    @Test
+    void falseDoesNotAddFlag() {
+      // When
+      flagBuilder.parameterInfoEnabled(false);
+
+      // Then
+      assertThat(flagBuilder.build()).doesNotContain("-parameters");
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>2.0.2-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>


### PR DESCRIPTION
Add the ability to set the debugger info flags explicitly, and default to
enabling said flags by default to improve the diagnostic capabilities of
generated class files.

Adds the ability to override the default parameter info inclusion setting
on the compiler, and defaults to including by default to enrich further
reflection assertions.