### PR TITLE
Fix the '-proc:full' flag to use the correct value.

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
@@ -32,7 +32,9 @@ public enum CompilationMode {
   /**
    * Run compilation and run the annotation processors, if configured.
    *
-   * <p>This is usually the default mode.
+   * <p>Prior to Java 21, this is the default if no {@code -proc} flag is provided to the compiler.
+   *
+   * <p>From Java 21 and onwards, this is equivalent to passing {@code -proc:full} to the compiler.
    */
   COMPILATION_AND_ANNOTATION_PROCESSING,
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
@@ -45,7 +45,7 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
   private static final String ANNOTATION_OPT = "-A";
   private static final String PROC_NONE = "-proc:none";
   private static final String PROC_ONLY = "-proc:only";
-  private static final String PROC_ALL = "-proc:all";
+  private static final String PROC_FULL = "-proc:full";
   private static final String DEBUG_LINES = "-g:lines";
   private static final String DEBUG_VARS = "-g:vars";
   private static final String DEBUG_SOURCE = "-g:source";
@@ -95,7 +95,7 @@ public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
       default:
         // In Java 22, the default is to disable all annotation processing by default.
         // Prior to Java 22, the default was to enable all annotation processing by default.
-        craftedFlags.add(PROC_ALL);
+        craftedFlags.add(PROC_FULL);
         break;
     }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JavacJctFlagBuilderImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/compilers/impl/JavacJctFlagBuilderImplTest.java
@@ -210,14 +210,14 @@ class JavacJctFlagBuilderImplTest {
       assertThat(flagBuilder.build()).containsExactly("-proc:only");
     }
 
-    @DisplayName(".compilationMode(COMPILATION_AND_ANNOTATION_PROCESSING) adds -proc:all")
+    @DisplayName(".compilationMode(COMPILATION_AND_ANNOTATION_PROCESSING) adds -proc:full")
     @Test
     void compilationAndAnnotationProcessingAddsProcAll() {
       // When
       flagBuilder.compilationMode(CompilationMode.COMPILATION_AND_ANNOTATION_PROCESSING);
 
       // Then
-      assertThat(flagBuilder.build()).containsExactly("-proc:all");
+      assertThat(flagBuilder.build()).containsExactly("-proc:full");
     }
 
     @DisplayName(".compilationMode(...) returns the flag builder")


### PR DESCRIPTION
### Summary

Fix the '-proc:full' flag to use the correct value. It currently uses `-proc:all` which isn't valid according to the OpenJDK Javac manpage.