### PR TITLE
GH-721: Add overloads for workspaces APIs to support list types.

### DIFF
--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
@@ -28,6 +28,7 @@ import io.github.ascopes.jct.workspaces.PathRoot;
 import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
 import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.tools.JavaFileManager.Location;
@@ -186,7 +187,7 @@ public final class OutputContainerGroupImpl
     var group = new AbstractPackageContainerGroup(moduleLocation, release) {};
     var pathWrapper = new WrappingDirectoryImpl(
         getPackages().iterator().next().getPathRoot(),
-        moduleLocation.getModuleName()
+        List.of(moduleLocation.getModuleName())
     );
     uncheckedIo(() -> Files.createDirectories(pathWrapper.getPath()));
     group.addPackage(pathWrapper);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
@@ -95,7 +95,7 @@ public final class FileUtils extends UtilityClass {
    * @param parts the parts to resolve.
    * @return the resolved path.
    */
-  public static Path resolvePathRecursively(Path root, String... parts) {
+  public static Path resolvePathRecursively(Path root, List<String> parts) {
     return resolve(root, parts);
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/DirectoryBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/DirectoryBuilder.java
@@ -18,6 +18,7 @@ package io.github.ascopes.jct.workspaces;
 import java.io.File;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
+import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -30,6 +31,38 @@ import org.apiguardian.api.API.Status;
 @SuppressWarnings("unused")
 @API(since = "0.0.1", status = Status.STABLE)
 public interface DirectoryBuilder {
+
+  /**
+   * Copy the contents of the directory at the given path recursively into this directory.
+   *
+   * <p>Symbolic links will not be followed.
+   *
+   * <p>This uses the default file system. If you want to use a different {@link FileSystem}
+   * as your source, then use {@link #copyContentsFrom(Path)} instead.
+   *
+   * <p>Examples:
+   *
+   * <pre><code>
+   *   // Letting JCT infer the correct path separators to use (recommended).
+   *   directoryBuilder.copyContentsFrom(List.of("foo", "bar", "baz"));
+   *
+   *   // Using POSIX platform-specific separators (may cause issues if your tests run on Windows)
+   *   directoryBuilder.copyContentsFrom(List.of("foo/bar/baz"));
+   *
+   *   // Using Windows platform-specific separators (may cause issues if your tests run on POSIX)
+   *   directoryBuilder.copyContentsFrom(List.of("foo\\bar\\baz"));
+   * </code></pre>
+   *
+   * @param fragments parts of the path.
+   * @return the root managed directory for further configuration.
+   * @throws IllegalArgumentException if no path fragments are provided.
+   * @throws NullPointerException     if any null path fragments are provided.
+   * @see #copyContentsFrom(Path)
+   * @see #copyContentsFrom(String...)
+   * @since 4.0.0
+   */
+  @API(since = "4.0.0", status = Status.STABLE)
+  ManagedDirectory copyContentsFrom(List<String> fragments);
 
   /**
    * Copy the contents of the directory at the given path recursively into this directory.
@@ -57,8 +90,11 @@ public interface DirectoryBuilder {
    * @throws IllegalArgumentException if no path fragments are provided.
    * @throws NullPointerException     if any null path fragments are provided.
    * @see #copyContentsFrom(Path)
+   * @see #copyContentsFrom(List)
    */
-  ManagedDirectory copyContentsFrom(String... fragments);
+  default ManagedDirectory copyContentsFrom(String... fragments) {
+    return copyContentsFrom(List.of(fragments));
+  }
 
   /**
    * Copy the contents of the directory at the given path recursively into this directory.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/FileBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/FileBuilder.java
@@ -18,8 +18,10 @@ package io.github.ascopes.jct.workspaces;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
+import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -176,7 +178,6 @@ public interface FileBuilder {
    */
   ManagedDirectory thatIsEmpty();
 
-
   /**
    * Create the file with the given byte contents.
    *
@@ -211,8 +212,52 @@ public interface FileBuilder {
    *
    * @param contents the bytes to write.
    * @return the root managed directory for further configuration.
+   * @see #withContents(ByteBuffer)
    */
   ManagedDirectory withContents(byte[] contents);
+
+  /**
+   * An overload of {@link #withContents(byte[])} that consumes a NIO byte buffer.
+   *
+   * @param buffer the byte buffer to consume.
+   * @return the managed directory.
+   * @since 4.0.0
+   */
+  @API(since = "4.0.0", status = Status.STABLE)
+  default ManagedDirectory withContents(ByteBuffer buffer) {
+    var array = new byte[buffer.remaining()];
+    buffer.get(array);
+    return withContents(array);
+  }
+
+  /**
+   * Create the file with the given contents.
+   *
+   * <pre><code>
+   *   directory
+   *      .createFile("org", "example", "HelloWorld.java")
+   *      .withContents(StandardCharsets.US_ASCII, List.of(
+   *        "package org.example;",
+   *        "",
+   *        "public class HelloWorld {",
+   *        "  public static void main(String[] args) {",
+   *        "    System.out.println(\"Hello, World!\");",
+   *        "  }",
+   *        "}"
+   *      ));
+   * </code></pre>
+   *
+   * @param charset the character encoding to use.
+   * @param lines   the lines to write.
+   * @return the root managed directory for further configuration.
+   * @see #withContents(Charset, String...)
+   * @see #withContents(String...)
+   * @see #withContents(List)
+   * @see #withContents(byte[])
+   * @since 4.0.0
+   */
+  @API(since = "4.0.0", status = Status.STABLE)
+  ManagedDirectory withContents(Charset charset, List<String> lines);
 
   /**
    * Create the file with the given contents.
@@ -253,10 +298,44 @@ public interface FileBuilder {
    * @param charset the character encoding to use.
    * @param lines   the lines to write.
    * @return the root managed directory for further configuration.
+   * @see #withContents(List)
+   * @see #withContents(Charset, List)
    * @see #withContents(String...)
    * @see #withContents(byte[])
    */
-  ManagedDirectory withContents(Charset charset, String... lines);
+  default ManagedDirectory withContents(Charset charset, String... lines) {
+    return withContents(charset, List.of(lines));
+  }
+
+  /**
+   * Create the file with the given contents as UTF-8.
+   *
+   * <p>If you are using multi-line strings, an example of usage would be:
+   *
+   * <pre><code>
+   *   directory
+   *      .createFile("org", "example", "HelloWorld.java")
+   *      .withContents(List.of(
+   *        "package org.example;",
+   *        "",
+   *        "public class HelloWorld {",
+   *        "  public static void main(String[] args) {",
+   *        "    System.out.println(\"Hello, World!\");",
+   *        "  }",
+   *        "}"
+   *      ));
+   * </code></pre>
+   *
+   * @param lines the lines to write using the default charset.
+   * @return the root managed directory for further configuration.
+   * @see #withContents(Charset, String...)
+   * @see #withContents(String...)
+   * @see #withContents(Charset, List)
+   * @see #withContents(byte[])
+   * @since 4.0.0
+   */
+  @API(since = "4.0.0", status = Status.STABLE)
+  ManagedDirectory withContents(List<String> lines);
 
   /**
    * Create the file with the given contents as UTF-8.
@@ -298,7 +377,11 @@ public interface FileBuilder {
    * @param lines the lines to write using the default charset.
    * @return the root managed directory for further configuration.
    * @see #withContents(Charset, String...)
+   * @see #withContents(List)
+   * @see #withContents(Charset, List)
    * @see #withContents(byte[])
    */
-  ManagedDirectory withContents(String... lines);
+  default ManagedDirectory withContents(String... lines) {
+    return withContents(List.of(lines));
+  }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/ManagedDirectory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/ManagedDirectory.java
@@ -17,6 +17,7 @@ package io.github.ascopes.jct.workspaces;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 
@@ -101,7 +102,31 @@ public interface ManagedDirectory extends DirectoryBuilder, PathRoot {
    * @throws IllegalArgumentException if no path fragments are provided.
    * @throws NullPointerException     if any of the path fragments are {@code null}.
    */
-  DirectoryBuilder createDirectory(String... fragments);
+  default DirectoryBuilder createDirectory(String... fragments) {
+    return createDirectory(List.of(fragments));
+  }
+
+  /**
+   * Create a directory builder for the given path in this RAM file system.
+   *
+   * <p>Examples:
+   *
+   * <pre><code>
+   *   // Using platform-specific separators.
+   *   dir.createDirectory(List.of("foo/bar/baz"))...;
+   *
+   *   // Letting JCT infer the correct path separators to use (recommended).
+   *   dir.createDirectory(List.of("foo", "bar", "baz"))...;
+   * </code></pre>
+   *
+   * @param fragments the parts of the path.
+   * @return the directory builder.
+   * @throws IllegalArgumentException if no path fragments are provided.
+   * @throws NullPointerException     if any of the path fragments are {@code null}.
+   * @since 4.0.0
+   */
+  @API(since = "4.0.0", status = Status.STABLE)
+  DirectoryBuilder createDirectory(List<String> fragments);
 
   /**
    * Create a file builder for the given path in this RAM file system.
@@ -119,7 +144,29 @@ public interface ManagedDirectory extends DirectoryBuilder, PathRoot {
    * @throws IllegalArgumentException if no path fragments are provided.
    * @throws NullPointerException     if any of the path fragments are {@code null}.
    */
-  FileBuilder createFile(String... fragments);
+  default FileBuilder createFile(String... fragments) {
+    return createFile(List.of(fragments));
+  }
+
+  /**
+   * Create a file builder for the given path in this RAM file system.
+   *
+   * <pre><code>
+   *   // Using platform-specific separators.
+   *   dir.createFile(List.of("foo/bar/baz.txt"))...;
+   *
+   *   // Letting JCT infer the correct path separators to use (recommended).
+   *   dir.createFile(List.of("foo", "bar", "baz.txt"))...;
+   * </code></pre>
+   *
+   * @param fragments the parts of the path.
+   * @return the file builder.
+   * @throws IllegalArgumentException if no path fragments are provided.
+   * @throws NullPointerException     if any of the path fragments are {@code null}.
+   * @since 4.0.0
+   */
+  @API(since = "4.0.0", status = Status.STABLE)
+  FileBuilder createFile(List<String> fragments);
 
   /**
    * Get the identifying name of the temporary file system.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
@@ -880,7 +880,7 @@ public interface Workspace extends AutoCloseable {
    * @since 3.2.0
    */
   @API(since = "3.2.0", status = Status.STABLE)
-  public interface ThrowingWorkspaceConsumer<T extends Throwable> {
+  interface ThrowingWorkspaceConsumer<T extends Throwable> {
 
     /**
      * Consume a workspace.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/AbstractManagedDirectory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/AbstractManagedDirectory.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
@@ -112,21 +113,21 @@ public abstract class AbstractManagedDirectory implements ManagedDirectory {
   }
 
   @Override
-  public FileBuilder createFile(String... fragments) {
+  public FileBuilder createFile(List<String> fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");
     return new FileBuilderImpl(this, fragments);
   }
 
   @Override
-  public DirectoryBuilder createDirectory(String... fragments) {
+  public DirectoryBuilder createDirectory(List<String> fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");
     return new DirectoryBuilderImpl(this, fragments);
   }
 
   @Override
-  public ManagedDirectory copyContentsFrom(String... fragments) {
+  public ManagedDirectory copyContentsFrom(List<String> fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");
     return rootDirectory().copyContentsFrom(fragments);
@@ -167,6 +168,6 @@ public abstract class AbstractManagedDirectory implements ManagedDirectory {
   }
 
   private DirectoryBuilder rootDirectory() {
-    return new DirectoryBuilderImpl(this, "");
+    return new DirectoryBuilderImpl(this, List.of(""));
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/DirectoryBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/DirectoryBuilderImpl.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
 import java.util.StringJoiner;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -55,7 +56,7 @@ public final class DirectoryBuilderImpl implements DirectoryBuilder {
    * @param parent    the parent managed directory to chain calls back onto.
    * @param fragments parts of the directory path.
    */
-  public DirectoryBuilderImpl(ManagedDirectory parent, String... fragments) {
+  public DirectoryBuilderImpl(ManagedDirectory parent, List<String> fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");
 
@@ -64,14 +65,15 @@ public final class DirectoryBuilderImpl implements DirectoryBuilder {
   }
 
   @Override
-  public ManagedDirectory copyContentsFrom(String... fragments) {
+  public ManagedDirectory copyContentsFrom(List<String> fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");
 
     // Path.of is fine here as it is for the default file system.
-    var path = Path.of(fragments[0]);
-    for (var i = 1; i < fragments.length; ++i) {
-      path = path.resolve(fragments[i]);
+    var iter = fragments.iterator();
+    var path = Path.of(iter.next());
+    while (iter.hasNext()) {
+      path = path.resolve(iter.next());
     }
 
     return copyContentsFrom(path);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
@@ -36,6 +36,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.List;
 import java.util.Locale;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
@@ -64,7 +65,7 @@ public final class FileBuilderImpl implements FileBuilder {
    * @param parent the parent managed directory to chain calls back onto.
    * @param fragments the parts of the file path.
    */
-  public FileBuilderImpl(ManagedDirectory parent, String... fragments) {
+  public FileBuilderImpl(ManagedDirectory parent, List<String> fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");
 
@@ -136,12 +137,12 @@ public final class FileBuilderImpl implements FileBuilder {
   }
 
   @Override
-  public ManagedDirectory withContents(Charset charset, String... lines) {
+  public ManagedDirectory withContents(Charset charset, List<String> lines) {
     return withContents(String.join("\n", lines).getBytes(charset));
   }
 
   @Override
-  public ManagedDirectory withContents(String... lines) {
+  public ManagedDirectory withContents(List<String> lines) {
     return withContents(DEFAULT_CHARSET, lines);
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
@@ -39,8 +39,7 @@ public final class MemoryFileSystemProvider {
   // We could initialise this lazily, but this class has fewer fields and initialisation
   // overhead than a lazy-loaded object would, so it doesn't really make sense to do it
   // here.
-  private static final MemoryFileSystemProvider INSTANCE
-      = new MemoryFileSystemProvider();
+  private static final MemoryFileSystemProvider INSTANCE = new MemoryFileSystemProvider();
 
   /**
    * Get the singleton instance of this provider.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImpl.java
@@ -27,6 +27,7 @@ import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
+import java.util.List;
 import org.apiguardian.api.API;
 import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
@@ -72,7 +73,7 @@ public final class WrappingDirectoryImpl implements PathRoot {
    *                                  protocol handler is registered for the associated
    *                                  {@link java.nio.file.FileSystem} providing the path).
    */
-  public WrappingDirectoryImpl(PathRoot parent, String... parts) {
+  public WrappingDirectoryImpl(PathRoot parent, List<String> parts) {
     this(
         requireNonNull(parent, "parent"),
         resolvePathRecursively(parent.getPath(), requireNonNullValues(parts, "parts"))

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/utils/FileUtilsTest.java
@@ -47,6 +47,7 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 import javax.tools.JavaFileObject.Kind;
@@ -116,7 +117,7 @@ class FileUtilsTest implements UtilityClassTestTemplate {
       "foo/bar/baz, bork/../../qux/./.././quxx, foo/bar/quxx",
   })
   @ParameterizedTest(
-      name = "resolvePathRecursively(\"{0}\", \"{1}\".split(\"/\")) should return \"{2}\""
+      name = "resolvePathRecursively(\"{0}\", List.of(\"{1}\".split(\"/\"))) should return \"{2}\""
   )
   void resolvePathRecursivelyResolvesThePathRecursively(
       String rootString,
@@ -127,7 +128,7 @@ class FileUtilsTest implements UtilityClassTestTemplate {
     try (var fs = someTemporaryFileSystem()) {
       var root = fs.getFileSystem().getPath(rootString);
       var expect = fs.getFileSystem().getPath(expectString);
-      var parts = partsString.split(fs.getFileSystem().getSeparator());
+      var parts = List.of(partsString.split(fs.getFileSystem().getSeparator()));
 
       // Then
       assertThat(resolvePathRecursively(root, parts))

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/WrappingDirectoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/tests/unit/workspaces/impl/WrappingDirectoryImplTest.java
@@ -27,6 +27,8 @@ import static org.mockito.Mockito.when;
 import io.github.ascopes.jct.utils.FileUtils;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -50,6 +52,7 @@ class WrappingDirectoryImplTest {
   class ConstructorTest {
 
     @DisplayName("Initialising without a parent configures the object correctly")
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void initialisingWithoutParentConfiguresTheObjectCorrectly() {
       // Given
@@ -76,13 +79,14 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Initialising with a parent configures the object correctly")
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void initialisingWithParentConfiguresTheObjectCorrectly() {
       // Given
       var parent = mock(PathRoot.class);
       var rootPath = somePath();
       when(parent.getPath()).thenReturn(rootPath);
-      var parts = new String[]{"foo", "bar", "baz"};
+      var parts = List.of("foo", "bar", "baz");
       var expectedPath = FileUtils.resolvePathRecursively(rootPath, parts);
 
       // When
@@ -106,6 +110,7 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Null paths are disallowed for parentless instances")
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void nullPathsAreDisallowedForParentlessInstances() {
       // Then
@@ -115,28 +120,34 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Null parents are disallowed for instances with parents")
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void nullParentsAreDisallowedForInstancesWithParents() {
       // Then
-      assertThatThrownBy(() -> new WrappingDirectoryImpl(null, "xxx"))
+      assertThatThrownBy(() -> new WrappingDirectoryImpl(null, List.of("xxx")))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("parent");
     }
 
-    @DisplayName("Null parts arrays are disallowed for instances with parents")
+    @DisplayName("Null parts lists are disallowed for instances with parents")
+    @SuppressWarnings("DataFlowIssue")
     @Test
-    void nullPartsArraysAreDisallowedForInstancesWithParents() {
+    void nullPartsListsAreDisallowedForInstancesWithParents() {
       // Then
-      assertThatThrownBy(() -> new WrappingDirectoryImpl(mock(PathRoot.class), (String[]) null))
+      assertThatThrownBy(() -> new WrappingDirectoryImpl(mock(PathRoot.class), null))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("parts");
     }
 
     @DisplayName("Null parts are disallowed for instances with parents")
+    @SuppressWarnings("DataFlowIssue")
     @Test
     void nullPartsAreDisallowedForInstancesWithParents() {
       // Then
-      assertThatThrownBy(() -> new WrappingDirectoryImpl(mock(PathRoot.class), (String) null))
+      var list = new ArrayList<String>();
+      list.add(null);
+
+      assertThatThrownBy(() -> new WrappingDirectoryImpl(mock(PathRoot.class), list))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("parts[0]");
     }
@@ -182,6 +193,7 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("objects equal themselves")
+    @SuppressWarnings("EqualsWithItself")  // Intentional, duh!
     @Test
     void equalThemselves() {
       // Then
@@ -220,7 +232,7 @@ class WrappingDirectoryImplTest {
     var parent = mock(PathRoot.class, "some path root parent");
     when(parent.getPath()).thenReturn(somePath());
 
-    var parentCase = new WrappingDirectoryImpl(parent, "foo", "bar", "baz");
+    var parentCase = new WrappingDirectoryImpl(parent, List.of("foo", "bar", "baz"));
     var parentExpected = String.format(
         "WrappingDirectoryImpl{parent=some path root parent, uri=\"%s\"}",
         parentCase.getUri()


### PR DESCRIPTION
Add overloads for workspaces APIs to support list types.

All varargs methods now are accompanied by an overload that consumes a `java.util.List`.

The previous varargs overloads are now handled as default methods in most cases, so this is a breaking API change to be bundled with v4.0.0.

Fixes GH-721.