### PR TITLE
Delete API guardian from the library.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 out/
 target/
+*.javaimport
 
 # Maven invoker plugin
 **/interpolated-pom.xml

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -49,12 +49,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apiguardian</groupId>
-      <artifactId>apiguardian-api</artifactId>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
     </dependency>

--- a/java-compiler-testing/src/it/dogfood/pom.xml
+++ b/java-compiler-testing/src/it/dogfood/pom.xml
@@ -75,11 +75,6 @@
     </dependency>
     
     <dependency>
-      <groupId>org.apiguardian</groupId>
-      <artifactId>apiguardian-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.jspecify</groupId>
       <artifactId>jspecify</artifactId>
     </dependency>

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssert.java
@@ -21,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.github.ascopes.jct.containers.ContainerGroup;
 import java.util.ArrayList;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.ObjectAssert;
@@ -36,7 +34,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public abstract class AbstractContainerGroupAssert<I extends AbstractContainerGroupAssert<I, C>, C extends ContainerGroup>
     extends AbstractAssert<I, C> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractEnumAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractEnumAssert.java
@@ -21,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.Nullable;
 
@@ -34,7 +32,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public abstract class AbstractEnumAssert<A extends AbstractEnumAssert<A, E>, E extends Enum<E>>
     extends AbstractAssert<A, E> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractJavaFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractJavaFileObjectAssert.java
@@ -27,8 +27,6 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractByteArrayAssert;
 import org.assertj.core.api.AbstractInstantAssert;
@@ -44,7 +42,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public abstract class AbstractJavaFileObjectAssert<I extends AbstractJavaFileObjectAssert<I, A>, A extends JavaFileObject>
     extends AbstractAssert<I, A> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ClassLoaderAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ClassLoaderAssert.java
@@ -15,8 +15,6 @@
  */
 package io.github.ascopes.jct.assertions;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.jspecify.annotations.Nullable;
 
@@ -29,7 +27,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class ClassLoaderAssert extends AbstractAssert<ClassLoaderAssert, ClassLoader> {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/DiagnosticKindAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/DiagnosticKindAssert.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.assertions;
 import java.util.EnumSet;
 import java.util.Set;
 import javax.tools.Diagnostic.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -28,7 +26,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class DiagnosticKindAssert
     extends AbstractEnumAssert<DiagnosticKindAssert, Kind> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectAssert.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.assertions;
 
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +24,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JavaFileObjectAssert
     extends AbstractJavaFileObjectAssert<JavaFileObjectAssert, JavaFileObject> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectKindAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JavaFileObjectKindAssert.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractStringAssert;
 import org.jspecify.annotations.Nullable;
 
@@ -29,7 +27,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JavaFileObjectKindAssert
     extends AbstractEnumAssert<JavaFileObjectKindAssert, Kind> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctAssertions.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctAssertions.java
@@ -26,8 +26,6 @@ import java.util.List;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -36,7 +34,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @SuppressWarnings("unused")
 public final class JctAssertions extends UtilityClass {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/JctCompilationAssert.java
@@ -25,8 +25,6 @@ import java.util.Collection;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.StringAssert;
 import org.jspecify.annotations.Nullable;
@@ -37,7 +35,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctCompilationAssert
     extends AbstractAssert<JctCompilationAssert, JctCompilation> {
 
@@ -249,8 +246,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the class package outputs.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert classOutputPackages() {
     return outputGroup(StandardLocation.CLASS_OUTPUT).packages();
   }
@@ -262,8 +259,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the class module outputs.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert classOutputModules() {
     return outputGroup(StandardLocation.CLASS_OUTPUT).modules();
   }
@@ -275,8 +272,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the source package outputs.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert sourceOutputPackages() {
     return outputGroup(StandardLocation.SOURCE_OUTPUT).packages();
   }
@@ -288,8 +285,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the source module outputs.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert sourceOutputModules() {
     return outputGroup(StandardLocation.SOURCE_OUTPUT).modules();
   }
@@ -301,8 +298,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the class path.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert classPathPackages() {
     return packageGroup(StandardLocation.CLASS_PATH);
   }
@@ -314,8 +311,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the source path.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public PackageContainerGroupAssert sourcePathPackages() {
     return packageGroup(StandardLocation.SOURCE_PATH);
   }
@@ -327,8 +324,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the source path.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert moduleSourcePathModules() {
     return moduleGroup(StandardLocation.MODULE_SOURCE_PATH);
   }
@@ -340,8 +337,8 @@ public final class JctCompilationAssert
    *
    * @return the assertions to perform on the module path.
    * @throws AssertionError if the compilation was null, or no group for the location was found.
+   * @since 0.6.4
    */
-  @API(since = "0.6.4", status = Status.STABLE)
   public ModuleContainerGroupAssert modulePathModules() {
     return moduleGroup(StandardLocation.MODULE_PATH);
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/LocationAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/LocationAssert.java
@@ -19,8 +19,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.ascopes.jct.repr.LocationRepresentation;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import org.jspecify.annotations.Nullable;
@@ -31,7 +29,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class LocationAssert extends AbstractAssert<LocationAssert, Location> {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssert.java
@@ -20,8 +20,6 @@ import static java.util.Objects.requireNonNull;
 import io.github.ascopes.jct.containers.ModuleContainerGroup;
 import io.github.ascopes.jct.filemanagers.ModuleLocation;
 import io.github.ascopes.jct.utils.StringUtils;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -30,7 +28,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class ModuleContainerGroupAssert
     extends AbstractContainerGroupAssert<ModuleContainerGroupAssert, ModuleContainerGroup> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/OutputContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/OutputContainerGroupAssert.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.assertions;
 
 import io.github.ascopes.jct.containers.OutputContainerGroup;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +24,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class OutputContainerGroupAssert
     extends AbstractContainerGroupAssert<OutputContainerGroupAssert, OutputContainerGroup> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssert.java
@@ -34,8 +34,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractPathAssert;
 import org.assertj.core.description.TextDescription;
 import org.assertj.core.error.MultipleAssertionsError;
@@ -47,7 +45,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class PackageContainerGroupAssert
     extends AbstractContainerGroupAssert<PackageContainerGroupAssert, PackageContainerGroup> {
 
@@ -185,7 +182,6 @@ public final class PackageContainerGroupAssert
    * @throws NullPointerException     if any of the fragments are null.
    * @throws IllegalArgumentException if no fragments are provided.
    */
-
   public AbstractPathAssert<?> fileExists(String... fragments) {
     requireNonNullValues(fragments, "fragments");
     requireAtLeastOne(fragments, "fragments");

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PathFileObjectAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/PathFileObjectAssert.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.github.ascopes.jct.filemanagers.PathFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractPathAssert;
 import org.jspecify.annotations.Nullable;
 
@@ -29,7 +27,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class PathFileObjectAssert
     extends AbstractJavaFileObjectAssert<PathFileObjectAssert, PathFileObject> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceAssert.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.assertions;
 import io.github.ascopes.jct.repr.StackTraceRepresentation;
 import java.util.ArrayList;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractListAssert;
 import org.jspecify.annotations.Nullable;
 
@@ -32,7 +30,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class StackTraceAssert
     extends AbstractListAssert<StackTraceAssert, List<? extends StackTraceElement>, StackTraceElement, StackTraceElementAssert> {
 
@@ -61,3 +58,4 @@ public final class StackTraceAssert
     return new StackTraceAssert(list);
   }
 }
+

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceElementAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/StackTraceElementAssert.java
@@ -17,8 +17,6 @@ package io.github.ascopes.jct.assertions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
@@ -28,13 +26,9 @@ import org.jspecify.annotations.Nullable;
 /**
  * Assertions to perform on a {@link StackTraceElement stack trace frame}.
  *
- * <p>This type is a placeholder and will be replaced when AssertJ releases changes to
- * support assertions on stack traces.
- *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(status = Status.EXPERIMENTAL)
 public final class StackTraceElementAssert
     extends AbstractAssert<StackTraceElementAssert, StackTraceElement> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticAssert.java
@@ -22,8 +22,6 @@ import io.github.ascopes.jct.diagnostics.TraceDiagnostic;
 import io.github.ascopes.jct.repr.TraceDiagnosticRepresentation;
 import java.util.Locale;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractInstantAssert;
 import org.assertj.core.api.AbstractLongAssert;
@@ -36,7 +34,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class TraceDiagnosticAssert
     extends AbstractAssert<TraceDiagnosticAssert, TraceDiagnostic<? extends JavaFileObject>> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssert.java
@@ -33,21 +33,19 @@ import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
 import javax.tools.Diagnostic.Kind;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractListAssert;
 import org.jspecify.annotations.Nullable;
 
+//@formatter:off
 /**
  * Assertions for a list of diagnostics.
  *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class TraceDiagnosticListAssert
-    extends
-    AbstractListAssert<TraceDiagnosticListAssert, List<? extends TraceDiagnostic<? extends JavaFileObject>>, TraceDiagnostic<? extends JavaFileObject>, TraceDiagnosticAssert> {
+    extends AbstractListAssert<TraceDiagnosticListAssert, List<? extends TraceDiagnostic<? extends JavaFileObject>>, TraceDiagnostic<? extends JavaFileObject>, TraceDiagnosticAssert> {
+  //@formatter:on
 
   /**
    * Initialize this assertion.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TypeAwareListAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/TypeAwareListAssert.java
@@ -21,13 +21,12 @@ import static java.util.stream.Collectors.toList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractListAssert;
 import org.assertj.core.api.AssertFactory;
 import org.jspecify.annotations.Nullable;
 
+//@formatter:off
 /**
  * An implementation of {@link AbstractListAssert} that can perform type-specific assertions on the
  * members of the container being asserted upon.
@@ -41,9 +40,9 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 3.1.0
  */
-@API(since = "3.1.0", status = Status.STABLE)
 public final class TypeAwareListAssert<E, A extends AbstractAssert<A, @Nullable E>>
     extends AbstractListAssert<TypeAwareListAssert<@Nullable E, A>, @Nullable List<? extends @Nullable E>, @Nullable E, A> {
+  //@formatter:on
 
   private final AssertFactory<@Nullable E, A> assertFactory;
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/package-info.java
@@ -16,8 +16,4 @@
 /**
  * AssertJ extensions for testing the results of compilations.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.assertions;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/AbstractJctCompiler.java
@@ -34,8 +34,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Set;
 import javax.annotation.processing.Processor;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -55,7 +53,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public abstract class AbstractJctCompiler implements JctCompiler {
 
   private final List<Processor> annotationProcessors;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/CompilationMode.java
@@ -15,9 +15,6 @@
  */
 package io.github.ascopes.jct.compilers;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * An enum representing the various types of compilation mode that a compiler can run under.
  *
@@ -26,7 +23,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public enum CompilationMode {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/DebuggingInfo.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/DebuggingInfo.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.compilers;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * An enum representing the various types of debugger info that can be included in compilations.
@@ -31,7 +29,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 3.0.0
  */
-@API(since = "3.0.0", status = Status.STABLE)
 public enum DebuggingInfo {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilation.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Set;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -38,15 +36,14 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface JctCompilation {
 
   /**
    * Get the command line arguments that were passed to the compiler.
    *
    * @return the command line arguments.
+   * @since 0.5.0
    */
-  @API(since = "0.5.0", status = Status.STABLE)
   List<String> getArguments();
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilationFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilationFactory.java
@@ -20,8 +20,6 @@ import io.github.ascopes.jct.filemanagers.JctFileManager;
 import java.util.Collection;
 import java.util.List;
 import javax.tools.JavaCompiler;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -31,7 +29,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface JctCompilationFactory {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -30,8 +30,6 @@ import java.util.Locale;
 import java.util.Set;
 import javax.annotation.processing.Processor;
 import javax.lang.model.SourceVersion;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -44,7 +42,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface JctCompiler {
 
   /**
@@ -642,7 +639,6 @@ public interface JctCompiler {
    *                                       compiler does not support integral version numbers.
    * @since 1.1.0
    */
-  @API(since = "1.1.0", status = Status.STABLE)
   default JctCompiler useRuntimeRelease() {
     return release(Runtime.version().feature());
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilerConfigurer.java
@@ -15,9 +15,6 @@
  */
 package io.github.ascopes.jct.compilers;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Function representing a configuration operation that can be applied to a compiler.
  *
@@ -91,7 +88,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @FunctionalInterface
 public interface JctCompilerConfigurer<E extends Exception> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompilers.java
@@ -17,8 +17,6 @@ package io.github.ascopes.jct.compilers;
 
 import io.github.ascopes.jct.compilers.impl.JavacJctCompilerImpl;
 import io.github.ascopes.jct.utils.UtilityClass;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Helpers to create new compiler instances.
@@ -26,7 +24,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctCompilers extends UtilityClass {
 
   private JctCompilers() {
@@ -40,7 +37,6 @@ public final class JctCompilers extends UtilityClass {
    * @return the compiler instance.
    * @since 0.2.0
    */
-  @API(status = Status.STABLE, since = "0.2.0")
   public static JctCompiler newPlatformCompiler() {
     return new JavacJctCompilerImpl();
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilder.java
@@ -17,8 +17,6 @@ package io.github.ascopes.jct.compilers;
 
 import java.util.List;
 import java.util.Set;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +24,6 @@ import org.jspecify.annotations.Nullable;
  *
  * @author Ashley Scopes
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface JctFlagBuilder {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilderFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctFlagBuilderFactory.java
@@ -15,16 +15,12 @@
  */
 package io.github.ascopes.jct.compilers;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Factory that creates a flag builder.
  *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @FunctionalInterface
 public interface JctFlagBuilderFactory {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/Jsr199CompilerFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/Jsr199CompilerFactory.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.compilers;
 
 import javax.tools.JavaCompiler;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Factory that creates an instance of a JSR-199 compiler.
@@ -25,7 +23,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @FunctionalInterface
 public interface Jsr199CompilerFactory {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
@@ -24,8 +24,6 @@ import io.github.ascopes.jct.filemanagers.JctFileManagerFactory;
 import io.github.ascopes.jct.filemanagers.impl.JctFileManagerFactoryImpl;
 import javax.lang.model.SourceVersion;
 import javax.tools.ToolProvider;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Implementation of a JCT compiler that integrates with the default {@code javac}
@@ -34,7 +32,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JavacJctCompilerImpl extends AbstractJctCompiler {
 
   private static final int JAVA_8 = 8;
@@ -78,7 +75,6 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler {
    * @return the minimum supported version.
    * @since 1.0.0
    */
-  @API(since = "1.0.0", status = Status.INTERNAL)
   public static int getEarliestSupportedVersionInt() {
     // Purposely do not hardcode members of the SourceVersion enum here other
     // than utility methods, as this prevents compilation problems on various
@@ -100,8 +96,8 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler {
    * Get the maximum version of Javac that is supported.
    *
    * @return the maximum supported version.
+   * @since 1.0.0
    */
-  @API(since = "1.0.0", status = Status.INTERNAL)
   public static int getLatestSupportedVersionInt() {
     return SourceVersion.latestSupported().ordinal();
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctFlagBuilderImpl.java
@@ -21,8 +21,6 @@ import io.github.ascopes.jct.compilers.JctFlagBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -31,7 +29,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JavacJctFlagBuilderImpl implements JctFlagBuilder {
 
   private static final String VERBOSE = "-verbose";

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationFactoryImpl.java
@@ -38,8 +38,6 @@ import javax.tools.JavaCompiler;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,7 +49,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JctCompilationFactoryImpl implements JctCompilationFactory {
 
   private static final Logger log = LoggerFactory.getLogger(JctCompilationFactoryImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JctCompilationImpl.java
@@ -25,8 +25,6 @@ import io.github.ascopes.jct.utils.ToStringBuilder;
 import java.util.List;
 import java.util.Set;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -35,7 +33,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JctCompilationImpl implements JctCompilation {
 
   private final List<String> arguments;
@@ -124,7 +121,6 @@ public final class JctCompilationImpl implements JctCompilation {
    * @author Ashley Scopes
    * @since 0.0.1
    */
-  @API(since = "0.0.1", status = Status.INTERNAL)
   public static final class Builder {
 
     private @Nullable List<String> arguments;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Compiler backend integrations.
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 package io.github.ascopes.jct.compilers.impl;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * APIs for performing compiler passes across user-defined workspaces.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.compilers;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/Container.java
@@ -27,8 +27,6 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -38,9 +36,7 @@ import org.jspecify.annotations.Nullable;
  * Already-opened resources passed to the implementation will not be closed.
  *
  * @author Ashley Scopes
- * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface Container extends Closeable {
 
   /**
@@ -110,7 +106,6 @@ public interface Container extends Closeable {
    * @return the path root.
    * @since 0.0.6
    */
-  @API(since = "0.0.6", status = Status.STABLE)
   PathRoot getInnerPathRoot();
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ContainerGroup.java
@@ -19,8 +19,6 @@ import io.github.ascopes.jct.filemanagers.PathFileObject;
 import java.io.Closeable;
 import java.util.ServiceLoader;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Base container group interface.
@@ -31,7 +29,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface ContainerGroup extends Closeable {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ModuleContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/ModuleContainerGroup.java
@@ -20,8 +20,6 @@ import io.github.ascopes.jct.workspaces.PathRoot;
 import java.util.Map;
 import java.util.Set;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,7 +31,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface ModuleContainerGroup extends ContainerGroup {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/OutputContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/OutputContainerGroup.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.containers;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.util.List;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * A base definition for an output-oriented container group.
@@ -38,7 +36,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface OutputContainerGroup extends PackageContainerGroup, ModuleContainerGroup {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/PackageContainerGroup.java
@@ -27,8 +27,6 @@ import javax.tools.FileObject;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -41,7 +39,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface PackageContainerGroup extends ContainerGroup {
 
   /**
@@ -305,6 +302,5 @@ public interface PackageContainerGroup extends ContainerGroup {
    * @throws IOException if the file lookup fails due to an IO error somewhere.
    * @since 0.6.0
    */
-  @API(since = "0.6.0", status = Status.STABLE)
   Map<Container, Collection<Path>> listAllFiles() throws IOException;
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/AbstractPackageContainerGroup.java
@@ -43,8 +43,6 @@ import java.util.Set;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -57,7 +55,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public abstract class AbstractPackageContainerGroup implements PackageContainerGroup {
 
   // https://docs.oracle.com/cd/E19830-01/819-4712/ablgz/index.html
@@ -279,7 +276,13 @@ public abstract class AbstractPackageContainerGroup implements PackageContainerG
     return Collections.unmodifiableSet(collection);
   }
 
-  @API(since = "0.6.0", status = Status.STABLE)
+  /**
+   * {@inheritdoc}
+   *
+   * @return all files in a multimap.
+   * @throws IOException if an IO exception occurs reading the file system.
+   * @since 0.6.0
+   */
   @Override
   public Map<Container, Collection<Path>> listAllFiles() throws IOException {
     var multimap = new LinkedHashMap<Container, Collection<Path>>();

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImpl.java
@@ -28,8 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +38,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class ContainerGroupRepositoryImpl implements AutoCloseable {
 
   private static final Logger log = LoggerFactory.getLogger(ContainerGroupRepositoryImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/JarContainerImpl.java
@@ -44,8 +44,6 @@ import java.util.stream.Collectors;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,7 +62,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JarContainerImpl implements Container {
 
   private static final Logger log = LoggerFactory.getLogger(JarContainerImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ModuleContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/ModuleContainerGroupImpl.java
@@ -36,8 +36,6 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,7 +44,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class ModuleContainerGroupImpl implements ModuleContainerGroup {
 
   private final Location location;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/OutputContainerGroupImpl.java
@@ -32,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -49,7 +47,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class OutputContainerGroupImpl
     extends AbstractPackageContainerGroup
     implements OutputContainerGroup {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupImpl.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.containers.impl;
 import io.github.ascopes.jct.ex.JctIllegalInputException;
 import io.github.ascopes.jct.utils.StringUtils;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * A group of containers that relate to a specific location.
@@ -31,7 +29,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class PackageContainerGroupImpl extends AbstractPackageContainerGroup {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoader.java
@@ -20,8 +20,6 @@ import io.github.ascopes.jct.containers.PackageContainerGroup;
 import io.github.ascopes.jct.workspaces.PathRoot;
 import java.net.URL;
 import java.net.URLClassLoader;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * An extension of the Java {@link URLClassLoader} that wraps around container groups.
@@ -29,7 +27,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class PackageContainerGroupUrlClassLoader extends URLClassLoader {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -35,8 +35,6 @@ import java.util.stream.Collectors;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +45,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class PathWrappingContainerImpl implements Container {
 
   private static final Logger log = LoggerFactory.getLogger(PathWrappingContainerImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Implementations of compiler container hierarchies.
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 package io.github.ascopes.jct.containers.impl;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/package-info.java
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * APIs for representing the various file management locations across multiple file system
  * implementations.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.containers;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
@@ -24,8 +24,6 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * A writer that wraps an output stream and also writes any content to an in-memory buffer.
@@ -35,7 +33,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class TeeWriter extends Writer {
 
   private final Lock lock;
@@ -97,7 +94,6 @@ public final class TeeWriter extends Writer {
    * @return the content.
    * @since 0.2.1
    */
-  @API(since = "0.2.1", status = Status.STABLE)
   public String getContent() {
     lock.lock();
     try {
@@ -110,9 +106,8 @@ public final class TeeWriter extends Writer {
   /**
    * Get the content of the internal buffer.
    *
-   * <p>This calls {@link #getContent()} internally as of 0.2.1.
-   *
    * @return the content.
+   * @since 0.2.1
    */
   @Override
   public String toString() {
@@ -151,7 +146,6 @@ public final class TeeWriter extends Writer {
    * @return the Tee Writer.
    * @since 0.2.1
    */
-  @API(since = "0.2.1", status = Status.STABLE)
   public static TeeWriter wrapOutputStream(OutputStream outputStream, Charset charset) {
     requireNonNull(outputStream, "outputStream");
     requireNonNull(charset, "charset");

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TraceDiagnostic.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TraceDiagnostic.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.Locale;
 import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -36,7 +34,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public class TraceDiagnostic<S extends JavaFileObject> implements Diagnostic<S> {
 
   private final Instant timestamp;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListener.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListener.java
@@ -28,8 +28,6 @@ import java.util.stream.Collectors;
 import javax.tools.Diagnostic;
 import javax.tools.DiagnosticListener;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.event.Level;
@@ -42,7 +40,6 @@ import org.slf4j.event.Level;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public class TracingDiagnosticListener<S extends JavaFileObject> implements DiagnosticListener<S> {
 
   private final ConcurrentLinkedQueue<TraceDiagnostic<S>> diagnostics;
@@ -73,12 +70,14 @@ public class TracingDiagnosticListener<S extends JavaFileObject> implements Diag
   /**
    * Only visible for testing.
    *
+   * <p>Users should <strong>NOT</strong> use this constructor. It may be changed
+   * or removed without notice.
+   *
    * @param logger       the logger to use.
    * @param threadGetter the supplier of the current thread.
    * @param logging      whether to enable logging.
    * @param stackTraces  whether to enable stack traces in the logging.
    */
-  @API(since = "0.0.1", status = Status.INTERNAL)
   @VisibleForTestingOnly
   protected TracingDiagnosticListener(
       Logger logger,

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Support for collecting and representing diagnostics from compiler implementations.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.diagnostics;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctCompilerException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctCompilerException.java
@@ -15,8 +15,6 @@
  */
 package io.github.ascopes.jct.ex;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,7 +23,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctCompilerException extends JctException {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctException.java
@@ -15,8 +15,6 @@
  */
 package io.github.ascopes.jct.ex;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,7 +23,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public abstract class JctException extends RuntimeException {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctIllegalInputException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctIllegalInputException.java
@@ -15,8 +15,6 @@
  */
 package io.github.ascopes.jct.ex;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -25,7 +23,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 1.1.0
  */
-@API(since = "1.1.0", status = Status.STABLE)
 public final class JctIllegalInputException extends JctException {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctJunitConfigurerException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctJunitConfigurerException.java
@@ -15,8 +15,6 @@
  */
 package io.github.ascopes.jct.ex;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -26,7 +24,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctJunitConfigurerException extends JctException {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotFoundException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotFoundException.java
@@ -15,16 +15,12 @@
  */
 package io.github.ascopes.jct.ex;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Exception raised if an element is not found.
  *
  * @author Ashley Scopes
  * @since 1.1.0
  */
-@API(since = "1.1.0", status = Status.STABLE)
 public final class JctNotFoundException extends JctException {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotImplementedException.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/JctNotImplementedException.java
@@ -15,16 +15,12 @@
  */
 package io.github.ascopes.jct.ex;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Exception that is raised if an internal feature is not implemented.
  *
  * @author Ashley Scopes
  * @since 1.1.0
  */
-@API(since = "1.1.0", status = Status.STABLE)
 public final class JctNotImplementedException extends JctException {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/ex/package-info.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Common exceptions used within this API.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.ex;
 
 import org.apiguardian.api.API;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/AnnotationProcessorDiscovery.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/AnnotationProcessorDiscovery.java
@@ -15,16 +15,12 @@
  */
 package io.github.ascopes.jct.filemanagers;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Mode for annotation processor discovery when no explicit processors are provided.
  *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public enum AnnotationProcessorDiscovery {
   /**
    * Discovery is enabled, and will also scan any dependencies in the classpath or module path.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -29,8 +29,6 @@ import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -46,7 +44,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface JctFileManager extends JavaFileManager {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagerFactory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagerFactory.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.filemanagers;
 
 import io.github.ascopes.jct.workspaces.Workspace;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Factory interface for building a file manager object.
@@ -25,7 +23,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @FunctionalInterface
 public interface JctFileManagerFactory {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManagers.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.filemanagers;
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.filemanagers.impl.JctFileManagerFactoryImpl;
 import io.github.ascopes.jct.utils.UtilityClass;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Helpers to create instances of default implementations for file managers.
@@ -27,7 +25,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 1.1.0
  */
-@API(since = "1.1.0", status = Status.STABLE)
 public final class JctFileManagers extends UtilityClass {
 
   private JctFileManagers() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/LoggingMode.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/LoggingMode.java
@@ -15,17 +15,16 @@
  */
 package io.github.ascopes.jct.filemanagers;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Options for how to handle logging on special internal components.
+ *
+ * <p>This primarily exists to support debugging the JCT library itself.
  *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public enum LoggingMode {
+
   /**
    * Enable basic logging.
    */

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/ModuleLocation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/ModuleLocation.java
@@ -20,8 +20,6 @@ import io.github.ascopes.jct.utils.ToStringBuilder;
 import java.util.Objects;
 import java.util.Optional;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -30,7 +28,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class ModuleLocation implements Location {
 
   private final Location parent;
@@ -123,13 +120,13 @@ public final class ModuleLocation implements Location {
 
   /**
    * Attempt to upcast a given location to a ModuleLocation if it is an instance of
-   * ModuleLocation. 
+   * ModuleLocation.
    *
    * @param location the location to attempt to upcast.
    * @return an optional containing the upcast location if it is a module location,
    *     or an empty optional if not.
+   * @since 1.1.5
    */
-  @API(since = "1.1.5", status = Status.STABLE)
   public static Optional<ModuleLocation> upcast(Location location) {
     return Optional.of(location)
         .filter(ModuleLocation.class::isInstance)

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/PathFileObject.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/PathFileObject.java
@@ -28,8 +28,6 @@ import javax.lang.model.element.NestingKind;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -43,7 +41,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 1.0.0
  */
-@API(since = "1.0.0", status = Status.STABLE)
 public interface PathFileObject extends JavaFileObject {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerAnnotationProcessorClassPathConfigurer.java
@@ -21,8 +21,6 @@ import io.github.ascopes.jct.filemanagers.AnnotationProcessorDiscovery;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import java.util.Map;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +33,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerAnnotationProcessorClassPathConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurer.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.filemanagers.config;
 
 import io.github.ascopes.jct.filemanagers.JctFileManager;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Interface for a {@link JctFileManager} configurer.
@@ -38,7 +36,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @FunctionalInterface
 public interface JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurerChain.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurerChain.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.filemanagers.config;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import java.util.LinkedList;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -28,7 +26,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>This is used to provide a set of ordered configuration operations to perform on newly
  * created file managers to prepare them for consumption in test cases. Common operations
- * may include: 
+ * may include:
  *
  * <ul>
  *   <li>Automatically configuring the annotation processor paths;</li>
@@ -50,7 +48,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerConfigurerChain {
 
   private static final Logger log = LoggerFactory.getLogger(JctFileManagerConfigurerChain.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathConfigurer.java
@@ -21,8 +21,6 @@ import io.github.ascopes.jct.utils.SpecialLocationUtils;
 import io.github.ascopes.jct.utils.StringUtils;
 import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerJvmClassPathConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmClassPathModuleConfigurer.java
@@ -22,8 +22,6 @@ import io.github.ascopes.jct.utils.SpecialLocationUtils;
 import io.github.ascopes.jct.utils.StringUtils;
 import java.util.Set;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +36,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerJvmClassPathModuleConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmModulePathConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmModulePathConfigurer.java
@@ -21,8 +21,6 @@ import io.github.ascopes.jct.utils.SpecialLocationUtils;
 import io.github.ascopes.jct.utils.StringUtils;
 import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerJvmModulePathConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmSystemModulesConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerJvmSystemModulesConfigurer.java
@@ -21,8 +21,6 @@ import io.github.ascopes.jct.utils.SpecialLocationUtils;
 import io.github.ascopes.jct.utils.StringUtils;
 import io.github.ascopes.jct.workspaces.impl.WrappingDirectoryImpl;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerJvmSystemModulesConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerLoggingProxyConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerLoggingProxyConfigurer.java
@@ -19,8 +19,6 @@ import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import io.github.ascopes.jct.filemanagers.LoggingMode;
 import io.github.ascopes.jct.filemanagers.impl.LoggingFileManagerProxy;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +29,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerLoggingProxyConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerRequiredLocationsConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerRequiredLocationsConfigurer.java
@@ -22,8 +22,6 @@ import io.github.ascopes.jct.utils.StringUtils;
 import io.github.ascopes.jct.workspaces.Workspace;
 import java.util.Set;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +33,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerRequiredLocationsConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerWorkspaceConfigurer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerWorkspaceConfigurer.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.filemanagers.config;
 import io.github.ascopes.jct.filemanagers.JctFileManager;
 import io.github.ascopes.jct.utils.StringUtils;
 import io.github.ascopes.jct.workspaces.Workspace;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -29,7 +27,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JctFileManagerWorkspaceConfigurer
     implements JctFileManagerConfigurer {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/package-info.java
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Reusable components for setting up JSR-199 file managers.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.filemanagers.config;
 
 import org.apiguardian.api.API;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerFactoryImpl.java
@@ -29,8 +29,6 @@ import io.github.ascopes.jct.filemanagers.config.JctFileManagerRequiredLocations
 import io.github.ascopes.jct.filemanagers.config.JctFileManagerWorkspaceConfigurer;
 import io.github.ascopes.jct.utils.VisibleForTestingOnly;
 import io.github.ascopes.jct.workspaces.Workspace;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Basic implementation for a file manager factory that returns a {@link JctFileManagerImpl}
@@ -42,7 +40,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JctFileManagerFactoryImpl implements JctFileManagerFactory {
 
   private final JctCompiler compiler;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImpl.java
@@ -38,8 +38,6 @@ import java.util.Set;
 import javax.tools.FileObject;
 import javax.tools.JavaFileObject;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -48,7 +46,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class JctFileManagerImpl implements JctFileManager {
 
   private static final int UNSUPPORTED_ARGUMENT = -1;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/LoggingFileManagerProxy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/LoggingFileManagerProxy.java
@@ -26,8 +26,6 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -47,7 +45,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class LoggingFileManagerProxy implements InvocationHandler {
 
   private final Logger logger;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/PathFileObjectImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/PathFileObjectImpl.java
@@ -44,8 +44,6 @@ import java.nio.file.Path;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -60,7 +58,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 1.0.0 (renamed from PathFileObject introduced in 0.0.1)
  */
-@API(since = "1.0.0", status = Status.INTERNAL)
 public final class PathFileObjectImpl implements PathFileObject {
 
   private static final Logger log = LoggerFactory.getLogger(PathFileObjectImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/impl/package-info.java
@@ -13,11 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * File manager implementation details.
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 package io.github.ascopes.jct.filemanagers.impl;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * APIs that integrate with the JSR-199 FileManager APIs.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.filemanagers;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/AbstractCompilersProvider.java
@@ -27,8 +27,6 @@ import java.lang.reflect.InaccessibleObjectException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
@@ -133,7 +131,6 @@ import org.junit.jupiter.params.support.AnnotationConsumer;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public abstract class AbstractCompilersProvider implements ArgumentsProvider {
 
   // Values that are late-bound when configure() is called from the
@@ -225,7 +222,6 @@ public abstract class AbstractCompilersProvider implements ArgumentsProvider {
    * @return the minimum supported compiler version.
    * @since 1.0.0
    */
-  @API(since = "1.0.0", status = Status.STABLE)
   protected abstract int minSupportedVersion();
 
   /**
@@ -234,7 +230,6 @@ public abstract class AbstractCompilersProvider implements ArgumentsProvider {
    * @return the minimum supported compiler version.
    * @since 1.0.0
    */
-  @API(since = "1.0.0", status = Status.STABLE)
   protected abstract int maxSupportedVersion();
 
   private JctCompiler createCompilerForVersion(int version) {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilerTest.java
@@ -21,8 +21,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
 import org.junit.jupiter.api.TestTemplate;
@@ -74,7 +72,6 @@ import org.junit.jupiter.params.provider.ArgumentsSource;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @ArgumentsSource(JavacCompilersProvider.class)
 @DisabledInNativeImage
 @Documented

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JavacCompilersProvider.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.junit;
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.compilers.impl.JavacJctCompilerImpl;
 import io.github.ascopes.jct.utils.VisibleForTestingOnly;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.junit.jupiter.params.support.AnnotationConsumer;
 
 /**
@@ -28,7 +26,6 @@ import org.junit.jupiter.params.support.AnnotationConsumer;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class JavacCompilersProvider extends AbstractCompilersProvider
     implements AnnotationConsumer<JavacCompilerTest> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JctExtension.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/JctExtension.java
@@ -21,8 +21,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.AfterEachCallback;
@@ -62,7 +60,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.4.0
  */
-@API(since = "0.4.0", status = Status.STABLE)
 public final class JctExtension
     implements Extension, BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
@@ -22,8 +22,6 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Annotation for a {@link Workspace} field in a test class. This will ensure it gets initialised
@@ -56,7 +54,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.4.0
  */
-@API(since = "0.4.0", status = Status.STABLE)
 @Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/VersionStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/VersionStrategy.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.junit;
 
 import io.github.ascopes.jct.compilers.JctCompiler;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Strategy for setting a version on a JUnit compiler annotation.
@@ -25,7 +23,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public enum VersionStrategy {
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Integrations with JUnit5 test cases.
- */
-@API(since = "0.0.1", status = Status.STABLE)
-package io.github.ascopes.jct.junit;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
+/**
+ * Integrations with Junit Jupiter APIs.
+ */
+package io.github.ascopes.jct.junit;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/LocationRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/LocationRepresentation.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.repr;
 
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.presentation.Representation;
 import org.jspecify.annotations.Nullable;
 
@@ -27,7 +25,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class LocationRepresentation implements Representation {
 
   private static final LocationRepresentation INSTANCE

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/StackTraceRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/StackTraceRepresentation.java
@@ -16,8 +16,6 @@
 package io.github.ascopes.jct.repr;
 
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.presentation.Representation;
 import org.jspecify.annotations.Nullable;
 
@@ -27,7 +25,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class StackTraceRepresentation implements Representation {
 
   private static final StackTraceRepresentation INSTANCE = new StackTraceRepresentation();

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticListRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticListRepresentation.java
@@ -20,8 +20,6 @@ import static java.util.stream.Collectors.joining;
 import io.github.ascopes.jct.diagnostics.TraceDiagnostic;
 import java.util.Collection;
 import javax.tools.JavaFileObject;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.presentation.Representation;
 import org.jspecify.annotations.Nullable;
 
@@ -31,7 +29,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class TraceDiagnosticListRepresentation implements Representation {
 
   private static final TraceDiagnosticListRepresentation INSTANCE

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentation.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentation.java
@@ -17,8 +17,6 @@ package io.github.ascopes.jct.repr;
 
 import io.github.ascopes.jct.diagnostics.TraceDiagnostic;
 import java.util.Locale;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.assertj.core.presentation.Representation;
 import org.jspecify.annotations.Nullable;
 
@@ -28,7 +26,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1, rewritten in 4.0.0
  */
-@API(since = "4.0.0", status = Status.STABLE)
 public final class TraceDiagnosticRepresentation implements Representation {
 
   private static final TraceDiagnosticRepresentation INSTANCE

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/repr/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Representation facilities for AssertJ integration.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.repr;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/FileUtils.java
@@ -30,8 +30,6 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 import javax.tools.JavaFileObject.Kind;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -40,7 +38,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class FileUtils extends UtilityClass {
 
   // Exclude any "empty" extensions. At the time of writing, this will just exclude Kind.EMPTY,

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IoExceptionUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IoExceptionUtils.java
@@ -17,8 +17,6 @@ package io.github.ascopes.jct.utils;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Utilities for handling {@link IOException}s and converting them to
@@ -26,7 +24,6 @@ import org.apiguardian.api.API.Status;
  *
  * @author Ashley Scopes
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class IoExceptionUtils extends UtilityClass {
 
   private IoExceptionUtils() {
@@ -85,9 +82,7 @@ public final class IoExceptionUtils extends UtilityClass {
    * A runnable interface that may throw an {@link IOException}.
    *
    * @author Ashley Scopes
-   * @since 0.0.1
    */
-  @API(since = "0.0.1", status = Status.INTERNAL)
   @FunctionalInterface
   public interface IoRunnable {
 
@@ -104,9 +99,7 @@ public final class IoExceptionUtils extends UtilityClass {
    *
    * @param <T> the return type of the supplier.
    * @author Ashley Scopes
-   * @since 0.0.1
    */
-  @API(since = "0.0.1", status = Status.INTERNAL)
   @FunctionalInterface
   public interface IoSupplier<T> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IterableUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/IterableUtils.java
@@ -23,8 +23,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,7 +31,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class IterableUtils extends UtilityClass {
 
   private IterableUtils() {
@@ -69,7 +66,6 @@ public final class IterableUtils extends UtilityClass {
    * @throws NullPointerException     if the array is {@code null}.
    * @since 4.0.0
    */
-  @API(status = Status.INTERNAL, since = "4.0.0")
   public static <T> @Nullable T[] requireAtLeastOne(
       @Nullable T @Nullable [] elements,
       String arrayName
@@ -97,7 +93,6 @@ public final class IterableUtils extends UtilityClass {
    * @throws NullPointerException     if the iterable is {@code null}.
    * @since 4.0.0
    */
-  @API(status = Status.INTERNAL, since = "4.0.0")
   public static <T extends Collection<@Nullable U>, U> T requireAtLeastOne(
       @Nullable T collection,
       String collectionName

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/Lazy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/Lazy.java
@@ -20,8 +20,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -42,7 +40,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class Lazy<T> {
 
   private final Supplier<T> initializer;
@@ -155,7 +152,6 @@ public final class Lazy<T> {
    * @author Ashley Scopes
    * @since 0.0.1
    */
-  @API(since = "0.0.1", status = Status.INTERNAL)
   @FunctionalInterface
   public interface ThrowingConsumer<T, E extends Throwable> {
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/LoomPolyfill.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/LoomPolyfill.java
@@ -15,9 +15,6 @@
  */
 package io.github.ascopes.jct.utils;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Polyfill to enable supporting using the newer Thread APIs on newer platforms.
  *
@@ -27,7 +24,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class LoomPolyfill extends UtilityClass {
 
   private LoomPolyfill() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ModuleDiscoverer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ModuleDiscoverer.java
@@ -24,8 +24,6 @@ import java.nio.file.Path;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,7 +35,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class ModuleDiscoverer extends UtilityClass {
 
   private static final Logger log = LoggerFactory.getLogger(ModuleDiscoverer.class);
@@ -75,8 +72,8 @@ public final class ModuleDiscoverer extends UtilityClass {
 
   /**
    * Representation of a candidate module that was discovered.
+   * @since 3.0.2
    */
-  @API(status = Status.INTERNAL, since = "3.0.2")
   public static final class ModuleCandidate {
 
     private final String name;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/SpecialLocationUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/SpecialLocationUtils.java
@@ -23,8 +23,6 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,7 +32,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class SpecialLocationUtils extends UtilityClass {
 
   // Files we don't want to propagate by default as they may clash with the environment.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringSlicer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringSlicer.java
@@ -19,8 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Stream;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Utility to efficiently split strings using a delimiter without using regular expressions.
@@ -30,7 +28,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class StringSlicer {
 
   private final String delimiter;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringUtils.java
@@ -26,8 +26,6 @@ import java.util.stream.Collectors;
 import me.xdrop.fuzzywuzzy.FuzzySearch;
 import me.xdrop.fuzzywuzzy.ToStringFunction;
 import me.xdrop.fuzzywuzzy.model.BoundExtractedResult;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -36,7 +34,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class StringUtils extends UtilityClass {
 
   // Number formatting stuff

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ToStringBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ToStringBuilder.java
@@ -29,8 +29,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.regex.Pattern;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -39,7 +37,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(status = Status.INTERNAL, since = "0.0.1")
 public final class ToStringBuilder {
 
   private static final String LSQUARE = "[";

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/UtilityClass.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/UtilityClass.java
@@ -15,16 +15,12 @@
  */
 package io.github.ascopes.jct.utils;
 
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
-
 /**
  * Abstract base for a static-only class. This base cannot be initialised.
  *
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public abstract class UtilityClass {
 
   protected UtilityClass() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/VisibleForTestingOnly.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/VisibleForTestingOnly.java
@@ -21,8 +21,6 @@ import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Annotation that marks the annotated method or constructor as only being visible for testing
@@ -33,9 +31,7 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 @Documented
-@Inherited
 @Retention(RetentionPolicy.CLASS)
 @Target({ElementType.CONSTRUCTOR, ElementType.METHOD})
 public @interface VisibleForTestingOnly {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/package-info.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Internal shared utilities.
  *
@@ -20,8 +21,4 @@
  * modules. As such, they are not covered by the semantic versioning policy and may change without
  * notice.
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 package io.github.ascopes.jct.utils;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/DirectoryBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/DirectoryBuilder.java
@@ -19,8 +19,6 @@ import java.io.File;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Chainable builder for creating directories.
@@ -29,7 +27,6 @@ import org.apiguardian.api.API.Status;
  * @since 0.0.1
  */
 @SuppressWarnings("unused")
-@API(since = "0.0.1", status = Status.STABLE)
 public interface DirectoryBuilder {
 
   /**
@@ -61,7 +58,6 @@ public interface DirectoryBuilder {
    * @see #copyContentsFrom(String...)
    * @since 4.0.0
    */
-  @API(since = "4.0.0", status = Status.STABLE)
   ManagedDirectory copyContentsFrom(List<String> fragments);
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/FileBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/FileBuilder.java
@@ -22,8 +22,6 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Chainable builder for creating individual files.
@@ -31,7 +29,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public interface FileBuilder {
 
@@ -43,7 +40,6 @@ public interface FileBuilder {
    * @return the root managed directory for further configuration.
    * @since 0.3.0
    */
-  @API(since = "0.3.0", status = Status.STABLE)
   ManagedDirectory asJarFrom(PathRoot directory);
 
   /**
@@ -63,7 +59,6 @@ public interface FileBuilder {
    * @return the root managed directory for further configuration.
    * @since 0.3.0
    */
-  @API(since = "0.3.0", status = Status.STABLE)
   ManagedDirectory asJarFrom(Path directory);
 
   /**
@@ -223,7 +218,6 @@ public interface FileBuilder {
    * @return the managed directory.
    * @since 4.0.0
    */
-  @API(since = "4.0.0", status = Status.STABLE)
   default ManagedDirectory withContents(ByteBuffer buffer) {
     var array = new byte[buffer.remaining()];
     buffer.get(array);
@@ -256,7 +250,6 @@ public interface FileBuilder {
    * @see #withContents(byte[])
    * @since 4.0.0
    */
-  @API(since = "4.0.0", status = Status.STABLE)
   ManagedDirectory withContents(Charset charset, List<String> lines);
 
   /**
@@ -334,7 +327,6 @@ public interface FileBuilder {
    * @see #withContents(byte[])
    * @since 4.0.0
    */
-  @API(since = "4.0.0", status = Status.STABLE)
   ManagedDirectory withContents(List<String> lines);
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/ManagedDirectory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/ManagedDirectory.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.workspaces;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Base interface for a managed directory, including the interfaces for creating fluent-style
@@ -28,7 +26,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public interface ManagedDirectory extends DirectoryBuilder, PathRoot {
 
   /**
@@ -125,7 +122,6 @@ public interface ManagedDirectory extends DirectoryBuilder, PathRoot {
    * @throws NullPointerException     if any of the path fragments are {@code null}.
    * @since 4.0.0
    */
-  @API(since = "4.0.0", status = Status.STABLE)
   DirectoryBuilder createDirectory(List<String> fragments);
 
   /**
@@ -165,7 +161,6 @@ public interface ManagedDirectory extends DirectoryBuilder, PathRoot {
    * @throws NullPointerException     if any of the path fragments are {@code null}.
    * @since 4.0.0
    */
-  @API(since = "4.0.0", status = Status.STABLE)
   FileBuilder createFile(List<String> fragments);
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathRoot.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathRoot.java
@@ -19,8 +19,6 @@ import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,7 +31,6 @@ import org.jspecify.annotations.Nullable;
  * @since 0.0.1
  */
 @SuppressWarnings("unused")
-@API(since = "0.0.1", status = Status.STABLE)
 public interface PathRoot {
 
   /**
@@ -47,7 +44,6 @@ public interface PathRoot {
    * @throws UnsupportedOperationException if the operation is not supported.
    * @since 0.4.0
    */
-  @API(since = "0.4.0", status = Status.STABLE)
   byte[] asJar();
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
@@ -22,8 +22,6 @@ import java.io.File;
 import java.nio.file.Path;
 import java.util.function.Function;
 import javax.annotation.processing.Filer;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Strategy to use for creating new test directories.
@@ -34,7 +32,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public enum PathStrategy {
   /**
    * Use RAM-based directories for any created directories.
@@ -93,7 +90,6 @@ public enum PathStrategy {
    * @param name the name to use.
    * @return the new test directory.
    */
-  @API(since = "0.0.1", status = Status.INTERNAL)
   public ManagedDirectory newInstance(String name) {
     return constructor.apply(name);
   }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspace.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import javax.tools.JavaFileManager.Location;
 import javax.tools.StandardLocation;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Interface for a Workspace to hold files and directories within.
@@ -100,7 +98,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public interface Workspace extends AutoCloseable {
 
@@ -118,12 +115,7 @@ public interface Workspace extends AutoCloseable {
    * @return {@code true} if closed, {@code false} if open.
    * @since 0.4.0
    */
-  @API(since = "0.4.0", status = Status.STABLE)
   boolean isClosed();
-
-  ///
-  /// Accessor operations
-  ///
 
   /**
    * Get an immutable copy of the current paths to operate on.
@@ -192,10 +184,6 @@ public interface Workspace extends AutoCloseable {
    * @since 0.1.0
    */
   List<? extends PathRoot> getPackages(Location location);
-
-  ///
-  /// Mutative operations
-  ///
 
   /**
    * Add an existing package root to this workspace and associate it with the given location.
@@ -334,10 +322,6 @@ public interface Workspace extends AutoCloseable {
    * @see #addModule(Location, String, Path)
    */
   ManagedDirectory createModule(Location location, String moduleName);
-
-  ///
-  /// Default implementation helpers.
-  ///
 
   /**
    * Add a package to the {@link StandardLocation#CLASS_OUTPUT class outputs}.
@@ -844,10 +828,6 @@ public interface Workspace extends AutoCloseable {
     return getModules(StandardLocation.MODULE_PATH);
   }
 
-  ///
-  /// Functional APIs.
-  ///
-
   /**
    * Functional equivalent of consuming this object with a try-with-resources.
    *
@@ -861,7 +841,6 @@ public interface Workspace extends AutoCloseable {
    * @throws T the checked exception that the consumer can throw.
    * @since 3.2.0
    */
-  @API(since = "3.2.0", status = Status.STABLE)
   default <T extends Throwable> void use(ThrowingWorkspaceConsumer<T> consumer) throws T {
     try {
       consumer.accept(this);
@@ -879,7 +858,6 @@ public interface Workspace extends AutoCloseable {
    * @author Ashley Scopes
    * @since 3.2.0
    */
-  @API(since = "3.2.0", status = Status.STABLE)
   interface ThrowingWorkspaceConsumer<T extends Throwable> {
 
     /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspaces.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/Workspaces.java
@@ -18,8 +18,6 @@ package io.github.ascopes.jct.workspaces;
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.utils.UtilityClass;
 import io.github.ascopes.jct.workspaces.impl.WorkspaceImpl;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Helpers to create new workspaces.
@@ -27,7 +25,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.STABLE)
 public final class Workspaces extends UtilityClass {
 
   private Workspaces() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/AbstractManagedDirectory.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/AbstractManagedDirectory.java
@@ -32,8 +32,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -45,7 +43,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public abstract class AbstractManagedDirectory implements ManagedDirectory {
 
   private final String name;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/DirectoryBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/DirectoryBuilderImpl.java
@@ -31,8 +31,6 @@ import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.StringJoiner;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,7 +40,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class DirectoryBuilderImpl implements DirectoryBuilder {
 
   private static final Logger log = LoggerFactory.getLogger(DirectoryBuilderImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/FileBuilderImpl.java
@@ -38,8 +38,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
 import java.util.Locale;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +48,6 @@ import org.slf4j.LoggerFactory;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class FileBuilderImpl implements FileBuilder {
 
   private static final Logger log = LoggerFactory.getLogger(FileBuilderImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/JarFactoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/JarFactoryImpl.java
@@ -27,8 +27,6 @@ import java.util.jar.JarOutputStream;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import java.util.zip.ZipEntry;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * A special singleton factory class that is used to create JAR files in memory on the fly.
@@ -36,7 +34,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.3.0
  */
-@API(since = "0.3.0", status = Status.STABLE)
 public final class JarFactoryImpl {
 
   private static final JarFactoryImpl INSTANCE = new JarFactoryImpl();

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/MemoryFileSystemProvider.java
@@ -22,8 +22,6 @@ import java.io.UncheckedIOException;
 import java.net.URLStreamHandler;
 import java.net.spi.URLStreamHandlerProvider;
 import java.nio.file.FileSystem;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -33,7 +31,6 @@ import org.jspecify.annotations.Nullable;
  * @author Ashley Scopes, Philippe Marschall
  * @since 0.7.0
  */
-@API(since = "0.7.0", status = Status.INTERNAL)
 public final class MemoryFileSystemProvider {
 
   // We could initialise this lazily, but this class has fewer fields and initialisation
@@ -83,7 +80,6 @@ public final class MemoryFileSystemProvider {
    * @author Ashley Scopes
    * @since 0.7.0
    */
-  @API(since = "0.7.0", status = Status.INTERNAL)
   public static final class MemoryFileSystemUrlHandlerProvider extends URLStreamHandlerProvider {
 
     private final MemoryURLStreamHandlerFactory factory;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/RamDirectoryImpl.java
@@ -23,8 +23,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,7 +49,6 @@ import org.slf4j.LoggerFactory;
  * @see TempDirectoryImpl
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class RamDirectoryImpl extends AbstractManagedDirectory {
 
   private static final Logger log = LoggerFactory.getLogger(RamDirectoryImpl.class);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/TempDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/TempDirectoryImpl.java
@@ -24,8 +24,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,7 +43,6 @@ import org.slf4j.LoggerFactory;
  * @see RamDirectoryImpl
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class TempDirectoryImpl extends AbstractManagedDirectory {
 
   private static final Logger log = LoggerFactory.getLogger(TempDirectoryImpl.class);
@@ -90,7 +87,6 @@ public final class TempDirectoryImpl extends AbstractManagedDirectory {
    * @return the temporary directory.
    */
   public static TempDirectoryImpl newTempDirectory(String name) {
-    // TODO(ascopes): are MS-DOS file name length limits a potential issue here?
     assertValidRootName(name);
     var tempDir = uncheckedIo(() -> Files.createTempDirectory("jct-" + name + "_"));
     log.debug("Initialized new root '{}' using temporary directory at '{}'", name, tempDir);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
@@ -32,8 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.tools.JavaFileManager.Location;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 
 /**
  * Implementation of a workspace to use by default.
@@ -46,7 +44,6 @@ import org.apiguardian.api.API.Status;
  * @author Ashley Scopes
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class WorkspaceImpl implements Workspace {
 
   private volatile boolean closed;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImpl.java
@@ -28,8 +28,6 @@ import java.net.URI;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;
 import org.jspecify.annotations.Nullable;
 
 /**
@@ -44,7 +42,6 @@ import org.jspecify.annotations.Nullable;
  * @see TempDirectoryImpl
  * @since 0.0.1
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 public final class WrappingDirectoryImpl implements PathRoot {
 
   private final @Nullable PathRoot parent;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Internal workspace implementation details.
  */
-@API(since = "0.0.1", status = Status.INTERNAL)
 package io.github.ascopes.jct.workspaces.impl;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/package-info.java
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 /**
  * Workspace components to hold complex source code structures within memory.
  */
-@API(since = "0.0.1", status = Status.STABLE)
 package io.github.ascopes.jct.workspaces;
-
-import org.apiguardian.api.API;
-import org.apiguardian.api.API.Status;

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -124,7 +124,6 @@ module io.github.ascopes.jct {
   requires java.compiler;
   requires java.management;
   requires me.xdrop.fuzzywuzzy;
-  requires static org.apiguardian.api;
   requires org.assertj.core;
   requires static org.jspecify;
   requires static org.junit.jupiter.api;

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,6 @@
 
   <properties>
     <!-- Dependencies -->
-    <apiguardian.version>1.1.2</apiguardian.version>
     <assertj.version>3.26.3</assertj.version>
     <awaitility.version>4.2.2</awaitility.version>
     <fuzzywuzzy.version>1.4.0</fuzzywuzzy.version>
@@ -187,13 +186,6 @@
         <groupId>me.xdrop</groupId>
         <artifactId>fuzzywuzzy</artifactId>
         <version>${fuzzywuzzy.version}</version>
-      </dependency>
-
-      <dependency>
-        <!-- API versioning annotations -->
-        <groupId>org.apiguardian</groupId>
-        <artifactId>apiguardian-api</artifactId>
-        <version>${apiguardian.version}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Usages of the annotation have never been fully consistent and users should be using reflection to determine the JAR version on the off chance they are manipulating this API programmatically.

API guardian has never been specified as part of the public API, so this is not a breaking change.