### PR TITLE
Implement a new AbstractListAssert implementation that replaces FactoryBasedNavigableListAssert

### DIFF
--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>io.github.ascopes.jct</groupId>
     <artifactId>java-compiler-testing-parent</artifactId>
-    <version>3.0.6-SNAPSHOT</version>
+    <version>3.1.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
@@ -21,18 +21,13 @@ import static java.util.stream.Collectors.toUnmodifiableList;
 import io.github.ascopes.jct.compilers.JctCompilation;
 import io.github.ascopes.jct.containers.ContainerGroup;
 import io.github.ascopes.jct.repr.TraceDiagnosticListRepresentation;
-import io.github.ascopes.jct.utils.StringUtils;
 import java.util.Collection;
-import java.util.List;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.StandardLocation;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractListAssert;
-import org.assertj.core.api.AbstractStringAssert;
-import org.assertj.core.api.FactoryBasedNavigableListAssert;
 import org.assertj.core.api.StringAssert;
 import org.jspecify.annotations.Nullable;
 
@@ -43,8 +38,8 @@ import org.jspecify.annotations.Nullable;
  * @since 0.0.1
  */
 @API(since = "0.0.1", status = Status.STABLE)
-public final class JctCompilationAssert extends
-    AbstractAssert<JctCompilationAssert, JctCompilation> {
+public final class JctCompilationAssert
+    extends AbstractAssert<JctCompilationAssert, JctCompilation> {
 
   /**
    * Initialize this compilation assertion.
@@ -62,15 +57,12 @@ public final class JctCompilationAssert extends
    * @return a list assertion object to perform assertions on the arguments with.
    * @throws AssertionError if the compilation was null.
    */
-  @SuppressWarnings("deprecation")  // No alternative present at the moment
-  public AbstractListAssert<?, List<? extends String>, String, ? extends AbstractStringAssert<?>> arguments() {
+  public TypeAwareListAssert<String, StringAssert> arguments() {
     isNotNull();
 
     var arguments = actual.getArguments();
 
-    return FactoryBasedNavigableListAssert
-        .assertThat(arguments, StringAssert::new)
-        .as("Compiler arguments %s", StringUtils.quotedIterable(arguments));
+    return new TypeAwareListAssert<>(arguments, StringAssert::new);
   }
 
   /**
@@ -353,7 +345,6 @@ public final class JctCompilationAssert extends
   public ModuleContainerGroupAssert modulePathModules() {
     return moduleGroup(StandardLocation.MODULE_PATH);
   }
-
 
   private AssertionError failWithDiagnostics(
       Collection<? extends Kind> kindsToDisplay,

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TypeAwareListAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TypeAwareListAssert.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2022 - 2024, the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.ascopes.jct.assertions;
+
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.StreamSupport;
+import org.apiguardian.api.API;
+import org.apiguardian.api.API.Status;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.AssertFactory;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * An implementation of {@link AbstractListAssert} that can perform type-specific assertions on the
+ * members of the container being asserted upon.
+ *
+ * <p>This acts as a bridge with AssertJ now that
+ * {@link org.assertj.core.api.FactoryBasedNavigableListAssert} has been deprecated. Users should
+ * treat this object like any other kind of {@link AbstractListAssert} for all purposes.
+ *
+ * @author Ashley Scopes
+ * @since 3.1.0
+ */
+@API(since = "3.1.0", status = Status.STABLE)
+public final class TypeAwareListAssert<E, A extends AbstractAssert<A, @Nullable E>>
+    extends AbstractListAssert<TypeAwareListAssert<@Nullable E, A>, @Nullable List<? extends @Nullable E>, @Nullable E, A> {
+
+  private final AssertFactory<@Nullable E, A> assertFactory;
+
+  TypeAwareListAssert(@Nullable List<? extends E> list, AssertFactory<E, A> assertFactory) {
+    super(list, TypeAwareListAssert.class);
+    this.assertFactory = assertFactory;
+  }
+
+  @Override
+  protected A toAssert(@Nullable E value, String description) {
+    return assertFactory.createAssert(value).describedAs(description);
+  }
+
+  @Override
+  protected TypeAwareListAssert<@Nullable E, A> newAbstractIterableAssert(
+      Iterable<? extends @Nullable E> iterable
+  ) {
+    return StreamSupport
+        .stream(iterable.spliterator(), false)
+        .collect(collectingAndThen(toList(), curry()));
+  }
+
+  private Function<@Nullable List<@Nullable E>, TypeAwareListAssert<@Nullable E, A>> curry() {
+    return list -> new TypeAwareListAssert<>(list, assertFactory);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>io.github.ascopes.jct</groupId>
   <artifactId>java-compiler-testing-parent</artifactId>
-  <version>3.0.6-SNAPSHOT</version>
+  <version>3.1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>Java Compiler Testing parent project</name>


### PR DESCRIPTION
This removes the need for FactoryBasedNavigableListAssert which is now deprecated for the purposes we were using it with.
