### PR TITLE
Fix Java 23 compatibility with Error Prone

### DIFF
--- a/java-compiler-testing/src/it/google-error-prone/pom.xml
+++ b/java-compiler-testing/src/it/google-error-prone/pom.xml
@@ -50,7 +50,7 @@
       -DmvnArgLinePropagated=true
     </argLine>
 
-    <error-prone.version>2.27.1</error-prone.version>
+    <error-prone.version>2.28.0</error-prone.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
A regression was created in the JDK 23 EA sources which breaks ErrorProne (see https://github.com/google/error-prone/issues/4415). 

Updating to 2.28.0 should fix this issue.