### PR TITLE
Remove EOL Java versions from build pipeline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,18 +23,9 @@ jobs:
       matrix:
         os-name: [ubuntu-latest]
         java-version:
-          - 11
-          - 12
-          - 13
-          - 14
-          - 15
-          - 16
-          - 17
-          - 18
-          - 19
-          - 20
-          - 21
-          - 22
+          - 11  # LTS
+          - 17  # LTS
+          - 21  # LTS
           - 23
           #- 24-ea
         include:


### PR DESCRIPTION
This disables CI builds for Java versions that are no longer supported by OpenJDK.

LTS builds will still be supported, but this reduces the number of builds we are performing that target obsolete platforms.