### PR TITLE
Update integration tests

### DIFF
--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -195,4 +195,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>invoker-debug</id>
+      <build>
+        <pluginManagement>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.maven.plugins</groupId>
+              <artifactId>maven-invoker-plugin</artifactId>
+              <version>${maven-invoker-plugin.version}</version>
+              <configuration>
+                <invokerPropertiesFile>invoker-debug.properties</invokerPropertiesFile>
+              </configuration>
+            </plugin>
+          </plugins>
+        </pluginManagement>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/java-compiler-testing/src/it/avaje-http/pom.xml
+++ b/java-compiler-testing/src/it/avaje-http/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for Avaje HTTP.</description>
 
   <properties>
-    <avaje-http.version>2.4</avaje-http.version>
+    <avaje-http.version>2.8</avaje-http.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/avaje-inject/pom.xml
+++ b/java-compiler-testing/src/it/avaje-inject/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for Avaje Inject.</description>
 
   <properties>
-    <avaje-inject.version>9.12</avaje-inject.version>
+    <avaje-inject.version>11.0</avaje-inject.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/avaje-inject/src/test/java/io/github/ascopes/jct/acceptancetests/avajeinject/AvajeInjectTest.java
+++ b/java-compiler-testing/src/it/avaje-inject/src/test/java/io/github/ascopes/jct/acceptancetests/avajeinject/AvajeInjectTest.java
@@ -19,6 +19,7 @@ import static io.github.ascopes.jct.assertions.JctAssertions.assertThatCompilati
 
 import io.github.ascopes.jct.compilers.JctCompiler;
 import io.github.ascopes.jct.junit.JavacCompilerTest;
+import io.github.ascopes.jct.workspaces.PathStrategy;
 import io.github.ascopes.jct.workspaces.Workspaces;
 import org.junit.jupiter.api.DisplayName;
 
@@ -29,7 +30,7 @@ class AvajeInjectTest {
   @JavacCompilerTest(minVersion = 11)
   void dependencyInjectionCodeGetsGeneratedAsExpected(JctCompiler compiler) {
     // Given
-    try (var workspace = Workspaces.newWorkspace()) {
+    try (var workspace = Workspaces.newWorkspace(PathStrategy.TEMP_DIRECTORIES)) {
       workspace
           .createSourcePathPackage()
           .copyContentsFrom("src", "test", "resources", "code");

--- a/java-compiler-testing/src/it/avaje-inject/src/test/resources/code/module-info.java
+++ b/java-compiler-testing/src/it/avaje-inject/src/test/resources/code/module-info.java
@@ -18,5 +18,5 @@ module org.example {
 
   requires io.avaje.inject;
 
-  provides io.avaje.inject.spi.Module with org.example.ExampleModule;
+  provides io.avaje.inject.spi.AvajeModule with org.example.ExampleModule;
 }

--- a/java-compiler-testing/src/it/dagger/pom.xml
+++ b/java-compiler-testing/src/it/dagger/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for Google Dagger.</description>
 
   <properties>
-    <dagger.version>2.51.1</dagger.version>
+    <dagger.version>2.54</dagger.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/google-auto-value/pom.xml
+++ b/java-compiler-testing/src/it/google-auto-value/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for Google AutoValue.</description>
 
   <properties>
-    <auto-value.version>1.10.4</auto-value.version>
+    <auto-value.version>1.11.0</auto-value.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/google-error-prone/pom.xml
+++ b/java-compiler-testing/src/it/google-error-prone/pom.xml
@@ -50,7 +50,7 @@
       -DmvnArgLinePropagated=true
     </argLine>
 
-    <error-prone.version>2.28.0</error-prone.version>
+    <error-prone.version>2.36.0</error-prone.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/google-error-prone/src/test/java/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.java
+++ b/java-compiler-testing/src/it/google-error-prone/src/test/java/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.java
@@ -56,7 +56,11 @@ class ErrorProneTest {
 
     // When
     var compilation = compiler
-        .addCompilerOptions("-Xplugin:ErrorProne", "-XDcompilePolicy=simple")
+        .addCompilerOptions(
+            "-Xplugin:ErrorProne",
+            "-XDcompilePolicy=simple",
+            "--should-stop=ifError=FLOW"
+        )
         .compile(workspace);
 
     // Then
@@ -74,7 +78,11 @@ class ErrorProneTest {
 
     // When
     var compilation = compiler
-        .addCompilerOptions("-Xplugin:ErrorProne", "-XDcompilePolicy=simple")
+        .addCompilerOptions(
+            "-Xplugin:ErrorProne",
+            "-XDcompilePolicy=simple",
+            "--should-stop=ifError=FLOW"
+        )
         .compile(workspace);
 
     // Then

--- a/java-compiler-testing/src/it/invoker-debug.properties
+++ b/java-compiler-testing/src/it/invoker-debug.properties
@@ -1,3 +1,3 @@
-invoker.mavenOpts = -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005
+invoker.mavenOpts = -Dmaven.surefire.debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005" -Dmaven.failsafe.debug="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005"
 invoker.quiet = false
 invoker.timeoutInSeconds = 0

--- a/java-compiler-testing/src/it/invoker-debug.properties
+++ b/java-compiler-testing/src/it/invoker-debug.properties
@@ -1,0 +1,3 @@
+invoker.mavenOpts = -agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=localhost:5005
+invoker.quiet = false
+invoker.timeoutInSeconds = 0

--- a/java-compiler-testing/src/it/lombok/pom.xml
+++ b/java-compiler-testing/src/it/lombok/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for Lombok.</description>
 
   <properties>
-    <lombok.version>1.18.32</lombok.version>
+    <lombok.version>1.18.36</lombok.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/mapstruct/pom.xml
+++ b/java-compiler-testing/src/it/mapstruct/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for MapStruct.</description>
 
   <properties>
-    <mapstruct.version>1.5.5.Final</mapstruct.version>
+    <mapstruct.version>1.6.3</mapstruct.version>
   </properties>
 
   <dependencies>

--- a/java-compiler-testing/src/it/micronaut/pom.xml
+++ b/java-compiler-testing/src/it/micronaut/pom.xml
@@ -31,20 +31,8 @@
   <description>Acceptance tests for Micronaut.</description>
 
   <properties>
-    <micronaut-bom.version>3.10.4</micronaut-bom.version>
+    <micronaut.version>4.7.9</micronaut.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>io.micronaut</groupId>
-        <artifactId>micronaut-bom</artifactId>
-        <version>${micronaut-bom.version}</version>
-        <scope>import</scope>
-        <type>pom</type>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -57,21 +45,19 @@
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-http-server-netty</artifactId>
+      <version>${micronaut.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-inject</artifactId>
+      <version>${micronaut.version}</version>
     </dependency>
 
     <dependency>
       <groupId>io.micronaut</groupId>
       <artifactId>micronaut-inject-java</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
+      <version>${micronaut.version}</version>
     </dependency>
 
     <dependency>

--- a/java-compiler-testing/src/it/spring/pom.xml
+++ b/java-compiler-testing/src/it/spring/pom.xml
@@ -31,7 +31,7 @@
   <description>Acceptance tests for Spring Framework.</description>
 
   <properties>
-    <spring-boot.version>3.3.0</spring-boot.version>
+    <spring-boot.version>3.4.1</spring-boot.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
- Bump versions of components used in integration tests (other than avaje-jsonb, looks like this is not working correctly under a newer version, so that has been deferred).
- Add mechanism to allow attaching a remote debugger to tests via a Maven profile.