### PR TITLE
Use edge Lombok for JDK24 support

### DIFF
--- a/java-compiler-testing/src/it/lombok/pom.xml
+++ b/java-compiler-testing/src/it/lombok/pom.xml
@@ -30,8 +30,15 @@
   <name>JCT acceptance tests for Lombok</name>
   <description>Acceptance tests for Lombok.</description>
 
+  <repositories>
+    <repository>
+      <id>projectlombok.org</id>
+      <url>https://projectlombok.org/edge-releases</url>
+    </repository>
+  </repositories>
+
   <properties>
-    <lombok.version>1.18.36</lombok.version>
+    <lombok.version>edge-SNAPSHOT</lombok.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Use edge version of Lombok to avoid JDK 24 failures until https://github.com/projectlombok/lombok/issues/3847#issuecomment-2762621662 is released as GA.