### PR TITLE
Implement nullability analysis, fix errorprone and nullability issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,11 +13,6 @@ updates:
       - ci
   - package-ecosystem: maven
     directory: /
-    groups:
-      # Group all Maven updates into a single PR.
-      maven:
-        patterns:
-          - "*"
     open-pull-requests-limit: 99
     rebase-strategy: auto
     schedule:

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,2 +1,15 @@
--XX:+TieredCompilation
+-Xshare:auto
 -XX:TieredStopAtLevel=1
+-XX:+CrashOnOutOfMemoryError
+-XX:+TieredCompilation
+-XX:+UseParallelGC
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/java-compiler-testing/pom.xml
+++ b/java-compiler-testing/pom.xml
@@ -115,7 +115,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <compilerArgs>
+          <annotationProcessorPaths combine.children="append"/>
+          <compilerArgs combine.children="append">
             <!--
               Disable warnings about modules. We cannot do much about some of these due to how Maven
               works with modules with Surefire.
@@ -212,6 +213,70 @@
             </plugin>
           </plugins>
         </pluginManagement>
+      </build>
+    </profile>
+
+    <profile>
+      <!-- ErrorProne only works with Java 21 and newer. If we're on Java 17, we cannot
+           enable it within the compiler. This is somewhat unfortunate but should be okay
+           as a workaround for now since we build on multiple JDKs on GitHub. -->
+      <id>errorprone</id>
+      <activation>
+        <jdk>[21,)</jdk>
+      </activation>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+
+            <configuration>
+              <annotationProcessorPaths>
+                <annotationProcessorPath>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${errorprone.version}</version>
+                </annotationProcessorPath>
+                <annotationProcessorPath>
+                  <!-- Override what Maven is pulling in. This is fine during compilation as our
+                       code doesn't use Guava at all. This is needed for ErrorProne to not crash
+                       on startup. -->
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava</artifactId>
+                  <version>[33,)</version>
+                </annotationProcessorPath>
+                <annotationProcessorPath>
+                  <groupId>com.uber.nullaway</groupId>
+                  <artifactId>nullaway</artifactId>
+                  <version>${nullaway.version}</version>
+                </annotationProcessorPath>
+              </annotationProcessorPaths>
+
+              <compilerArgs>
+                <!--
+                  Disable warnings about modules. We cannot do much about some of these due to how Maven
+                  works with modules with Surefire.
+                -->
+                <arg>-Xlint:-module</arg>
+                <!-- ErrorProne configuration -->
+                <compilerArg>--should-stop=ifError=FLOW</compilerArg>
+                <compilerArg>
+                  -Xplugin:ErrorProne
+                  -XepDisableWarningsInGeneratedCode
+                  -XepExcludedPaths:.*/target/generated.*?/.*
+                  -XepOpt:NullAway:AnnotatedPackages=io.github.ascopes.jct
+                  <!-- See https://github.com/uber/NullAway/issues/1319 -->
+                  -XepOpt:NullAway:ExcludedFieldAnnotations=org.junit.jupiter.*,org.mockito.*
+                  -XepOpt:NullAway:KnownInitializers=io.github.ascopes.jct.annotations.Initializer,io.github.ascopes.jct.junit.Managed
+                </compilerArg>
+                <!-- Needed for ErrorProne to be able to run -->
+                <compilerArg>-XDaddTypeAnnotationsToSymbol=true</compilerArg>
+                <compilerArg>-XDcompilePolicy=simple</compilerArg>
+              </compilerArgs>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>

--- a/java-compiler-testing/src/it/google-error-prone/pom.xml
+++ b/java-compiler-testing/src/it/google-error-prone/pom.xml
@@ -49,8 +49,6 @@
       <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-317391 -->
       -DmvnArgLinePropagated=true
     </argLine>
-
-    <error-prone.version>2.36.0</error-prone.version>
   </properties>
 
   <dependencies>
@@ -64,7 +62,7 @@
     <dependency>
       <groupId>com.google.errorprone</groupId>
       <artifactId>error_prone_core</artifactId>
-      <version>${error-prone.version}</version>
+      <version>${errorprone.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/java-compiler-testing/src/it/google-error-prone/src/test/java/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.java
+++ b/java-compiler-testing/src/it/google-error-prone/src/test/java/io/github/ascopes/jct/acceptancetests/errorprone/ErrorProneTest.java
@@ -57,6 +57,7 @@ class ErrorProneTest {
     // When
     var compilation = compiler
         .addCompilerOptions(
+            "-XDaddTypeAnnotationsToSymbol=true",
             "-Xplugin:ErrorProne",
             "-XDcompilePolicy=simple",
             "--should-stop=ifError=FLOW"
@@ -79,6 +80,7 @@ class ErrorProneTest {
     // When
     var compilation = compiler
         .addCompilerOptions(
+            "-XDaddTypeAnnotationsToSymbol=true",
             "-Xplugin:ErrorProne",
             "-XDcompilePolicy=simple",
             "--should-stop=ifError=FLOW"

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/annotations/DeadCodeGenerated.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/annotations/DeadCodeGenerated.java
@@ -13,10 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Use bsh rather than groovy since groovy does not support arbitrary JVM bytecode versions.
-if (Runtime.version().major() < 21) {
-  System.out.println("Micronaut does not support JVMs before Java 21");
-  return false;
-} else {
-  return true;
+package io.github.ascopes.jct.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method as being known to have uncoverable code-paths by design.
+ *
+ * <p>The {@code Generated} suffix tells JaCoCo to ignore coverage for this method.
+ *
+ * @author Ashley Scopes
+ * @since 6.0.1
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.CONSTRUCTOR, ElementType.METHOD, ElementType.TYPE})
+public @interface DeadCodeGenerated {
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/annotations/Initializer.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/annotations/Initializer.java
@@ -13,10 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Use bsh rather than groovy since groovy does not support arbitrary JVM bytecode versions.
-if (Runtime.version().major() < 21) {
-  System.out.println("Micronaut does not support JVMs before Java 21");
-  return false;
-} else {
-  return true;
+package io.github.ascopes.jct.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks the annotation as being an initialiser annotation, which keeps NullAway happy.
+ *
+ * @author Ashley Scopes
+ * @since 6.0.1
+ */
+@Documented
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.ANNOTATION_TYPE)
+public @interface Initializer {
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/annotations/package-info.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/annotations/package-info.java
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-// Use bsh rather than groovy since groovy does not support arbitrary JVM bytecode versions.
-if (Runtime.version().major() < 21) {
-  System.out.println("Micronaut does not support JVMs before Java 21");
-  return false;
-} else {
-  return true;
-}
+/**
+ * Annotations used for various metadata purposes.
+ */
+package io.github.ascopes.jct.annotations;

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractEnumAssert.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/assertions/AbstractEnumAssert.java
@@ -36,12 +36,11 @@ public abstract class AbstractEnumAssert<A extends AbstractEnumAssert<A, E>, E e
     extends AbstractAssert<A, E> {
 
   /**
-   * Initialize this enum assertion.
+   * Initialise this enum assertion.
    *
    * @param value    the value to assert upon.
    * @param selfType the type of this assertion implementation.
    */
-  @SuppressWarnings("DataFlowIssue")
   protected AbstractEnumAssert(@Nullable E value, Class<?> selfType) {
     super(value, selfType);
   }
@@ -139,6 +138,6 @@ public abstract class AbstractEnumAssert<A extends AbstractEnumAssert<A, E>, E e
   }
 
   private String description() {
-    return String.format("%s enum value <%s>", actual.getClass().getSimpleName(), actual);
+    return String.format("%s enum value <%s>", actual.getDeclaringClass().getSimpleName(), actual);
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/JctCompiler.java
@@ -621,8 +621,11 @@ public interface JctCompiler {
    * @throws UnsupportedOperationException if the compiler does not support integer versions.
    * @throws NullPointerException if the release is null.
    */
+
   default JctCompiler release(SourceVersion release) {
-    return release(Integer.toString(release.ordinal()));
+    @SuppressWarnings("EnumOrdinal")
+    var ordinal = release.ordinal();
+    return release(Integer.toString(ordinal));
   }
 
   /**
@@ -718,7 +721,9 @@ public interface JctCompiler {
    * @throws NullPointerException          if the source is null.
    */
   default JctCompiler source(SourceVersion source) {
-    return source(Integer.toString(source.ordinal()));
+    @SuppressWarnings("EnumOrdinal")
+    var ordinal = source.ordinal();
+    return source(Integer.toString(ordinal));
   }
 
   /**
@@ -795,7 +800,9 @@ public interface JctCompiler {
    * @throws NullPointerException          if the target is null.
    */
   default JctCompiler target(SourceVersion target) {
-    return target(Integer.toString(target.ordinal()));
+    @SuppressWarnings("EnumOrdinal")
+    var ordinal = target.ordinal();
+    return target(Integer.toString(ordinal));
   }
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImpl.java
@@ -80,6 +80,7 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler {
     // than utility methods, as this prevents compilation problems on various
     // versions of the JDK when certain members are unavailable.
 
+    @SuppressWarnings("EnumOrdinal")
     var latestSupported = SourceVersion.latestSupported().ordinal();
 
     if (latestSupported >= JAVA_20) {
@@ -99,6 +100,9 @@ public final class JavacJctCompilerImpl extends AbstractJctCompiler {
    * @since 1.0.0
    */
   public static int getLatestSupportedVersionInt() {
-    return SourceVersion.latestSupported().ordinal();
+    @SuppressWarnings("EnumOrdinal")
+    var ordinal = SourceVersion.latestSupported().ordinal();
+
+    return ordinal;
   }
 }

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/containers/impl/PathWrappingContainerImpl.java
@@ -106,7 +106,7 @@ public final class PathWrappingContainerImpl implements Container {
    * <p>This implementation returns the same value as {@link #getPathRoot}, since this
    * implementation is not an opaque wrapper for an archive or serialized resource.
    *
-   * @returns the path root.
+   * @return the path root.
    */
   @Override
   public PathRoot getInnerPathRoot() {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/diagnostics/TeeWriter.java
@@ -35,14 +35,14 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public final class TeeWriter extends Writer {
 
-  private final Lock lock;
+  private final Lock operationLock;
 
   private volatile boolean closed;
 
   private final Writer writer;
 
-  // We use a StringBuilder and manually synchronise it rather than
-  // a string buffer, as we want to manually synchronise the builder
+  // We use a StringBuilder and manually synchronize it rather than
+  // a string buffer, as we want to manually synchronize the builder
   // and the delegated output writer at the same time.
   private final StringBuilder builder;
 
@@ -52,7 +52,7 @@ public final class TeeWriter extends Writer {
    * @param writer the underlying writer to "tee" to.
    */
   public TeeWriter(Writer writer) {
-    lock = new ReentrantLock();
+    operationLock = new ReentrantLock();
     closed = false;
 
     this.writer = requireNonNull(writer, "writer");
@@ -64,7 +64,7 @@ public final class TeeWriter extends Writer {
   public void close() throws IOException {
     // release to set and acquire to check ensures in-order operations to prevent
     // a very minute chance of a race condition.
-    lock.lock();
+    operationLock.lock();
     try {
       if (!closed) {
         closed = true;
@@ -73,18 +73,18 @@ public final class TeeWriter extends Writer {
         writer.close();
       }
     } finally {
-      lock.unlock();
+      operationLock.unlock();
     }
   }
 
   @Override
   public void flush() throws IOException {
-    lock.lock();
+    operationLock.lock();
     try {
       ensureOpen();
       writer.flush();
     } finally {
-      lock.unlock();
+      operationLock.unlock();
     }
   }
 
@@ -95,11 +95,11 @@ public final class TeeWriter extends Writer {
    * @since 0.2.1
    */
   public String getContent() {
-    lock.lock();
+    operationLock.lock();
     try {
       return builder.toString();
     } finally {
-      lock.unlock();
+      operationLock.unlock();
     }
   }
 
@@ -116,7 +116,7 @@ public final class TeeWriter extends Writer {
 
   @Override
   public void write(char[] buffer, int offset, int length) throws IOException {
-    lock.lock();
+    operationLock.lock();
     try {
       ensureOpen();
 
@@ -125,7 +125,7 @@ public final class TeeWriter extends Writer {
       // operation has completed.
       builder.append(buffer, offset, length);
     } finally {
-      lock.unlock();
+      operationLock.unlock();
     }
   }
 

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/JctFileManager.java
@@ -326,6 +326,7 @@ public interface JctFileManager extends JavaFileManager {
    * @throws IllegalStateException    if {@link #close} has been called and this file manager cannot
    *                                  be reopened.
    */
+  @Override
   boolean handleOption(String current, Iterator<String> remaining);
 
   /**
@@ -334,6 +335,7 @@ public interface JctFileManager extends JavaFileManager {
    * @param location a location.
    * @return true if the location is known to this file manager.
    */
+  @Override
   boolean hasLocation(Location location);
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurerChain.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerConfigurerChain.java
@@ -16,7 +16,8 @@
 package io.github.ascopes.jct.filemanagers.config;
 
 import io.github.ascopes.jct.filemanagers.JctFileManager;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,13 +53,13 @@ public final class JctFileManagerConfigurerChain {
 
   private static final Logger log = LoggerFactory.getLogger(JctFileManagerConfigurerChain.class);
 
-  private final LinkedList<JctFileManagerConfigurer> configurers;
+  private final Deque<JctFileManagerConfigurer> configurers;
 
   /**
    * Initialise this chain.
    */
   public JctFileManagerConfigurerChain() {
-    configurers = new LinkedList<>();
+    configurers = new ArrayDeque<>();
   }
 
   /**

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/junit/Managed.java
@@ -15,6 +15,7 @@
  */
 package io.github.ascopes.jct.junit;
 
+import io.github.ascopes.jct.annotations.Initializer;
 import io.github.ascopes.jct.workspaces.PathStrategy;
 import io.github.ascopes.jct.workspaces.Workspace;
 import java.lang.annotation.Documented;
@@ -55,6 +56,7 @@ import java.lang.annotation.Target;
  * @since 0.4.0
  */
 @Documented
+@Initializer
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Managed {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/LoomPolyfill.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/LoomPolyfill.java
@@ -15,6 +15,8 @@
  */
 package io.github.ascopes.jct.utils;
 
+import io.github.ascopes.jct.annotations.DeadCodeGenerated;
+
 /**
  * Polyfill to enable supporting using the newer Thread APIs on newer platforms.
  *
@@ -38,6 +40,7 @@ public final class LoomPolyfill {
    * @param thread the thread to use.
    * @return the thread ID.
    */
+  @DeadCodeGenerated
   public static long getThreadId(Thread thread) {
     // Note: this test will never get 100% coverage on one JDK, because it totally depends on the
     // JDK in use as to which code path runs.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringUtils.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/StringUtils.java
@@ -43,7 +43,6 @@ public final class StringUtils {
   // Other stuff
   private static final char LF = '\n';
   private static final String NULL_STRING = "null";
-  private static final String EMPTY_STRING = "";
 
   private StringUtils() {
     // Disallow initialisation.
@@ -75,7 +74,7 @@ public final class StringUtils {
       CharSequence lastConnector
   ) {
     if (words.isEmpty()) {
-      return EMPTY_STRING;
+      return "";
     }
 
     if (words.size() == 1) {

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ToStringBuilder.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/utils/ToStringBuilder.java
@@ -142,7 +142,7 @@ public final class ToStringBuilder {
         case '\"' -> builder.append("\\\"");
         case '\\' -> builder.append("\\\\");
         default -> {
-          if (0x20 <= next && next <= 0x7E || 0x80 <= next && next <= 0xFF) {
+          if ((0x20 <= next && next <= 0x7E) || (0x80 <= next && next <= 0xFF)) {
             builder.append(next);
           } else {
             var hex = Integer.toHexString(next);

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/PathStrategy.java
@@ -71,6 +71,7 @@ public enum PathStrategy {
    */
   TEMP_DIRECTORIES(TempDirectoryImpl::newTempDirectory);
 
+  @SuppressWarnings("ImmutableEnumChecker")
   private final Function<String, AbstractManagedDirectory> constructor;
 
   PathStrategy(Function<String, AbstractManagedDirectory> constructor) {
@@ -98,7 +99,7 @@ public enum PathStrategy {
    * Determine the default strategy to fall back onto.
    *
    * <p>This will be {@link #RAM_DIRECTORIES} by default, but this may be subject to change between
-   * minor versions without notice, so do not rely on this if you are testing code that may be
+   * minor versions without notice. Do not rely on this if you are testing code that may be
    * sensitive to the type of file system being used.
    *
    * @return the path strategy to use by default.

--- a/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
+++ b/java-compiler-testing/src/main/java/io/github/ascopes/jct/workspaces/impl/WorkspaceImpl.java
@@ -123,7 +123,7 @@ public final class WorkspaceImpl implements Workspace {
   @Override
   public void addModule(Location location, String moduleName, Path path) {
     requireNonNull(location, "location");
-    requireNonNull(location, "moduleName");
+    requireNonNull(moduleName, "moduleName");
     requireNonNull(path, "path");
 
     if (!location.isModuleOrientedLocation() && !location.isOutputLocation()) {
@@ -159,7 +159,7 @@ public final class WorkspaceImpl implements Workspace {
   @Override
   public ManagedDirectory createModule(Location location, String moduleName) {
     requireNonNull(location, "location");
-    requireNonNull(location, "moduleName");
+    requireNonNull(moduleName, "moduleName");
 
     if (!location.isModuleOrientedLocation() && !location.isOutputLocation()) {
       throw new JctIllegalInputException(

--- a/java-compiler-testing/src/main/java/module-info.java
+++ b/java-compiler-testing/src/main/java/module-info.java
@@ -119,10 +119,6 @@ import org.jspecify.annotations.NullMarked;
 @NullMarked
 module io.github.ascopes.jct {
 
-  ////////////////////
-  /// DEPENDENCIES ///
-  ////////////////////
-
   requires transitive com.github.marschall.memoryfilesystem;
   requires transitive java.compiler;
   requires transitive java.management;
@@ -133,10 +129,7 @@ module io.github.ascopes.jct {
   requires static transitive org.junit.jupiter.params;
   requires transitive org.slf4j;
 
-  //////////////////
-  /// PUBLIC API ///
-  //////////////////
-
+  exports io.github.ascopes.jct.annotations;
   exports io.github.ascopes.jct.assertions;
   exports io.github.ascopes.jct.containers;
   exports io.github.ascopes.jct.compilers;
@@ -147,10 +140,6 @@ module io.github.ascopes.jct {
   exports io.github.ascopes.jct.junit;
   exports io.github.ascopes.jct.repr;
   exports io.github.ascopes.jct.workspaces;
-
-  ///////////////////////////////////
-  /// SERVICE PROVIDER INTERFACES ///
-  ///////////////////////////////////
 
   provides URLStreamHandlerProvider with MemoryFileSystemUrlHandlerProvider;
 }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/AbstractContainerGroupAssertTest.java
@@ -85,6 +85,7 @@ class AbstractContainerGroupAssertTest {
   class ServicesTest {
 
     @DisplayName(".services() throws a NullPointerException if the class parameter is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void servicesThrowsNullPointerExceptionIfClassParameterIsNull() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/AbstractEnumAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/AbstractEnumAssertTest.java
@@ -56,6 +56,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we assert against a single null element")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNullOnSingleElement() {
       // Given
@@ -67,6 +68,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we assert against a null array")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNullArray() {
       // Given
@@ -78,6 +80,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we against multiple null elements")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNullOnMultipleElements() {
       // Given
@@ -170,6 +173,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we assert against a null iterable")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNull() {
       // Given
@@ -259,6 +263,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we assert against a single null element")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNullOnSingleElement() {
       // Given
@@ -270,6 +275,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we assert against a null array")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNullOnMultipleElementsArray() {
       // Given
@@ -281,6 +287,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we against multiple null elements")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNullOnMultipleElements() {
       // Given
@@ -361,6 +368,7 @@ class AbstractEnumAssertTest {
     }
 
     @DisplayName("Expect error if we assert against a null iterable")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void errorsIfExpectedIsNull() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/AbstractJavaFileObjectAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/AbstractJavaFileObjectAssertTest.java
@@ -196,6 +196,7 @@ class AbstractJavaFileObjectAssertTest {
     }
 
     @DisplayName(".content(Charset) fails if the charset is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void charsetArgsFailsIfCharsetIsNull() {
       // Given
@@ -241,6 +242,7 @@ class AbstractJavaFileObjectAssertTest {
     }
 
     @DisplayName(".content(CharsetDecoder) fails if the charset is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void charsetDecoderArgsFailsIfCharsetIsNull() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/JctCompilationAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/JctCompilationAssertTest.java
@@ -475,6 +475,7 @@ class JctCompilationAssertTest {
     }
 
     @DisplayName(".packageGroup(...) fails if the compilation is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void packageGroupFailsIfLocationIsNull() {
       // Given
@@ -585,6 +586,7 @@ class JctCompilationAssertTest {
     }
 
     @DisplayName(".moduleGroup(...) fails if the compilation is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void moduleGroupFailsIfLocationIsNull() {
       // Given
@@ -694,6 +696,7 @@ class JctCompilationAssertTest {
     }
 
     @DisplayName(".outputGroup(...) fails if the compilation is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void outputGroupFailsIfLocationIsNull() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/ModuleContainerGroupAssertTest.java
@@ -45,6 +45,7 @@ class ModuleContainerGroupAssertTest {
   class ModuleExistsTest {
 
     @DisplayName(".moduleExists(...) fails if the module name is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void moduleExistsFailsIfModuleNameIsNull() {
       // Given
@@ -68,6 +69,7 @@ class ModuleContainerGroupAssertTest {
     }
 
     @DisplayName(".moduleExists(...) fails with fuzzy suggestions when the module does not exist")
+    @SuppressWarnings({"NullAway", "StringConcatToTextBlock"})
     @Test
     void moduleExistsFailsWithFuzzySuggestionsWhenTheModuleDoesNotExist() {
       // Given
@@ -124,6 +126,7 @@ class ModuleContainerGroupAssertTest {
   class ModuleDoesNotExistTest {
 
     @DisplayName(".moduleDoesNotExist(...) fails if the module name is null")
+    @SuppressWarnings({"NullAway", "DataFlowIssue"})
     @Test
     void moduleDoesNotExistFailsIfModuleNameIsNull() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/PackageContainerGroupAssertTest.java
@@ -38,12 +38,13 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.spi.FileSystemProvider;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.zip.ZipOutputStream;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -62,7 +63,7 @@ class PackageContainerGroupAssertTest {
   class AllFilesExistStringArrayTest {
 
     @DisplayName(".allFilesExist(String...) throws an exception if the array is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void allFilesExistThrowsExceptionIfArrayIsNull() {
       // Given
@@ -75,7 +76,7 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".allFilesExist(String...) throws an exception if the array has null values")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void allFilesExistThrowsExceptionIfArrayHasNullValues() {
       // Given
@@ -125,7 +126,7 @@ class PackageContainerGroupAssertTest {
   class AllFilesExistStringIterableTest {
 
     @DisplayName(".allFilesExist(Iterable<String>) throws an exception if the iterable is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void allFilesExistThrowsExceptionIfIterableIsNull() {
       // Given
@@ -140,14 +141,20 @@ class PackageContainerGroupAssertTest {
     @DisplayName(
         ".allFilesExist(Iterable<String>) throws an exception if the iterable has null members"
     )
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void allFilesExistThrowsExceptionIfIterableHasNullMembers() {
       // Given
+      var files = new ArrayList<@Nullable String>();
+      files.add("foo");
+      files.add("bar");
+      files.add(null);
+
       var assertions = new PackageContainerGroupAssert(mock());
 
       // Then
       // Arrays#asList does not NPE if any members are null. List#of does throw NPE.
-      assertThatThrownBy(() -> assertions.allFilesExist(Arrays.asList("foo", "bar", null)))
+      assertThatThrownBy(() -> assertions.allFilesExist(files))
           .isInstanceOf(NullPointerException.class)
           .hasMessage("paths[2]");
     }
@@ -247,7 +254,7 @@ class PackageContainerGroupAssertTest {
   class FileDoesNotExistTest {
 
     @DisplayName(".fileDoesNotExist(String...) throws an exception if the array is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void fileDoesNotExistThrowsExceptionIfArrayIsNull() {
       // Given
@@ -260,7 +267,7 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".fileDoesNotExist(String...) throws an exception if the array has null values")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void fileDoesNotExistThrowsExceptionIfArrayHasNullValues() {
       // Given
@@ -299,7 +306,6 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".fileDoesNotExist(String...) fails if the file exists")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void fileDoesNotExistFailsIfFileExists() {
       // Given
@@ -324,7 +330,6 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".fileDoesNotExist(String...) succeeds if the file does not exist")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void fileDoesNotExistSucceedsIfFileDoesNotExist() {
       // Given
@@ -351,7 +356,7 @@ class PackageContainerGroupAssertTest {
   class FileExistsTest {
 
     @DisplayName(".fileExists(String...) throws an exception if the array is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void fileExistsThrowsExceptionIfArrayIsNull() {
       // Given
@@ -364,7 +369,7 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".fileExists(String...) throws an exception if the array has null values")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void fileExistsThrowsExceptionIfArrayHasNullValues() {
       // Given
@@ -402,7 +407,6 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".fileExists(String...) fails with fuzzy suggestions if the file does not exist")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void fileExistsFailsWithFuzzySuggestionsIfTheFileDoesNotExist() throws IOException {
       // Given
@@ -478,7 +482,6 @@ class PackageContainerGroupAssertTest {
     }
 
     @DisplayName(".fileExists(String...) succeeds if the file exists")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void fileExistsSucceedsIfFileExists() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssertTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/assertions/TraceDiagnosticListAssertTest.java
@@ -326,7 +326,7 @@ class TraceDiagnosticListAssertTest {
   class FilteringByKindsVarargsTest {
 
     @DisplayName(".filteringByKinds(Kind...) fails if the vararg array is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfVarargArrayIsNull() {
       // Given
@@ -339,7 +339,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".filteringByKinds(Kind...) fails if any varargs are null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfAnyVarargsAreNull() {
       // Given
@@ -375,6 +375,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".filteringByKinds(Kind...) filters diagnostics by kind")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void filtersDiagnosticsByKind() {
       // Given
@@ -408,7 +409,7 @@ class TraceDiagnosticListAssertTest {
   class FilteringByKindsIterableTest {
 
     @DisplayName(".filteringByKinds(Iterable<Kind>) fails if the iterable is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfKindIterableIsNull() {
       // Given
@@ -421,6 +422,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".filteringByKinds(Iterable<Kind>) fails if any kinds are null")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void failsIfAnyKindsAreNull() {
       // Given
@@ -444,6 +446,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".filteringByKinds(Iterable<Kind>) filters diagnostics by kind")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void filtersDiagnosticsByKind() {
       // Given
@@ -477,7 +480,7 @@ class TraceDiagnosticListAssertTest {
   class ExcludingKindsVarargsTest {
 
     @DisplayName(".excludingKinds(Kind...) fails if the vararg array is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfVarargArrayIsNull() {
       // Given
@@ -490,7 +493,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".excludingKinds(Kind...) fails if any varargs are null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfAnyVarargsAreNull() {
       // Given
@@ -526,6 +529,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".excludingKinds(Kind...) filters diagnostics by kind")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void filtersDiagnosticsByKind() {
       // Given
@@ -560,7 +564,7 @@ class TraceDiagnosticListAssertTest {
   class ExcludingKindsIterableTest {
 
     @DisplayName(".excludingKinds(Iterable<Kind>) fails if the iterable is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfKindIterableIsNull() {
       // Given
@@ -573,6 +577,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".excludingKinds(Iterable<Kind>) fails if any kinds are null")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void failsIfAnyKindsAreNull() {
       // Given
@@ -596,6 +601,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".excludingKinds(Iterable<Kind>) filters diagnostics by kind")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void filtersDiagnosticsByKind() {
       // Given
@@ -1016,7 +1022,7 @@ class TraceDiagnosticListAssertTest {
   class HasNoDiagnosticsOfKindsVarargsTest {
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Kind...) fails if the vararg array is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfVarargArrayIsNull() {
       // Given
@@ -1029,7 +1035,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Kind...) fails if any varargs are null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfAnyVarargsAreNull() {
       // Given
@@ -1066,7 +1072,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Kind...) fails if any provided kinds are present")
-    @SuppressWarnings("ConstantValue")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void failsIfAnyProvidedKindsArePresent() {
       // Given
@@ -1100,6 +1106,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Kind...) succeeds if no provided kinds are present")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void succeedsIfNoProvidedKindsArePresent() {
       // Given
@@ -1126,7 +1133,7 @@ class TraceDiagnosticListAssertTest {
   class HasNoDiagnosticsOfKindsIterableTest {
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Iterable<Kind>) fails if the iterable is null")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void failsIfIterableIsNull() {
       // Given
@@ -1139,6 +1146,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Iterable<Kind>) fails if the iterable has null members")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void failsIfIterableHasNullMembers() {
       // Given
@@ -1163,7 +1171,7 @@ class TraceDiagnosticListAssertTest {
     }
 
     @DisplayName(".hasNoDiagnosticsOfKinds(Iterable<Kind>) fails if any provided kinds are present")
-    @SuppressWarnings("ConstantValue")
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void failsIfAnyProvidedKindsArePresent() {
       // Given
@@ -1199,6 +1207,7 @@ class TraceDiagnosticListAssertTest {
     @DisplayName(
         ".hasNoDiagnosticsOfKinds(Iterable<Kind>) succeeds if no provided kinds are present"
     )
+    @SuppressWarnings({"NullAway", "NullableProblems"})
     @Test
     void succeedsIfNoProvidedKindsArePresent() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/AbstractJctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/AbstractJctCompilerTest.java
@@ -117,6 +117,7 @@ class AbstractJctCompilerTest {
   class ConstructorTest {
 
     @DisplayName("constructor raises a NullPointerException if name is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void constructorRaisesNullPointerExceptionIfNameIsNull() {
       // Then
@@ -511,6 +512,7 @@ class AbstractJctCompilerTest {
   class ConfigureTest {
 
     @DisplayName(".configure(...) raises a NullPointerException if the input is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void configureRaisesNullPointerExceptionOnNullInput() {
       // Then
@@ -611,6 +613,7 @@ class AbstractJctCompilerTest {
     }
 
     @DisplayName(".name(null) throws a NullPointerException")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void passingNullToNameThrowsNullPointerException() {
       // Then
@@ -1385,6 +1388,7 @@ class AbstractJctCompilerTest {
     }
 
     @DisplayName(".locale(...) throws a NullPointerException if the locale is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void localeThrowsNullPointerExceptionIfNull() {
       // Then
@@ -1431,6 +1435,7 @@ class AbstractJctCompilerTest {
     }
 
     @DisplayName(".logCharset(...) throws a NullPointerException if the logCharset is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void logCharsetThrowsNullPointerExceptionIfNull() {
       // Then
@@ -1478,6 +1483,7 @@ class AbstractJctCompilerTest {
 
     @DisplayName(".fileManagerLoggingMode(...) throws a NullPointerException if "
         + "fileManagerLoggingMode is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void fileManagerLoggingModeThrowsNullPointerExceptionIfNull() {
       // Then
@@ -1525,6 +1531,7 @@ class AbstractJctCompilerTest {
 
     @DisplayName(".diagnosticLoggingMode(...) throws a NullPointerException "
         + "if diagnosticLoggingMode is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void diagnosticLoggingModeThrowsNullPointerExceptionIfNull() {
       // Then
@@ -1572,6 +1579,7 @@ class AbstractJctCompilerTest {
 
     @DisplayName(".annotationProcessorDiscovery(...) throws a NullPointerException "
         + "if annotationProcessorDiscovery is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void annotationProcessorDiscoveryThrowsNullPointerExceptionIfNull() {
       // Then
@@ -1622,6 +1630,7 @@ class AbstractJctCompilerTest {
     }
 
     @DisplayName(".debuggingInfo(...) throws a NullPointerException if debugging info is null")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void debuggingInfoThrowsNullPointerExceptionIfNull() {
       // Then

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/JctCompilerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/JctCompilerTest.java
@@ -290,12 +290,13 @@ class JctCompilerTest {
     var thirdClass = "com.organisation.FooBar";
 
     // When
-    var result = compiler.compile(workspace, firstClass, secondClass, thirdClass);
+    compiler.compile(workspace, firstClass, secondClass, thirdClass);
 
     // Then
     then(compiler).should().compile(workspace, List.of(firstClass, secondClass, thirdClass));
   }
 
+  @SuppressWarnings("EnumOrdinal")
   static Stream<Arguments> sourceVersions() {
     return Stream
         .of(SourceVersion.values())

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/impl/JavacJctCompilerImplTest.java
@@ -147,6 +147,7 @@ class JavacJctCompilerImplTest {
       "                    21,              9",
   })
   @ParameterizedTest(name = "expect {1} when using Javac for JDK {0}")
+  @SuppressWarnings({"EnumOrdinal", "ResultOfMethodCallIgnored"})
   void earliestSupportedVersionReturnsTheExpectedValue(int latest, int expectedResult) {
     // Given
     try (var sourceVersionMock = mockStatic(SourceVersion.class)) {
@@ -183,6 +184,7 @@ class JavacJctCompilerImplTest {
       "                    21,             21",
   })
   @ParameterizedTest(name = "expect {1} when using Javac for JDK {0}")
+  @SuppressWarnings({"EnumOrdinal", "ResultOfMethodCallIgnored"})
   void latestSupportedVersionReturnsTheExpectedValue(int latest, int expectedResult) {
     // Given
     try (var sourceVersionMock = mockStatic(SourceVersion.class)) {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/impl/JctCompilationFactoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/impl/JctCompilationFactoryImplTest.java
@@ -111,6 +111,7 @@ class JctCompilationFactoryImplTest {
   }
 
   @DisplayName("Multi-module sources are used when they exist")
+  @SuppressWarnings("DistinctVarargsChecker")
   @Test
   void multiModuleSourcesAreUsedWhenTheyExist() throws IOException {
     // Given
@@ -161,6 +162,7 @@ class JctCompilationFactoryImplTest {
   }
 
   @DisplayName("Legacy sources are used when multi-module sources do not exist")
+  @SuppressWarnings("DistinctVarargsChecker")
   @Test
   void legacySourcesAreUsedWhenMultiModuleSourcesDoNotExist() throws IOException {
     // Given
@@ -403,7 +405,7 @@ class JctCompilationFactoryImplTest {
       "STACKTRACES, true,  true"
   })
   @ParameterizedTest(name = "- LoggingMode.{0} should use new TracingDiagnosticListener({1}, {2})")
-  @SuppressWarnings({"unchecked", "rawtypes", "AssertBetweenInconvertibleTypes"})
+  @SuppressWarnings({"unchecked", "rawtypes"})
   void correctlyConfiguredDiagnosticListenerIsUsedForCompilation(
       LoggingMode loggingMode,
       boolean expectedEnabled,
@@ -652,6 +654,7 @@ class JctCompilationFactoryImplTest {
   }
 
   @DisplayName("Exceptions during compilation get wrapped and rethrown")
+  @SuppressWarnings("MockIllegalThrows")
   @Test
   void exceptionsDuringCompilationGetWrappedAndRethrown() throws IOException {
     // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/impl/JctCompilationImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/compilers/impl/JctCompilationImplTest.java
@@ -219,6 +219,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Building with null arguments raises a NullPointerException")
+    @SuppressWarnings({"NullableProblems", "NullAway"})
     @Test
     void buildingWithNullArgumentsRaisesNullPointerException() {
       // Given
@@ -277,6 +278,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Setting null compilation units raises a NullPointerException")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void settingNullCompilationUnitsRaisesNullPointerException() {
       // Given
@@ -308,6 +310,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Building with null compilation units raises a NullPointerException")
+    @SuppressWarnings({"NullableProblems", "NullAway"})
     @Test
     void buildingWithNullCompilationUnitsRaisesNullPointerException() {
       // Given
@@ -334,6 +337,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Setting null diagnostics raises a NullPointerException")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void settingNullDiagnosticsRaisesNullPointerException() {
       // Given
@@ -365,6 +369,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Building with null diagnostics raises a NullPointerException")
+    @SuppressWarnings("NullAway")
     @Test
     void buildingWithNullDiagnosticsRaisesNullPointerException() {
       // Given
@@ -389,6 +394,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Setting null file managers raises a NullPointerException")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void settingNullFileManagerRaisesNullPointerException() {
       // Given
@@ -420,6 +426,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Setting null output lines raises a NullPointerException")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void settingNullOutputLinesRaisesNullPointerException() {
       // Given
@@ -451,6 +458,7 @@ class JctCompilationImplTest {
     }
 
     @DisplayName("Building with null output lines raises a NullPointerException")
+    @SuppressWarnings({"NullableProblems", "NullAway"})
     @Test
     void buildingWithNullOutputLinesRaisesNullPointerException() {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/containers/impl/ContainerGroupRepositoryImplTest.java
@@ -17,6 +17,7 @@ package io.github.ascopes.jct.containers.impl;
 
 import static io.github.ascopes.jct.fixtures.Fixtures.somePathRoot;
 import static io.github.ascopes.jct.fixtures.Fixtures.someRelease;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.list;
 import static org.mockito.ArgumentMatchers.any;
@@ -111,7 +112,7 @@ class ContainerGroupRepositoryImplTest {
           .hasSize(1)
           .containsKey(moduleLocation);
 
-      var module = modules.get(moduleLocation);
+      var module = requireNonNull(modules.get(moduleLocation), "modules.get");
       assertThat(module.getLocation())
           .as("module group location")
           .isEqualTo(moduleLocation);

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoaderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/containers/impl/PackageContainerGroupUrlClassLoaderTest.java
@@ -16,6 +16,7 @@
 package io.github.ascopes.jct.containers.impl;
 
 import static io.github.ascopes.jct.fixtures.Fixtures.oneOf;
+import static java.util.Objects.requireNonNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -37,6 +38,7 @@ import java.util.List;
 import javax.lang.model.SourceVersion;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -167,6 +169,7 @@ class PackageContainerGroupUrlClassLoaderTest {
    * Since Mockito struggles to mock classloading mechanisms, we make real class files to use in our
    * test cases. This reduces the dependencies on other JCT components for this test.
    */
+  @SuppressWarnings("EffectivelyPrivate")
   private static final class SomeClassFile {
 
     private static final Logger log = LoggerFactory.getLogger(SomeClassFile.class);
@@ -176,7 +179,7 @@ class PackageContainerGroupUrlClassLoaderTest {
     private final String sourceFileName;
     private final String classFileName;
     private final String qualifiedName;
-    private volatile byte[] cachedClassFile;
+    private volatile byte @Nullable[] cachedClassFile;
 
     public SomeClassFile(String packageName, String className) {
       this.packageName = packageName;
@@ -192,7 +195,7 @@ class PackageContainerGroupUrlClassLoaderTest {
       }
 
       var packageDir = path;
-      for (var part : packageName.split("\\.")) {
+      for (var part : packageName.split("\\.", -1)) {
         packageDir = packageDir.resolve(part);
       }
 
@@ -208,7 +211,7 @@ class PackageContainerGroupUrlClassLoaderTest {
       );
 
       try (var stream = Files.newOutputStream(outputFile)) {
-        stream.write(cachedClassFile);
+        stream.write(requireNonNull(cachedClassFile));
       }
     }
 
@@ -217,7 +220,7 @@ class PackageContainerGroupUrlClassLoaderTest {
 
       try {
         var packageDir = dir;
-        for (var part : packageName.split("\\.")) {
+        for (var part : packageName.split("\\.", -1)) {
           packageDir = packageDir.resolve(part);
         }
 
@@ -243,6 +246,7 @@ class PackageContainerGroupUrlClassLoaderTest {
         sfm.setLocation(StandardLocation.SOURCE_PATH, List.of(dir.toFile()));
         sfm.setLocation(StandardLocation.CLASS_OUTPUT, List.of(dir.toFile()));
 
+        @SuppressWarnings("EnumOrdinal")
         var options = List.of("--release", "" + SourceVersion.latestSupported().ordinal());
         var compilationUnits = sfm.getJavaFileObjects(packageDir.resolve(sourceFileName));
 
@@ -257,7 +261,7 @@ class PackageContainerGroupUrlClassLoaderTest {
             "{}.{} compiled to {} bytes of binary data",
             packageName,
             className,
-            cachedClassFile.length
+            requireNonNull(cachedClassFile).length
         );
       } finally {
         Files.walkFileTree(dir, new SimpleFileVisitor<>() {

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/diagnostics/TeeWriterTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/diagnostics/TeeWriterTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 class TeeWriterTest {
 
   @DisplayName("Null writers are disallowed")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void nullWritersAreDisallowed() {
     assertThatCode(() -> new TeeWriter(null))
@@ -180,6 +181,7 @@ class TeeWriterTest {
   }
 
   @DisplayName(".wrapOutputStream(null, Charset) throws a NullPointerException")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void wrapOutputStreamWithNullOutputStreamThrowsNullPointerException() {
     // Then
@@ -189,6 +191,7 @@ class TeeWriterTest {
   }
 
   @DisplayName(".wrapOutputStream(OutputStream, null) throws a NullPointerException")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void wrapOutputStreamWithNullCharsetThrowsNullPointerException() {
     // Then

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/diagnostics/TraceDiagnosticTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/diagnostics/TraceDiagnosticTest.java
@@ -52,6 +52,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class TraceDiagnosticTest {
 
   @DisplayName("null original diagnostics are rejected")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void nullDiagnosticsAreRejected() {
     // Given
@@ -192,6 +193,7 @@ class TraceDiagnosticTest {
   }
 
   @DisplayName("null timestamps are rejected")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void nullTimestampsAreRejected() {
     var diag = someDiagnostic();
@@ -202,6 +204,7 @@ class TraceDiagnosticTest {
   }
 
   @DisplayName("null stack traces are rejected")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void nullStackTracesAreRejected() {
     var now = now();
@@ -310,6 +313,7 @@ class TraceDiagnosticTest {
     assertThat(actualStackTrace).isEqualTo(expectedStackTrace);
   }
 
+  @SuppressWarnings("DataFlowIssue")
   @DisplayName("getStackTrace() returns an immutable list")
   @Test
   void getStackTraceReturnsAnImmutableStackTrace() {
@@ -331,6 +335,7 @@ class TraceDiagnosticTest {
   }
 
   @DisplayName("toString() returns the expected value")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @RepeatedTest(5)
   void toStringReturnsExpectedValue() {
     // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListenerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/diagnostics/TracingDiagnosticListenerTest.java
@@ -138,6 +138,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Diagnostics are logged with the expected timestamp")
   @MethodSource("loggingArgs")
   @ParameterizedTest(name = "for logging={0}, stackTraces={1}")
+  @SuppressWarnings("ReturnValueIgnored")
   void diagnosticsAreLoggedWithTheExpectedTimestamp(boolean logging, boolean stackTraces) {
     // Given
     var listener = new AccessibleImpl<>(logging, stackTraces);
@@ -283,6 +284,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Errors should be logged as errors when stacktraces are disabled")
   @EnumSource(value = Kind.class, names = "ERROR")
   @ParameterizedTest(name = "for kind = {0}")
+  @SuppressWarnings("NullAway")
   void errorsShouldBeLoggedAsErrorsWhenStackTracesAreDisabled(Kind kind) {
     // Given
     var logger = new Slf4jLoggerFake();
@@ -307,6 +309,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Errors should be logged as errors when stacktraces are enabled")
   @EnumSource(value = Kind.class, names = "ERROR")
   @ParameterizedTest(name = "for kind = {0}")
+  @SuppressWarnings("NullAway")
   void errorsShouldBeLoggedAsErrorsWhenStackTracesAreEnabled(Kind kind) {
     // Given
     var logger = new Slf4jLoggerFake();
@@ -341,6 +344,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Warnings should be logged as warnings when stacktraces are disabled")
   @EnumSource(value = Kind.class, names = {"WARNING", "MANDATORY_WARNING"})
   @ParameterizedTest(name = "for kind = {0}")
+  @SuppressWarnings("NullAway")
   void warningsShouldBeLoggedAsWarningsWhenStackTracesAreDisabled(Kind kind) {
     // Given
     var logger = new Slf4jLoggerFake();
@@ -365,6 +369,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Warnings should be logged as warnings when stacktraces are enabled")
   @EnumSource(value = Kind.class, names = {"WARNING", "MANDATORY_WARNING"})
   @ParameterizedTest(name = "for kind = {0}")
+  @SuppressWarnings("NullAway")
   void warningsShouldBeLoggedAsWarningsWhenStackTracesAreEnabled(Kind kind) {
     // Given
     var logger = new Slf4jLoggerFake();
@@ -398,6 +403,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Info should be logged as info when stacktraces are disabled")
   @EnumSource(value = Kind.class, names = {"NOTE", "OTHER"})
   @ParameterizedTest(name = "for kind = {0}")
+  @SuppressWarnings("NullAway")
   void infoShouldBeLoggedAsInfoWhenStackTracesAreDisabled(Kind kind) {
     // Given
     var logger = new Slf4jLoggerFake();
@@ -422,6 +428,7 @@ class TracingDiagnosticListenerTest {
   @DisplayName("Info should be logged as info when stacktraces are enabled")
   @EnumSource(value = Kind.class, names = {"NOTE", "OTHER"})
   @ParameterizedTest(name = "for kind = {0}")
+  @SuppressWarnings("NullAway")
   void infoShouldBeLoggedAsInfoWhenStackTracesAreEnabled(Kind kind) {
     // Given
     var logger = new Slf4jLoggerFake();

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/ModuleLocationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/ModuleLocationTest.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ModuleLocationTest {
 
   @DisplayName("Passing a null parent to the constructor raises an exception")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void passingNullParentToConstructorRaisesException() {
     // Then
@@ -52,6 +53,7 @@ class ModuleLocationTest {
   }
 
   @DisplayName("Passing a null module name to the constructor raises an exception")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void passingNullNameToConstructorRaisesException() {
     // Then
@@ -151,6 +153,7 @@ class ModuleLocationTest {
   }
 
   @DisplayName(".equals(...) returns true for the same object")
+  @SuppressWarnings({"EqualsWithItself", "SelfAssertion"})
   @Test
   void equalsReturnsTrueForSameObject() {
     // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerWorkspaceConfigurerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/config/JctFileManagerWorkspaceConfigurerTest.java
@@ -53,6 +53,7 @@ class JctFileManagerWorkspaceConfigurerTest {
   JctFileManagerWorkspaceConfigurer configurer;
 
   @DisplayName(".configure(...) will copy all workspace paths to the file manager")
+  @SuppressWarnings("DistinctVarargsChecker")
   @Test
   void configureWillCopyAllWorkspacePathsToTheFileManager() {
     // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/impl/JctFileManagerImplTest.java
@@ -103,7 +103,7 @@ class JctFileManagerImplTest {
   }
 
   @DisplayName("Constructor disallows null releases")
-  @SuppressWarnings("resource")
+  @SuppressWarnings({"NullAway", "resource"})
   @Test
   void constructorDisallowsNullReleases() {
     // Then
@@ -1322,6 +1322,7 @@ class JctFileManagerImplTest {
     }
 
     @DisplayName(".list(...) returns the file listing for the location")
+    @SuppressWarnings("DistinctVarargsChecker")
     @Test
     void listReturnsFileListingForTheLocation() throws IOException {
       // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/impl/LoggingFileManagerProxyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/impl/LoggingFileManagerProxyTest.java
@@ -163,6 +163,7 @@ class LoggingFileManagerProxyTest {
   @DisplayName("Method invocations are logged without stacktraces")
   @MethodSource("proxiedMethods")
   @ParameterizedTest(name = "for method {0}")
+  @SuppressWarnings("NullAway")
   void methodInvocationsGetLoggedWithoutStacktraces(String ignored, Method method)
       throws Throwable {
 
@@ -207,6 +208,7 @@ class LoggingFileManagerProxyTest {
   @DisplayName("Method invocations are logged with stacktraces")
   @MethodSource("proxiedMethods")
   @ParameterizedTest(name = "for method {0}")
+  @SuppressWarnings("NullAway")
   void methodInvocationsGetLoggedWithStacktraces(String ignored, Method method) throws Throwable {
     // Given
     try (
@@ -254,6 +256,7 @@ class LoggingFileManagerProxyTest {
   @DisplayName("Method results are logged")
   @MethodSource("proxiedMethods")
   @ParameterizedTest(name = "for method {0}")
+  @SuppressWarnings("NullAway")
   void methodResultsGetLogged(String ignored, Method method) throws Throwable {
     // Given
     try (

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/impl/PathFileObjectImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/filemanagers/impl/PathFileObjectImplTest.java
@@ -55,6 +55,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 class PathFileObjectImplTest {
 
   @DisplayName("Passing a null location to the constructor raises an exception")
+  @SuppressWarnings("NullAway")
   @Test
   void passingNullLocationToConstructorRaisesException() {
     // Then
@@ -64,6 +65,7 @@ class PathFileObjectImplTest {
   }
 
   @DisplayName("Passing a null root path to the constructor raises an exception")
+  @SuppressWarnings("NullAway")
   @Test
   void passingNullRootPathToConstructorRaisesException() {
     // Then
@@ -73,6 +75,7 @@ class PathFileObjectImplTest {
   }
 
   @DisplayName("Passing a null relative path to the constructor raises an exception")
+  @SuppressWarnings("NullAway")
   @Test
   void passingNullRelativePathToConstructorRaisesException() {
     // Then

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/fixtures/ExtraArgumentMatchers.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/fixtures/ExtraArgumentMatchers.java
@@ -60,7 +60,7 @@ public final class ExtraArgumentMatchers {
    * @return the argument matcher.
    */
   @SafeVarargs
-  @SuppressWarnings("varargs")
+  @SuppressWarnings({"varargs", "TypeParameterUnusedInFormals"})
   public static <E, T extends Iterable<E>> T containsExactlyElements(E... expected) {
     return containsExactlyElements(Set.of(expected));
   }
@@ -73,6 +73,7 @@ public final class ExtraArgumentMatchers {
    * @param <T>      the iterable type.
    * @return the argument matcher.
    */
+  @SuppressWarnings("TypeParameterUnusedInFormals")
   public static <E, T extends Iterable<E>> T containsExactlyElements(Collection<E> expected) {
     return argThat(new ArgumentMatcher<>() {
       @Override

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/fixtures/Slf4jLoggerFake.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/fixtures/Slf4jLoggerFake.java
@@ -19,11 +19,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.stream.Collectors;
+import org.assertj.core.util.Arrays;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Marker;
 import org.slf4j.event.Level;
 import org.slf4j.helpers.AbstractLogger;
@@ -52,7 +53,7 @@ public final class Slf4jLoggerFake extends AbstractLogger {
    */
   public void assertThatEntryLogged(
       Level level,
-      Throwable ex,
+      @Nullable Throwable ex,
       String message,
       Object... args
   ) {
@@ -60,7 +61,7 @@ public final class Slf4jLoggerFake extends AbstractLogger {
         .stream()
         .filter(entry -> entry.getKey().equals(level));
 
-    var expect = new LogRecord(ex, message, args);
+    var expect = new LogRecord(ex, message, List.of(args));
 
     assertThat(levelEntries)
         .withFailMessage("Expected at least one %s entry to be logged", level)
@@ -94,7 +95,7 @@ public final class Slf4jLoggerFake extends AbstractLogger {
     entries.add(new SimpleImmutableEntry<>(level, new LogRecord(
         throwable,
         format,
-        args
+        Arrays.asList(args)
     )));
   }
 
@@ -149,14 +150,14 @@ public final class Slf4jLoggerFake extends AbstractLogger {
     return true;
   }
 
-  private record LogRecord(Throwable ex, String message, Object... args) {
+  private record LogRecord(@Nullable Throwable ex, String message, List<Object> args) {
 
     @Override
     public boolean equals(Object other) {
       if (other instanceof LogRecord that) {
         return Objects.equals(ex, that.ex)
             && Objects.equals(message, that.message)
-            && Arrays.deepEquals(args, that.args);
+            && args.equals(that.args);
       }
       return false;
     }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/integration/AbstractIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/integration/AbstractIntegrationTest.java
@@ -38,7 +38,7 @@ public abstract class AbstractIntegrationTest {
     // classes.
     var dirName = getClass().getCanonicalName() + "_resources";
 
-    for (var part : dirName.split("[./]")) {
+    for (var part : dirName.split("[./]", -1)) {
       path = path.resolve(part);
     }
 

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/integration/junit/JctExtensionIntegrationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/integration/junit/JctExtensionIntegrationTest.java
@@ -50,10 +50,12 @@ import org.junit.platform.testkit.engine.EngineTestKit;
  *
  * @author Ashley Scopes
  */
+@SuppressWarnings({"Convert2MethodRef", "resource"})
 @DisplayName("JctExtension integration tests")
 class JctExtensionIntegrationTest {
 
   @DisplayName("Static workspaces are initialized and closed for all tests")
+  @SuppressWarnings("resource")
   @Test
   void staticWorkspacesAreInitializedAndClosedOnceForAllTests() {
     var workspace = mock(Workspace.class);
@@ -78,6 +80,7 @@ class JctExtensionIntegrationTest {
   static class StaticLifecycleTestCase {
 
     @Managed
+    @SuppressWarnings("NullAway")
     static Workspace workspace;
 
     @Test
@@ -129,12 +132,15 @@ class JctExtensionIntegrationTest {
   static class InstanceLifecycleTestCase {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace workspace1;
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace workspace2;
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace workspace3;
 
     @Test
@@ -192,6 +198,7 @@ class JctExtensionIntegrationTest {
   static class ParameterizedLifecycleTestCase {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace workspace;
 
     @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
@@ -236,6 +243,7 @@ class JctExtensionIntegrationTest {
   static class DynamicLifecycleTestCase {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace workspace;
 
     @TestFactory
@@ -274,15 +282,19 @@ class JctExtensionIntegrationTest {
   static class CustomPathStrategyTestCase {
 
     @Managed(pathStrategy = PathStrategy.RAM_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     static Workspace staticRamDirectoriesWorkspace;
 
     @Managed(pathStrategy = PathStrategy.TEMP_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     static Workspace staticTempDirectoriesWorkspace;
 
     @Managed(pathStrategy = PathStrategy.RAM_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     Workspace ramDirectoriesWorkspace;
 
     @Managed(pathStrategy = PathStrategy.TEMP_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     Workspace tempDirectoriesWorkspace;
 
     @Test

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/junit/AbstractCompilersProviderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/junit/AbstractCompilersProviderTest.java
@@ -83,6 +83,7 @@ class AbstractCompilersProviderTest {
   }
 
   @DisplayName("Configuring the provider with a null version strategy will raise an exception")
+  @SuppressWarnings("NullAway")
   @Test
   void configuringTheProviderWithNullVersionStrategyWillRaiseException() {
     // Given

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/junit/JctExtensionTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/junit/JctExtensionTest.java
@@ -46,6 +46,7 @@ import org.mockito.Answers;
  *
  * @author Ashley Scopes
  */
+@SuppressWarnings("resource")
 @DisplayName("JctExtension tests")
 @Execution(ExecutionMode.SAME_THREAD)
 @Isolated("This modifies global state in some test cases")
@@ -61,6 +62,7 @@ class JctExtensionTest {
   }
 
   @DisplayName("The beforeAll hook initialises annotated static workspace fields")
+  @SuppressWarnings("NullAway")
   @Test
   void beforeAllHookInitialisesAnnotatedStaticWorkspaceFields() {
     // Given
@@ -130,25 +132,32 @@ class JctExtensionTest {
   static class StaticWorkspaceTestCase {
 
     @Managed
+    @SuppressWarnings("NullAway")
     static Workspace staticWorkspace1;
 
     @Managed(pathStrategy = PathStrategy.RAM_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     static Workspace staticWorkspace2;
 
     @Managed(pathStrategy = PathStrategy.TEMP_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     static Workspace staticWorkspace3;
 
     // These all get ignored because they don't match the typing/annotation criteria.
+    @SuppressWarnings("NullAway")
     static Workspace someIgnoredStaticWorkspace;
 
     @Managed
+    @SuppressWarnings("NullAway")
     static Object someInvalidStaticWorkspace;
 
     // These should be ignored because they are not static, so no instance exists to apply them on.
     @Managed
+    @SuppressWarnings("NullAway")
     Object someInvalidInstanceWorkspace;
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace someIgnoredInstanceWorkspace;
 
     @Test
@@ -163,6 +172,7 @@ class JctExtensionTest {
   }
 
   @DisplayName("The beforeEach hook initialises annotated instance workspace fields")
+  @SuppressWarnings("NullAway")
   @Test
   void beforeEachHookInitialisesAnnotatedInstanceWorkspaceFields() {
     // Given
@@ -296,25 +306,32 @@ class JctExtensionTest {
   static class InstanceWorkspaceTestCase {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace workspace1;
 
     @Managed(pathStrategy = PathStrategy.RAM_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     Workspace workspace2;
 
     @Managed(pathStrategy = PathStrategy.TEMP_DIRECTORIES)
+    @SuppressWarnings("NullAway")
     Workspace workspace3;
 
     // These all get ignored because they don't match the typing/annotation criteria.
+    @SuppressWarnings("NullAway")
     Workspace someIgnoredInstanceWorkspace;
 
     @Managed
+    @SuppressWarnings("NullAway")
     Object someInvalidInstanceWorkspace;
 
     // These should be ignored because they are static.
     @Managed
+    @SuppressWarnings("NullAway")
     static Object someInvalidStaticWorkspace;
 
     @Managed
+    @SuppressWarnings("NullAway")
     static Workspace someIgnoredStaticWorkspace;
 
     @Test
@@ -360,6 +377,7 @@ class JctExtensionTest {
   }
 
   @DisplayName("The afterEach hook will close workspaces in any superclasses")
+  @SuppressWarnings("NullAway")
   @Test
   void afterEachHookWillCloseWorkspacesInAnySuperClasses() {
     // Given
@@ -391,24 +409,28 @@ class JctExtensionTest {
   static class TestCaseBase1 {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace testCaseBase1Workspace;
   }
 
   static class TestCaseBase2 extends TestCaseBase1 {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace testCaseBase2Workspace;
   }
 
   static class TestCaseBase3 extends TestCaseBase2 {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace testCaseBase3Workspace;
   }
 
   static class TestCaseImpl extends TestCaseBase3 {
 
     @Managed
+    @SuppressWarnings("NullAway")
     Workspace testCaseImplWorkspace;
   }
 }

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentationTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/repr/TraceDiagnosticRepresentationTest.java
@@ -54,6 +54,7 @@ class TraceDiagnosticRepresentationTest {
       + "with no source")
   @EnumSource(value = Kind.class)
   @ParameterizedTest(name = "for kind {0}")
+  @SuppressWarnings("StringConcatToTextBlock")
   void toStringOfTraceDiagnosticReturnsTheExpectedMessageWhenNoCodeIsProvidedWithNoSource(
       Kind kind
   ) {
@@ -82,6 +83,7 @@ class TraceDiagnosticRepresentationTest {
       + "with a source")
   @EnumSource(value = Kind.class)
   @ParameterizedTest(name = "for kind {0}")
+  @SuppressWarnings("StringConcatToTextBlock")
   void toStringOfTraceDiagnosticReturnsTheExpectedMessageWhenNoCodeIsProvidedWithSource(Kind kind) {
     // Given
     PathFileObject fileObject = mock();
@@ -113,6 +115,7 @@ class TraceDiagnosticRepresentationTest {
       + "with no source")
   @EnumSource(value = Kind.class)
   @ParameterizedTest(name = "for kind {0}")
+  @SuppressWarnings("StringConcatToTextBlock")
   void toStringOfTraceDiagnosticReturnsTheExpectedMessageWhenCodeIsProvidedWithNoSource(Kind kind) {
     // Given
     TraceDiagnostic<?> diagnostic = mock();
@@ -139,6 +142,7 @@ class TraceDiagnosticRepresentationTest {
       + "with a source")
   @EnumSource(value = Kind.class)
   @ParameterizedTest(name = "for kind {0}")
+  @SuppressWarnings("StringConcatToTextBlock")
   void toStringOfTraceDiagnosticReturnsTheExpectedMessageWhenCodeIsProvidedWithSource(Kind kind) {
     // Given
     PathFileObject fileObject = mock();

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/LazyTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/LazyTest.java
@@ -59,6 +59,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class LazyTest {
 
   @DisplayName("Initialising with a null supplier throws a NullPointerException")
+  @SuppressWarnings("NullAway")
   @Test
   @Timeout(15)
   void initialisingWithNullSupplierThrowsNullPointerException() {
@@ -93,6 +94,7 @@ class LazyTest {
   @DisplayName("access() synchronizes correctly on initial accesses")
   @MethodSource("concurrentRepeatCases")
   @ParameterizedTest(name = "for {0} concurrent read(s)")
+  @SuppressWarnings("FutureReturnValueIgnored")
   @Timeout(15)
   void accessSynchronizesCorrectlyOnInitialAccesses(int concurrency) {
     // This is closeable in Java 19, but not before.
@@ -145,6 +147,7 @@ class LazyTest {
   @DisplayName("access() synchronizes correctly on subsequent accesses")
   @MethodSource("concurrentRepeatCases")
   @ParameterizedTest(name = "for {0} concurrent read(s)")
+  @SuppressWarnings("FutureReturnValueIgnored")
   @Timeout(15)
   void accessSynchronizesCorrectlyOnSubsequentAccesses(int concurrency) {
     // This is closeable in Java 19, but not before.

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/StringSlicerTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/StringSlicerTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class StringSlicerTest {
 
   @DisplayName("Initializing with a null delimiter throws a NullPointerException")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void initializingWithNullDelimiterThrowsNullPointerException() {
     thenCode(() -> new StringSlicer(null))

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/StringUtilsTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/StringUtilsTest.java
@@ -66,6 +66,7 @@ class StringUtilsTest implements UtilityClassTestTemplate {
     assertThat(actual).isEqualTo(expected);
   }
 
+  @SuppressWarnings("BadImport")
   static Stream<Arguments> toWordedListCases() {
     return Stream.of(
         of(List.of(), ", ", ", and ", ""),
@@ -167,6 +168,7 @@ class StringUtilsTest implements UtilityClassTestTemplate {
       "'hello\nworld\n\nblahblah\nblah\n', 100_000, 27",
   })
   @ParameterizedTest(name = "indexOfEndOfLine(..., {1}) returns {2}")
+  @SuppressWarnings("TextBlockMigration")
   void indexOfEndOfLineReturnsExpectedValue(String input, int startAt, int expectedIndex) {
     // When
     var actualIndex = StringUtils.indexOfEndOfLine(input, startAt);
@@ -228,6 +230,7 @@ class StringUtilsTest implements UtilityClassTestTemplate {
     then(StringUtils.quoted(input)).isEqualTo(expected);
   }
 
+  @SuppressWarnings("BadImport")
   static Stream<Arguments> singleObjectCases() {
     return Stream.of(
         of(Object.class, null, "null"),
@@ -257,6 +260,7 @@ class StringUtilsTest implements UtilityClassTestTemplate {
     then(StringUtils.quotedIterable(input)).isEqualTo(expected);
   }
 
+  @SuppressWarnings({"BadImport", "JdkObsolete"})
   static Stream<Arguments> iterableCases() {
     return Stream.of(
         of(Iterable.class, null, "null"),

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/ToStringBuilderTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/utils/ToStringBuilderTest.java
@@ -38,6 +38,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class ToStringBuilderTest {
 
   @DisplayName("Owner cannot be null")
+  @SuppressWarnings({"DataFlowIssue", "NullAway"})
   @Test
   void ownerCannotBeNull() {
     // Then
@@ -216,6 +217,7 @@ class ToStringBuilderTest {
         .hasToString("Bar{input=" + expected + "}");
   }
 
+  @SuppressWarnings("IllegalTokenText")
   static Stream<Arguments> stringRepresentations() {
     return Stream.of(
         // (input, expected output)
@@ -224,7 +226,7 @@ class ToStringBuilderTest {
         Arguments.of("hello, m'lady", "\"hello, m'lady\""),
         Arguments.of("quotes: \"hello!\" <--", "\"quotes: \\\"hello!\\\" <--\""),
         Arguments.of("back slash: \\ <--", "\"back slash: \\\\ <--\""),
-        Arguments.of("form feed: \f <--", "\"form feed: \f <--\""),
+        Arguments.of("form feed: \f <--", "\"form feed: \\u000c <--\""),
         Arguments.of("\1", "\"\\u0001\""),
         Arguments.of("\u000b", "\"\\u000b\""),
         Arguments.of("\u007f", "\"\\u007f\""),

--- a/java-compiler-testing/src/test/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImplTest.java
+++ b/java-compiler-testing/src/test/java/io/github/ascopes/jct/workspaces/impl/WrappingDirectoryImplTest.java
@@ -51,7 +51,6 @@ class WrappingDirectoryImplTest {
   class ConstructorTest {
 
     @DisplayName("Initialising without a parent configures the object correctly")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void initialisingWithoutParentConfiguresTheObjectCorrectly() {
       // Given
@@ -78,7 +77,6 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Initialising with a parent configures the object correctly")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void initialisingWithParentConfiguresTheObjectCorrectly() {
       // Given
@@ -109,7 +107,7 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Null paths are disallowed for parentless instances")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void nullPathsAreDisallowedForParentlessInstances() {
       // Then
@@ -119,7 +117,7 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Null parents are disallowed for instances with parents")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void nullParentsAreDisallowedForInstancesWithParents() {
       // Then
@@ -129,7 +127,7 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Null parts lists are disallowed for instances with parents")
-    @SuppressWarnings("DataFlowIssue")
+    @SuppressWarnings({"DataFlowIssue", "NullAway"})
     @Test
     void nullPartsListsAreDisallowedForInstancesWithParents() {
       // Then
@@ -139,7 +137,6 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("Null parts are disallowed for instances with parents")
-    @SuppressWarnings("DataFlowIssue")
     @Test
     void nullPartsAreDisallowedForInstancesWithParents() {
       // Then
@@ -192,7 +189,7 @@ class WrappingDirectoryImplTest {
     }
 
     @DisplayName("objects equal themselves")
-    @SuppressWarnings("EqualsWithItself")  // Intentional, duh!
+    @SuppressWarnings({"EqualsWithItself", "SelfAssertion"})  // Intentional, duh!
     @Test
     void equalThemselves() {
       // Then

--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,13 @@
     <!-- Dependencies -->
     <assertj.version>4.0.0-M1</assertj.version>
     <awaitility.version>4.3.0</awaitility.version>
+    <errorprone.version>2.50.0</errorprone.version>
     <fuzzywuzzy.version>1.4.0</fuzzywuzzy.version>
     <jspecify.version>1.0.0</jspecify.version>
     <junit.version>6.0.0</junit.version>
     <memoryfilesystem.version>2.8.2</memoryfilesystem.version>
     <mockito.version>5.23.0</mockito.version>
+    <nullaway.version>0.13.7</nullaway.version>
     <slf4j.version>2.0.18</slf4j.version>
 
     <!-- Plugins -->
@@ -177,6 +179,22 @@
       </dependency>
 
       <dependency>
+        <!-- Included here to allow dependabot to keep the version up to date.
+             Only actually used within Maven Compiler Plugin. -->
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_core</artifactId>
+        <version>${errorprone.version}</version>
+      </dependency>
+
+      <dependency>
+        <!-- Included here to allow dependabot to keep the version up to date.
+             Only actually used within Maven Compiler Plugin. -->
+        <groupId>com.uber.nullaway</groupId>
+        <artifactId>nullaway</artifactId>
+        <version>${nullaway.version}</version>
+      </dependency>
+
+      <dependency>
         <!-- Fuzzy string matching -->
         <groupId>me.xdrop</groupId>
         <artifactId>fuzzywuzzy</artifactId>
@@ -241,13 +259,57 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.mycila</groupId>
+          <artifactId>license-maven-plugin</artifactId>
+          <version>${license-maven-plugin.version}</version>
+
+          <configuration>
+            <aggregate>true</aggregate>
+            <licenseSets>
+              <licenseSet>
+                <header>.mvn/license/license-header.txt</header>
+                <!-- Useful flags: https://mycila.carbou.me/license-maven-plugin/ -->
+                <includes>
+                  <include>**.toml</include>
+                  <include>**.yml</include>
+                  <include>**.yaml</include>
+                  <include>**/pom.xml</include>
+                  <include>**/security-suppressions.xml</include>
+                  <include>**/src/**/*.bsh</include>
+                  <include>**/src/**/*.groovy</include>
+                  <include>**/src/**/*.java</include>
+                  <include>**/src/it/settings.xml</include>
+                </includes>
+              </licenseSet>
+            </licenseSets>
+            <mapping>
+              <bsh>SLASHSTAR_STYLE</bsh>
+              <groovy>SLASHSTAR_STYLE</groovy>
+              <java>SLASHSTAR_STYLE</java>
+              <toml>SCRIPT_STYLE</toml>
+            </mapping>
+            <strictCheck>true</strictCheck>
+          </configuration>
+
+          <executions>
+            <execution>
+              <phase>validate</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+
+        <plugin>
           <!-- Java compiler config -->
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
 
           <configuration>
-            <compilerArgs>
+            <annotationProcessorPaths combine.children="append"/>
+            <compilerArgs combine.children="append">
               <compilerArg>-Xlint:all,-classfile,-processing,-requires-automatic,-serial</compilerArg>
             </compilerArgs>
             <failOnWarning>true</failOnWarning>
@@ -585,48 +647,10 @@
 
     <plugins>
       <plugin>
-        <!-- Enforces our license header and allows adding it automatically to code. -->
+        <!-- Enforces our licence header and allows adding it automatically to code. -->
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>${license-maven-plugin.version}</version>
         <inherited>false</inherited>
-
-        <configuration>
-          <aggregate>true</aggregate>
-          <licenseSets>
-            <licenseSet>
-              <header>file:.mvn/license/license-header.txt</header>
-              <!-- Useful flags: https://mycila.carbou.me/license-maven-plugin/ -->
-              <includes>
-                <include>**.toml</include>
-                <include>**.yml</include>
-                <include>**.yaml</include>
-                <include>**/pom.xml</include>
-                <include>**/security-suppressions.xml</include>
-                <include>**/src/**/*.bsh</include>
-                <include>**/src/**/*.groovy</include>
-                <include>**/src/**/*.java</include>
-                <include>**/src/it/settings.xml</include>
-              </includes>
-            </licenseSet>
-          </licenseSets>
-          <mapping>
-            <bsh>SLASHSTAR_STYLE</bsh>
-            <groovy>SLASHSTAR_STYLE</groovy>
-            <java>SLASHSTAR_STYLE</java>
-            <toml>SCRIPT_STYLE</toml>
-          </mapping>
-          <strictCheck>true</strictCheck>
-        </configuration>
-
-        <executions>
-          <execution>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
- Hooks up ErrorProne and NullAway for nullability analysis and bug analysis
- Addresses nullability bugs we missed in the past.
- Addresses bugs spotted by ErrorProne
- Suppresses known edge cases in tests that are intentionally in violation of rules (e.g. testing passing null values to non-null methods to check validation is working correctly).

Disabled grouped dependency upgrades as ErrorProne tends to break NullAway on latest versions periodically, so this avoids PRs getting blocked unnecessary.

Closes GH-564