### PR TITLE
Improve accuracy of module discovery 

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImpl.java
@@ -23,7 +23,6 @@ import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.utils.ModuleDiscoverer;
 import io.github.ascopes.jct.workspaces.PathRoot;
-import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
@@ -350,20 +349,17 @@ public final class ContainerGroupRepositoryImpl implements AutoCloseable {
   }
 
   private void addModuleRoot(Location location, PathRoot pathRoot) {
-    // Attempt to find the modules in the location.
     var modules = ModuleDiscoverer.findModulesIn(pathRoot.getPath());
 
     if (modules.isEmpty()) {
-      LOGGER.warn(
-          "There were no valid modules present in {}, so nothing has been registered.",
-          pathRoot.getPath()
-      );
-    } else {
-      var moduleGroup = getOrCreateModuleContainerGroup(location);
+      LOGGER.debug("Not adding module root {} as no modules were found inside it", location);
+      return;
+    }
 
-      modules.forEach((moduleName, modulePath) -> {
-        moduleGroup.addModule(moduleName, new WrappingDirectoryImpl(modulePath));
-      });
+    var group = getOrCreateModuleContainerGroup(location);
+
+    for (var module : modules) {
+      group.addModule(module.getName(), module.createPathRoot());
     }
   }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/containers/impl/ContainerGroupRepositoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/containers/impl/ContainerGroupRepositoryImplTest.java
@@ -21,6 +21,7 @@ import static java.util.stream.Collectors.toMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 
 import io.github.ascopes.jct.containers.Container;
@@ -28,9 +29,12 @@ import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.containers.impl.ContainerGroupRepositoryImpl;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.utils.ModuleDiscoverer;
+import io.github.ascopes.jct.utils.ModuleDiscoverer.ModuleCandidate;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.AfterEach;
@@ -174,7 +178,7 @@ class ContainerGroupRepositoryImplTest {
         PathRoot pathRoot = somePathRoot();
 
         moduleDiscoverer.when(() -> ModuleDiscoverer.findModulesIn(any()))
-            .thenReturn(Map.of());
+            .thenReturn(Set.of());
 
         // When
         repository.addPath(location, pathRoot);
@@ -197,13 +201,15 @@ class ContainerGroupRepositoryImplTest {
       // Given
       try (var moduleDiscoverer = mockStatic(ModuleDiscoverer.class)) {
         var location = StandardLocation.MODULE_SOURCE_PATH;
-        PathRoot pathRoot = somePathRoot();
+        var pathRoot = somePathRoot();
 
         var discoveredModules = Stream.of("foo.bar", "baz.bork")
-            .collect(toMap(
-                Function.identity(),
-                pathRoot.getPath()::resolve
-            ));
+            .map(name -> new ModuleCandidate(
+                name,
+                pathRoot.getPath().resolve(name),
+                mock("some descriptor")
+            ))
+            .collect(Collectors.toSet());
 
         moduleDiscoverer.when(() -> ModuleDiscoverer.findModulesIn(any()))
             .thenReturn(discoveredModules);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurerTest.java
@@ -17,25 +17,27 @@ package io.github.ascopes.jct.tests.unit.filemanagers.config;
 
 import static io.github.ascopes.jct.tests.helpers.Fixtures.somePath;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.filemanagers.config.JctFileManagerJvmClassPathModuleConfigurer;
 import io.github.ascopes.jct.filemanagers.impl.JctFileManagerImpl;
+import io.github.ascopes.jct.utils.ModuleDiscoverer;
+import io.github.ascopes.jct.utils.ModuleDiscoverer.ModuleCandidate;
 import io.github.ascopes.jct.utils.SpecialLocationUtils;
-import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
 import java.util.List;
+import java.util.Set;
 import javax.tools.StandardLocation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mock.Strictness;
@@ -65,30 +67,48 @@ class JctFileManagerJvmClassPathModuleConfigurerTest {
   @Test
   void configureAddsTheClassPathToTheFileManagerModulePath() {
     // Given
-    try (var specialLocationUtilsStatic = mockStatic(SpecialLocationUtils.class)) {
-      var paths = List.of(
-          somePath(),
-          somePath(),
-          somePath(),
-          somePath(),
-          somePath()
-      );
+    try (
+        var specialLocationUtilsStatic = mockStatic(SpecialLocationUtils.class);
+        var moduleDiscovererStatic = mockStatic(ModuleDiscoverer.class)
+    ) {
+
+      var path1 = somePath();
+      var modulePath1a = somePath();
+      var module1a = new ModuleCandidate("module1a", modulePath1a, mock());
+      var modulePath1b = somePath();
+      var module1b = new ModuleCandidate("module1b", modulePath1b, mock());
+
+      var path2 = somePath();
+
+      var path3 = somePath();
+      var modulePath3a = somePath();
+      var module3a = new ModuleCandidate("module3a", modulePath3a, mock());
+      var modulePath3b = somePath();
+      var module3b = new ModuleCandidate("module3b", modulePath3b, mock());
+      var modulePath3c = somePath();
+      var module3c = new ModuleCandidate("module3c", modulePath3c, mock());
+
+      var path4 = somePath();
 
       specialLocationUtilsStatic.when(SpecialLocationUtils::currentClassPathLocations)
-          .thenReturn(paths);
+          .thenReturn(List.of(path1, path2, path3, path4));
+      moduleDiscovererStatic.when(() -> ModuleDiscoverer.findModulesIn(any()))
+          .thenReturn(Set.of());
+      moduleDiscovererStatic.when(() -> ModuleDiscoverer.findModulesIn(path1))
+          .thenReturn(Set.of(module1a, module1b));
+      moduleDiscovererStatic.when(() -> ModuleDiscoverer.findModulesIn(path3))
+          .thenReturn(Set.of(module3a, module3b, module3c));
 
       // When
       configurer.configure(fileManager);
 
       // Then
-      var captor = ArgumentCaptor.forClass(WrappingDirectoryImpl.class);
-
-      verify(fileManager, times(paths.size()))
-          .addPath(eq(StandardLocation.MODULE_PATH), captor.capture());
-
-      assertThat(captor.getAllValues())
-          .map(WrappingDirectoryImpl::getPath)
-          .containsExactlyElementsOf(paths);
+      verify(fileManager).addPath(StandardLocation.MODULE_PATH, module1a.createPathRoot());
+      verify(fileManager).addPath(StandardLocation.MODULE_PATH, module1b.createPathRoot());
+      verify(fileManager).addPath(StandardLocation.MODULE_PATH, module3a.createPathRoot());
+      verify(fileManager).addPath(StandardLocation.MODULE_PATH, module3b.createPathRoot());
+      verify(fileManager).addPath(StandardLocation.MODULE_PATH, module3c.createPathRoot());
+      verifyNoMoreInteractions(fileManager);
     }
   }
 


### PR DESCRIPTION
Fix an internal logic issue that caused warnings to appear for each build when an empty module path was provided (e.g. from surefire/failsafe target roots).

This also has the side effect of improving the accuracy of internal module-keeping logic slightly.